### PR TITLE
fix: Remove hash prefix from commit message format + skip migration tests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,7 +22,7 @@
     {
       "name": "monty-code-review",
       "description": "Hyper-pedantic Django4Lyfe backend code review Skill (Monty's taste).",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "author": {
         "name": "Diversio Devs"
       },
@@ -43,8 +43,8 @@
     },
     {
       "name": "backend-atomic-commit",
-      "description": "Pedantic backend pre-commit and atomic-commit Skill enforcing AGENTS.md, pre-commit hooks, .security/* helpers, and Monty’s backend taste without AI commit signatures.",
-      "version": "0.1.1",
+      "description": "Pedantic backend pre-commit and atomic-commit Skill enforcing AGENTS.md, pre-commit hooks, .security/* helpers, and Monty's backend taste without AI commit signatures.",
+      "version": "0.1.2",
       "author": {
         "name": "Diversio Devs"
       },

--- a/plugins/backend-atomic-commit/.claude-plugin/plugin.json
+++ b/plugins/backend-atomic-commit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-atomic-commit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Pedantic backend pre-commit and atomic-commit Skill for Django/Optimo-style repos, enforcing local AGENTS.md, pre-commit hooks, and Monty’s backend taste.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/backend-atomic-commit/commands/atomic-commit.md
+++ b/plugins/backend-atomic-commit/commands/atomic-commit.md
@@ -18,7 +18,7 @@ Do everything the `/backend-atomic-commit:pre-commit` command would do, plus:
   - Pre-commit hooks
 - Propose a commit message that:
   - Extracts the ticket ID from the branch name using local `AGENTS.md`
-    conventions (e.g. `clickup_<ticket_id>_...` → `#<ticket_id>: Description`).
+    conventions (e.g. `clickup_<ticket_id>_...` → `<ticket_id>: Description`).
   - Contains **no** Claude/AI/plugin signature or footer.
 
 Your output should clearly state whether the commit is ready:

--- a/plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md
+++ b/plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md
@@ -363,7 +363,7 @@ you must be **very strict**:
 - Extract ticket ID from branch name using repo conventions:
   - For the Diversio backend:
     - Branch name: `clickup_<ticket_id>_...`
-    - Commit format per `AGENTS.md`: `#<ticket_id>: Description`.
+    - Commit format per `AGENTS.md`: `<ticket_id>: Description`.
   - If commit message hooks like `commit_msg_hook.py` exist:
     - Avoid double-prefixing ticket IDs.
     - If hooks and docs disagree, call that out as `[SHOULD_FIX]` and follow

--- a/plugins/monty-code-review/.claude-plugin/plugin.json
+++ b/plugins/monty-code-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monty-code-review",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Hyper-pedantic Django4Lyfe backend code review Skill (Monty's taste).",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/monty-code-review/skills/monty-code-review/SKILL.md
+++ b/plugins/monty-code-review/skills/monty-code-review/SKILL.md
@@ -232,6 +232,8 @@ When scanning a file or function, run through these lenses:
    - Are there tests covering new behavior, edge cases, and regression paths?
    - Do tests use factories/fixtures rather than hand-rolled graphs where possible?
    - Do tests reflect multi-tenant and time-dimension scenarios where relevant?
+   - **Exception:** Django migration files (`*/migrations/*.py`) do not require tests;
+     focus test coverage on the models and business logic they represent instead.
 
 9. Migrations & schema changes
    - Does the PR include Django model or migration changes? If so:


### PR DESCRIPTION
## Summary

Two bug fixes for backend plugins:
1. **backend-atomic-commit**: Remove erroneous `#` prefix from commit message format example. The skill was generating `#GH-4226 ...` instead of `GH-4226 ...`
2. **monty-code-review**: Add exception to skip test coverage suggestions for Django migration files

## Plugins / Skills Touched

- Plugin(s):
  - [ ] New plugin
  - [x] Existing plugin(s) updated
- Skills:
  - `plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md`: Fixed commit format
  - `plugins/monty-code-review/skills/monty-code-review/SKILL.md`: Added migration test exception
- Commands:
  - `plugins/backend-atomic-commit/commands/atomic-commit.md`: Fixed commit format example
- Manifests / marketplace:
  - `plugins/backend-atomic-commit/.claude-plugin/plugin.json`: 0.1.1 → 0.1.2
  - `plugins/monty-code-review/.claude-plugin/plugin.json`: 1.1.2 → 1.1.3
  - `.claude-plugin/marketplace.json`: Updated both versions

## Checklist (from CONTRIBUTING.md)

Please confirm that you have:

- [x] Limited changes to configuration / docs:
      `.claude-plugin/marketplace.json`, plugin manifests, `SKILL.md`,
      `commands/*.md`, `AGENTS.md`, `README.md`, `CONTRIBUTING.md`.
- [x] **Not** added any application logic (Django, React, Terraform, etc.) to
      this repo.
- [x] For each plugin you touched:
  - [x] `plugins/<plugin>/.claude-plugin/plugin.json` exists and is valid JSON.
  - [x] Version in `plugin.json` was bumped appropriately
        (e.g. `0.1.0` → `0.1.1`).
  - [x] Matching entry exists in `.claude-plugin/marketplace.json` with the
        same `name` and `version`.
- [x] SKILL docs include:
  - [x] A clear "When to Use This Skill" section.
  - [x] One or more "Example Prompts".
  - [x] Any severity tags / output shape expectations the Skill relies on.
- [x] Command files under `plugins/<plugin>/commands/*.md`:
  - [x] Are thin wrappers that tell Claude to use the correct Skill.
  - [x] Clearly describe the mode or behavior (e.g. pre-commit vs atomic-commit).
- [x] `README.md` is updated (tree diagram, Available Plugins table, install and
      usage examples) when introducing or renaming plugins. *(N/A - no new plugins)*
- [x] `AGENTS.md` is updated with install instructions and a short usage note
      when adding new plugins meant for general use. *(N/A - no new plugins)*
- [x] No secrets, tokens, or customer-specific confidential details have been
      added (including example data or URLs).
- [x] Any LLM-generated content (SKILL docs, commands, etc.) has been reviewed
      and edited to match Diversio's tone and practices.

## Testing / Validation

- [x] JSON validation: Both `marketplace.json` and plugin `plugin.json` files validated with `python -m json.tool`
- [x] Verified version consistency between plugin manifests and marketplace