### PR TITLE
Add explicit ty checking to pre-commit skill workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,7 +44,7 @@
     {
       "name": "backend-atomic-commit",
       "description": "Pedantic backend pre-commit and atomic-commit Skill enforcing AGENTS.md, pre-commit hooks, .security/* helpers, and Monty's backend taste without AI commit signatures.",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "author": {
         "name": "Diversio Devs"
       },

--- a/plugins/backend-atomic-commit/.claude-plugin/plugin.json
+++ b/plugins/backend-atomic-commit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-atomic-commit",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Pedantic backend pre-commit and atomic-commit Skill for Django/Optimo-style repos, enforcing local AGENTS.md, pre-commit hooks, and Monty’s backend taste.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/backend-atomic-commit/commands/pre-commit.md
+++ b/plugins/backend-atomic-commit/commands/pre-commit.md
@@ -7,11 +7,18 @@ Run your `backend-atomic-commit` Skill in **pre-commit** mode.
 Focus on:
 
 - Actively fixing the files in `git status` so they match backend `AGENTS.md`,
-  `.pre-commit-config.yaml`, `.security/*` helpers, and Monty’s backend taste.
+  `.pre-commit-config.yaml`, `.security/*` helpers, and Monty's backend taste.
 - Eliminating local imports, debug statements, PII-in-logs issues, and obvious
   type-hint problems.
-- Making sure Ruff, djlint, ty, Django system checks, and pre-commit hooks
-  are all happy for the current changes.
+- Running the following checks in order:
+  1. `.bin/ruff check --fix` and `.bin/ruff format` on modified Python files.
+  2. `.bin/ty check` on **modified Python files only** to catch type errors
+     before CI (avoids baseline errors in unmodified code).
+  3. `python manage.py check --fail-level WARNING` for Django system checks.
+  4. Any pre-commit hooks defined in `.pre-commit-config.yaml`.
+- **IMPORTANT**: For any file you touch, resolve **ALL** ruff and ty errors in
+  that file—not just the ones you introduced. CI will fail on pre-existing
+  errors in modified files. Do not dismiss errors as "pre-existing".
 
 Do **not** propose a commit message in this mode; just leave the working tree
 and index in the cleanest, most standards-compliant state you can, and report:


### PR DESCRIPTION
## Summary

This PR adds explicit `ty` (type checker) integration to the backend-atomic-commit pre-commit skill workflow to catch type errors locally before CI.

### Problem Solved

| Issue | Impact |
|-------|--------|
| `ty` runs in CI but not locally | Feedback gap causing extra fix-and-push cycles |
| Pre-existing errors in touched files | CI failures even when your changes are correct |
| ruff/ty conflicts (e.g., ARG002 vs method signatures) | Fixes for one tool break the other |

---

## Key Changes

### 1. Explicit ty Checking Step

Added a dedicated type checking step in the pipeline with scoped commands:

```bash
# For staged files (atomic-commit mode):
.bin/ty check $(git diff --cached --name-only --diff-filter=ACMR | grep '\.py$')

# For all modified files (pre-commit mode):
.bin/ty check $(git diff --name-only --diff-filter=ACMR | grep '\.py$')
```

### 2. "Fix ALL Errors in Touched Files" Rule

**IMPORTANT**: For both ruff and ty, the skill now explicitly requires fixing **all** errors in any file you touch—not just the ones you introduced. This matches CI behavior and prevents surprises.

### 3. Common Pitfall Documentation

Documented the ruff ARG002 vs ty signature conflict:
- ruff ARG002 wants `_unused_arg` prefix for unused arguments
- `ty` may fail if Django method signatures must match parent class exactly
- Solution: Run both checks together and adjust approach per-case

---

## Files Changed

<details>
<summary>Skill & Commands (click to expand)</summary>

- `plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md` - Added explicit ty checking step, clarified "fix all errors" rule for both ruff and ty
- `plugins/backend-atomic-commit/commands/pre-commit.md` - Updated check order with ty step, added "fix all errors" notice

</details>

<details>
<summary>Version Bumps (click to expand)</summary>

- `plugins/backend-atomic-commit/.claude-plugin/plugin.json` - Bumped to 0.1.4
- `.claude-plugin/marketplace.json` - Bumped to 0.1.4

</details>

---

## Notes

- **No migrations**: This is a plugin/skill configuration change only
- **Backwards compatible**: Existing usage patterns remain valid
- **Version**: 0.1.3 → 0.1.4

---

🤖 Generated with [Claude Code](https://claude.ai/code)