### PR TITLE
Add bruno-api plugin (Bruno .bru → Django endpoint docs)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -51,6 +51,17 @@
       "source": "./plugins/backend-atomic-commit",
       "category": "process",
       "keywords": ["django", "backend", "pre-commit", "atomic-commit", "optimo", "diversio"]
+    },
+    {
+      "name": "bruno-api",
+      "description": "Comprehensive API documentation generator from Bruno (.bru) files that maps endpoints to Django4Lyfe implementations (DRF/Django Ninja).",
+      "version": "0.1.0",
+      "author": {
+        "name": "Diversio Devs"
+      },
+      "source": "./plugins/bruno-api",
+      "category": "documentation",
+      "keywords": ["django", "api", "docs", "bruno", "drf", "ninja", "diversio"]
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,9 +21,15 @@ Key layout:
   - `monty-code-review/`
     - `.claude-plugin/plugin.json` – plugin manifest for `monty-code-review`.
     - `skills/monty-code-review/SKILL.md` – the Monty backend code review Skill.
+  - `backend-atomic-commit/`
+    - `.claude-plugin/plugin.json` – plugin manifest for backend pre-commit / atomic commit.
+    - `skills/backend-atomic-commit/SKILL.md` – backend atomic commit Skill.
   - `backend-pr-workflow/`
     - `.claude-plugin/plugin.json` – plugin manifest for backend PR workflow checks.
     - `skills/backend-pr-workflow/SKILL.md` – backend PR workflow Skill.
+  - `bruno-api/`
+    - `.claude-plugin/plugin.json` – plugin manifest for Bruno API docs generator.
+    - `skills/bruno-api/SKILL.md` – Bruno API documentation Skill.
   - `code-review-digest-writer/`
     - `.claude-plugin/plugin.json` – plugin manifest for code review digests.
     - `skills/code-review-digest-writer/SKILL.md` – code review digest writer Skill.
@@ -119,6 +125,12 @@ When working in this repo, Claude Code should:
   /plugin install backend-pr-workflow@diversiotech
   ```
 
+- Install the Bruno API docs plugin:
+
+  ```bash
+  /plugin install bruno-api@diversiotech
+  ```
+
 - Install the code review digest writer plugin:
 
   ```bash
@@ -149,6 +161,8 @@ marketplace), respond with instructions that avoid hardcoded paths:
      signatures).
   - `backend-pr-workflow` for backend PR workflow checks (ClickUp-linked
     branch/PR naming, migrations, downtime-safe schema changes).
+  - `bruno-api` to generate API endpoint documentation from Bruno (`.bru`)
+    files by tracing the corresponding Django4Lyfe implementation.
   - `code-review-digest-writer` to generate weekly code review digests for a
     repo based on PR review comments.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ agent-skills-marketplace/
 | `monty-code-review` | Hyper-pedantic Django4Lyfe backend code review Skill |
 | `backend-atomic-commit` | Backend pre-commit / atomic-commit Skill that enforces AGENTS.md, pre-commit hooks, .security helpers, and Monty’s backend taste (no AI commit signatures) |
 | `backend-pr-workflow` | Backend PR workflow Skill that enforces ClickUp-linked branch/PR naming, safe migrations, and downtime-safe schema changes |
+| `bruno-api` | API endpoint documentation generator from Bruno (`.bru`) files that traces Django4Lyfe implementations (DRF/Django Ninja) |
 | `code-review-digest-writer` | Weekly code-review digest writer Skill (repo-agnostic) |
 
 ## Installation
@@ -111,6 +112,9 @@ agent-skills-marketplace/
    # Backend PR workflow (ClickUp + migrations/downtime)
    /plugin install backend-pr-workflow@diversiotech
 
+   # Bruno API docs generator (.bru -> Django endpoint docs)
+   /plugin install bruno-api@diversiotech
+
    # Code review digest writer
    /plugin install code-review-digest-writer@diversiotech
    ```
@@ -122,6 +126,7 @@ agent-skills-marketplace/
    /backend-atomic-commit:pre-commit       # Actively fix backend files to meet AGENTS/pre-commit/.security standards
    /backend-atomic-commit:atomic-commit    # Strict atomic commit helper (all gates green, no AI signature)
    /backend-pr-workflow:check-pr           # Backend PR workflow & migrations check
+   /bruno-api:docs                         # Generate endpoint docs from Bruno (.bru) files
    /code-review-digest-writer:review-digest  # Generate a code review digest
    ```
 

