### PR TITLE
Fix mixpanel-analytics distinct_id fallback and Optional field handling

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,7 +88,7 @@
     {
       "name": "mixpanel-analytics",
       "description": "MixPanel analytics tracking implementation and review Skill for Django4Lyfe optimo_analytics module with PII protection and pattern enforcement.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "Diversio Devs"
       },

--- a/plugins/mixpanel-analytics/.claude-plugin/plugin.json
+++ b/plugins/mixpanel-analytics/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-analytics",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MixPanel analytics tracking implementation and review Skills for Django4Lyfe optimo_analytics module.",
   "author": {
     "name": "Diversio Devs"


### PR DESCRIPTION
## Summary

Fixes two implementation issues discovered when using the mixpanel-analytics skill to add tracking calls in the backend repository:

1. **Duplicate Optional field definitions** - The skill was generating schemas that redefined base fields (like `organization_id`, `organization_name`) as `Optional[str]` when values might be `None`. This is incorrect - empty string `""` should be used instead.

2. **Incorrect distinct_id values** - The skill was passing `organization_id` directly as `distinct_id`. This should strictly be the user's UUID, with defined fallbacks.

## Changes

| File | Change |
|------|--------|
| `SKILL.md` | Added "Optional Values for String Fields" section with BAD/GOOD examples |
| `SKILL.md` | Updated distinct_id section from P2 → P1 with strict fallback hierarchy |
| `SKILL.md` | Added distinct_id fallback comments in Step 4 code example |
| `SKILL.md` | Added base schema field check to Review Mode Schema Design checklist |
| `plugin.json` | Bumped version 0.1.0 → 0.1.1 |
| `marketplace.json` | Bumped version 0.1.0 → 0.1.1 |

## distinct_id Fallback Hierarchy (New)

```
1. User's UUID (primary - always preferred)
2. org_<organization_uuid> (when no user context)
3. Context-specific: slack_<id>, apikey_<id>, webhook_<id>
```

**Key rule**: Never pass raw `organization_id` as `distinct_id` - always prefix with `org_`.

## Test Plan

- [x] JSON files remain valid (`marketplace.json`, `plugin.json`)
- [x] SKILL.md markdown linting passes
- [x] Version bumped consistently in both manifests
- [x] Review checklist updated with new verification items

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)