--- a/plugins/bruno-api/.claude-plugin/plugin.json
+++ b/plugins/bruno-api/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "bruno-api",
+  "version": "0.1.0",
+  "description": "Comprehensive API documentation generator from Bruno (.bru) files that maps endpoints to Django4Lyfe implementations (DRF/Django Ninja).",
+  "author": {
+    "name": "Diversio Devs"
+  }
+}

--- a/plugins/bruno-api/commands/docs.md
+++ b/plugins/bruno-api/commands/docs.md
@@ -1,0 +1,12 @@
+---
+description: Generate API endpoint docs from Bruno (.bru) files by tracing Django4Lyfe implementations (DRF/Django Ninja).
+---
+
+Use your `bruno-api` Skill to generate (or plan) comprehensive API documentation
+from Bruno `.bru` files by locating the corresponding Django4Lyfe endpoint code.
+
+Support these modes (ask for any missing inputs):
+- `--dry-run` – show an analysis plan only (no deep codebase search).
+- `--output <path>` – write the generated markdown doc to a file.
+- `--scan <dir>` – analyze all `.bru` files under a directory.
+

--- a/plugins/bruno-api/skills/bruno-api/SKILL.md
+++ b/plugins/bruno-api/skills/bruno-api/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: bruno-api
+description: >
+  Generate comprehensive API endpoint documentation from Bruno (.bru) files by
+  mapping requests to a Django4Lyfe/Diversio-style backend implementation
+  (Django REST Framework or Django Ninja), including auth/permissions,
+  multi-tenant filtering, request/response schemas, and line-numbered code
+  references. Use for single endpoints, directory scans of .bru files, or when
+  writing docs to a specific output path.
+allowed-tools:
+  - Bash
+  - Read
+  - Edit
+  - Glob
+  - Grep
+---
+
+# Bruno API Documentation Generator Skill
+
+## Inputs & Modes
+
+This Skill expects one of:
+
+- A path to a single Bruno file (usually `*.bru`), OR
+- `--scan <dir>` to analyze all `.bru` files under a directory.
+
+Optional flags:
+
+- `--dry-run` – produce an analysis plan only (no deep codebase search).
+- `--output <path>` – write the generated markdown documentation to a file.
+
+If inputs are missing or ambiguous, ask the user to confirm:
+
+- Which `.bru` file(s) to analyze.
+- Whether they want `--dry-run` or full documentation.
+- Whether an output file should be written.
+
+## Output Shape & Severity Tags
+
+### Dry-run output
+
+Return a short plan containing:
+
+- Endpoint summary: method, URL, auth, and any detected params/body.
+- Where you will look in the Django codebase (specific file paths/directories).
+- Which documentation sections will be generated.
+- Complexity notes (e.g., “DRF ViewSet + serializer” vs “Ninja router + schema”).
+
+### Full documentation output
+
+Generate a single markdown document for each endpoint using this structure:
+
+- `# <Endpoint Name>`
+- ``<METHOD> <URL Pattern>``
+- **Authentication**, **Permissions**, **Multi-tenant**
+- `## Overview`
+- `## Request` (headers + params/body with types/validation)
+- `## Response` (success example + common error cases)
+- `## Implementation Details` (URL config + view + serializer/schema; always with `file.py:line`)
+- `## Business Logic` (step-by-step, include side effects like tasks/external calls)
+- `## Frontend Integration` (TypeScript types + call example + React Query hook example)
+- `## Testing` (Bruno tests + edge cases + required fixtures/data)
+- `## Notes` (perf considerations, related endpoints, rollout notes)
+
+Use severity tags only when something prevents correctness/completeness:
+
+- `[BLOCKING]` – cannot locate the endpoint implementation or critical auth/permission logic.
+- `[SHOULD_FIX]` – documentation gaps due to missing/incomplete source details (e.g., response shape unclear).
+- `[NOTE]` – optional improvements, related endpoints, refactors, or performance observations.
+
+## Workflow
+
+### Step 1 — Parse the Bruno file(s)
+
+For each `.bru` file:
+
+- Extract:
+  - HTTP method
+  - URL / path pattern
+  - Headers
+  - Query parameters
+  - Path parameters (from the URL pattern)
+  - Request body (and infer a schema where possible)
+- Detect authentication intent:
+  - JWT / token headers
+  - Session/cookie usage
+  - Explicit “no auth” signals
+- Capture any Bruno test/assert blocks as testing hints.
+
+### Step 2 — Locate the Django route & implementation
+
+Treat these repo conventions as first-class when present:
+
+- If the URL starts with `/api/v2/`:
+  - Check `dashboardapp/v2_urls.py`.
+  - Check `dashboardapp/views/v2/` for the view/viewset.
+- If the URL starts with `/api/v2/pulse/`:
+  - Check `pulse_iq/api/` for Django Ninja routers/endpoints.
+- Otherwise:
+  - Search app-level `urls.py` modules for the path prefix.
+  - If needed, `Grep` for a distinctive path segment from the Bruno URL.
+
+Once the route is found, identify the implementation type:
+
+- **DRF**
+  - View / ViewSet class and handler method (`list`, `retrieve`, `create`, custom actions).
+  - Serializer(s) used (including nested serializers) and validation rules.
+  - Permissions / authentication classes.
+  - Queryset and filtering (especially company/org scoping).
+- **Ninja**
+  - Router and endpoint function.
+  - Pydantic schema(s) and validation.
+  - Auth configuration/decorators.
+  - Multi-tenant scoping and access control.
+
+Always record code references with line numbers (`path/to/file.py:123`).
+
+### Step 3 — Extract behavior and contracts
+
+For the located endpoint:
+
+- Summarize the business purpose and any key invariants.
+- Document validation and error behavior:
+  - Common 400 reasons (schema/serializer validation).
+  - Auth failures (401) and permission failures (403).
+  - Not-found cases (404) and domain-specific error cases.
+- Identify multi-tenant constraints:
+  - How company/org is inferred (JWT claims, request context, URL param).
+  - Which queryset filters enforce scoping.
+- Note side effects:
+  - Background tasks (Celery), emails, webhooks, external service calls.
+  - Writes to critical models and any transactional boundaries.
+
+### Step 4 — Generate documentation
+
+Write the markdown doc per “Full documentation output”.
+
+Rules:
+
+- Prefer precise types over “string/number” when you can infer them.
+- Include at least one realistic example request and success response.
+- If response shape is dynamic or large, document the stable contract and
+  include a representative sample, not the entire universe of fields.
+- When you’re unsure, be explicit about assumptions and mark with `[SHOULD_FIX]`.
+
+### Step 5 — Handle `--output` and `--scan`
+
+- If `--scan <dir>`:
+  - Find all `.bru` files recursively under that directory.
+  - Generate one markdown doc per file.
+  - If no `--output` is provided, return docs in the response (grouped by file).
+- If `--output <path>` is provided:
+  - Write output to that path.
+  - If scanning multiple files, either:
+    - Write a single combined doc (with a clear table of contents), OR
+    - Write multiple files under an output directory (ask the user which they want).
+


### PR DESCRIPTION
## Summary
Adds a new `bruno-api` plugin/Skill that generates API endpoint documentation from Bruno `.bru` files by tracing the corresponding Django4Lyfe implementation (Django REST Framework or Django Ninja).

## What's included
- New plugin + skill: `plugins/bruno-api/`
- New slash command entrypoint: `/bruno-api:docs` (supports `--dry-run`, `--scan`, `--output`)
- Marketplace registration: `.claude-plugin/marketplace.json`
- Docs updates: `README.md`, `AGENTS.md`

## Usage
- Install: `/plugin install bruno-api@diversiotech`
- Single file: `/bruno-api:docs --dry-run path/to/endpoint.bru`
- Scan: `/bruno-api:docs --scan path/to/dir --output docs/api`

## Notes
Ported from the existing Django4Lyfe command `monolith/backend/.claude/commands/bruno-api.md` into a reusable marketplace Skill.