### PR TITLE
feat(plugins): add session-review-notes skill for PR session ledger

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -85,6 +85,17 @@
       "keywords": ["github", "pull-request", "documentation", "workflow", "diversio"]
     },
     {
+      "name": "session-review-notes",
+      "description": "Upsert a single PR comment that serves as an AI session ledger (human steering, deltas, tests) across Codex + Claude Code. Not a PR description.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Diversio Devs"
+      },
+      "source": "./plugins/session-review-notes",
+      "category": "documentation",
+      "keywords": ["prompt", "session", "pull-request", "review", "documentation", "workflow", "diversio"]
+    },
+    {
       "name": "process-code-review",
       "description": "Process code review findings - interactively fix or skip issues from monty-code-review output with status tracking.",
       "version": "0.1.1",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,9 @@ Key layout:
   - `pr-description-writer/`
     - `.claude-plugin/plugin.json` – plugin manifest for PR descriptions.
     - `skills/pr-description-writer/SKILL.md` – PR description generator Skill.
+  - `session-review-notes/`
+    - `.claude-plugin/plugin.json` – plugin manifest for PR-ready AI session review notes.
+    - `skills/session-review-notes/SKILL.md` – session review notes Skill.
   - `process-code-review/`
     - `.claude-plugin/plugin.json` – plugin manifest for code review processor.
     - `skills/process-code-review/SKILL.md` – process code review findings Skill.
@@ -166,6 +169,12 @@ When working in this repo, Claude Code should:
   /plugin install pr-description-writer@diversiotech
   ```
 
+- Install the session review notes plugin:
+
+  ```bash
+  /plugin install session-review-notes@diversiotech
+  ```
+
 - Install the code review processor plugin:
 
   ```bash
@@ -220,6 +229,11 @@ marketplace), respond with instructions that avoid hardcoded paths:
     automated execution via `/plan-directory:run <slug>`.
   - `pr-description-writer` to generate comprehensive, reviewer-friendly PR
     descriptions with visual diagrams, summary tables, and structured sections.
+  - `session-review-notes` to upsert a single, auto-updating PR comment with AI
+    session notes that summarize intent, what changed, how the human steered the
+    session, review hotspots, tests run, and follow-ups. Command:
+    - `/session-review-notes:generate` – Generate PR-ready AI session review notes
+    - `/session-review-notes:list-sessions` – List recent Codex + Claude sessions (picker for backfill)
   - `process-code-review` to interactively process code review findings from
     monty-code-review output - fix or skip issues with status tracking.
   - `mixpanel-analytics` to implement new MixPanel tracking events and review

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ agent-skills-marketplace/
 │   │   │   ├── SKILL.md
 │   │   │   └── references/
 │   │   └── commands/write-pr.md
+│   ├── session-review-notes/          # PR-ready AI session review notes
+│   │   ├── .claude-plugin/plugin.json
+│   │   ├── skills/session-review-notes/
+│   │   │   ├── SKILL.md
+│   │   │   └── references/
+│   │   └── commands/
+│   │       ├── generate.md
+│   │       └── list-sessions.md
 │   ├── process-code-review/           # Code review processor (fix/skip issues)
 │   │   ├── .claude-plugin/plugin.json
 │   │   ├── skills/process-code-review/SKILL.md
@@ -139,6 +147,7 @@ agent-skills-marketplace/
 | `code-review-digest-writer` | Weekly code-review digest writer Skill (repo-agnostic) |
 | `plan-directory` | Structured plan directories with PLAN.md index, numbered task files, and RALPH loop integration for iterative execution |
 | `pr-description-writer` | Generates comprehensive, reviewer-friendly PR descriptions with visual diagrams, summary tables, and structured sections |
+| `session-review-notes` | Upsert a single PR comment that serves as an AI session ledger (human steering, deltas, tests) across Codex + Claude Code (not a PR description) |
 | `process-code-review` | Process code review findings - interactively fix or skip issues from monty-code-review output with status tracking |
 | `mixpanel-analytics` | MixPanel tracking implementation and review Skill for Django4Lyfe optimo_analytics module with PII protection and pattern enforcement |
 | `clickup-ticket` | Create and manage ClickUp tickets directly from Claude Code or Codex with multi-org support, interactive ticket creation, subtasks, and backlog management |
@@ -175,6 +184,9 @@ agent-skills-marketplace/
    # PR description writer
    /plugin install pr-description-writer@diversiotech
 
+   # PR-ready AI session review notes
+   /plugin install session-review-notes@diversiotech
+
    # Code review processor (fix/skip issues from monty-code-review)
    /plugin install process-code-review@diversiotech
 
@@ -198,6 +210,8 @@ agent-skills-marketplace/
    /plan-directory:backend-ralph-plan        # Create RALPH loop-integrated plan for backend
    /plan-directory:run <slug>                # Execute a RALPH plan via ralph-wiggum loop
    /pr-description-writer:write-pr           # Generate a comprehensive PR description
+   /session-review-notes:generate            # Generate PR-ready AI session review notes
+   /session-review-notes:list-sessions       # List recent Codex + Claude sessions (human-readable picker)
    /process-code-review:process-review       # Process code review findings (fix/skip issues)
    /mixpanel-analytics:implement             # Implement new MixPanel tracking events
    /mixpanel-analytics:review                # Review MixPanel implementations for compliance

--- a/plugins/session-review-notes/.claude-plugin/plugin.json
+++ b/plugins/session-review-notes/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "session-review-notes",
+  "version": "0.1.0",
+  "description": "Upsert a single PR comment that serves as an AI session ledger (human steering, deltas, tests) across Codex + Claude Code. Not a PR description.",
+  "author": {
+    "name": "Diversio Devs"
+  }
+}

--- a/plugins/session-review-notes/HANDOFF.md
+++ b/plugins/session-review-notes/HANDOFF.md
@@ -1,0 +1,308 @@
+# Handoff (2026-01-13): `session-review-notes` Skill / Plugin (Codex + Claude Code)
+
+I’m building a cross-platform **Agent Skill** + **Claude Code plugin** that upserts **exactly one** PR comment: a “session ledger” capturing **human steering**, **full-PR scope**, **delta since last update**, and **tests actually run** across **multiple Codex + Claude Code sessions**.
+
+You’re an expert LLM engineer who knows Codex + Claude Code deeply. You don’t have access to my repo, so I’m including everything you need to reason about the design and help me harden it. I’m explicitly asking for **implementation guidance**, **failure-mode hardening**, and **creative/UI feedback**.
+
+---
+
+## 0) Agent Skills Standard (so we’re aligned)
+
+This repo follows the **Agent Skills standard**: a Skill is a directory with `SKILL.md` (YAML frontmatter + instructions) plus optional `references/`, `scripts/`, etc. The same Skill can be installed into Codex.
+
+This repo also includes **Claude Code plugin** metadata:
+- Marketplace: `.claude-plugin/marketplace.json`
+- Plugin manifest: `plugins/<plugin>/.claude-plugin/plugin.json`
+- Slash commands: `plugins/<plugin>/commands/*.md`
+- Skill + scripts: `plugins/<plugin>/skills/<skill-name>/...`
+
+Codex consumes the **Skill directory** via installation into `$CODEX_HOME/skills/<skill-name>/...`.
+
+---
+
+## 1) What I’m building (and what it’s not)
+
+### What it is
+
+`session-review-notes`:
+- Upserts **one** PR comment (create-or-update; never duplicates).
+- Comment is a **mini database** + human narrative:
+  1) **PR scope** (regenerated from PR diff every run, so it never “forgets” early work)
+  2) **Session log** (cumulative entries per session across Codex + Claude)
+
+### What it is not
+
+It is not the PR description. It’s intentionally smaller and more operational:
+- `pr-description-writer` = PR body narrative + diagrams + full test plan.
+- `session-review-notes` = one upserted comment answering “how did the human steer the agent”, plus deltas and tests.
+
+---
+
+## 2) My opinionated architecture (hybrid, deterministic merge)
+
+I’m following the “hybrid” recommendation:
+- **LLM writes only narrative payload JSON** (intent, steering, decisions, tests, hotspots).
+- **Deterministic script owns invariants**:
+  - single-comment upsert
+  - comment schema + markers
+  - session entry identity + merging/dedup
+  - PR machine facts (base/head, diffstat)
+  - delta computation (previous head → current head)
+  - redaction on everything going to GitHub
+  - concurrency handling (merge → patch → verify → retry)
+
+This is meant to permanently eliminate “LLM drift” failure modes: marker deletion, duplicate comments, overwritten ledgers, implied tests, etc.
+
+---
+
+## 3) Repo layout (everything relevant)
+
+```text
+plugins/session-review-notes/
+  .claude-plugin/plugin.json
+  commands/
+    generate.md
+    list-sessions.md
+  skills/session-review-notes/
+    SKILL.md
+    references/
+      transcripts.md
+    scripts/
+      list-sessions.py
+      upsert-pr-comment.py
+```
+
+---
+
+## 4) PR comment “database schema” (markers + state)
+
+The comment is uniquely identified by a marker near the top:
+
+```md
+<!-- diversio:session-review-notes -->
+```
+
+Hidden state (single-line JSON):
+
+```md
+<!-- diversio:session-review-notes:state {"schema":2,"base":"main","head":"<sha>","prev_head":"<sha-or-null>","rev":3,"sessions_total":5,"codex":2,"claude":3,"included_sessions":[{"tool":"codex","id":"..."},{"tool":"claude","id":"..."}],"last_updated":"2026-01-13T07:48:00-05:00"} -->
+```
+
+Session log region is *inside* the wrapper details (canonical layout):
+
+```md
+<details>
+<summary><strong>Session log (cumulative)</strong> <sub>(newest first)</sub></summary>
+
+<!-- diversio:session-review-notes:sessions:start -->
+...entries only...
+<!-- diversio:session-review-notes:sessions:end -->
+
+</details>
+```
+
+Each session entry has a hidden per-entry marker (for dedupe/update safety):
+
+```md
+<!-- diversio:session-review-notes:entry {"tool":"claude","session_id":"<id>","created_at":"<ISO8601>"} -->
+<details>
+<summary>...</summary>
+...
+</details>
+```
+
+---
+
+## 5) End-to-end flow (how it runs)
+
+### Claude Code (plugin install)
+
+- Commands the user runs:
+  - `/session-review-notes:list-sessions`
+  - `/session-review-notes:generate`
+
+My command docs call the scripts via `${CLAUDE_PLUGIN_ROOT}` (documented by Anthropic as the plugin root directory). This is a key thing I want you to sanity-check. Docs: `CLAUDE_PLUGIN_ROOT` env var in Claude Code plugins.  
+https://docs.anthropic.com/en/docs/claude-code/plugins#environment-variables
+
+### Codex (Skill install)
+
+- Install Skill:
+  - Use Codex skill installer (repo/path install) and restart Codex.
+- Run:
+  - Generate payload JSON (LLM)
+  - Run `python3 scripts/upsert-pr-comment.py ...`
+
+---
+
+## 6) Handling multi-session + “latest minor session trap”
+
+The big trap I’m trying to avoid:
+- A tiny follow-up session overwrites intent and makes reviewers think that small delta is “the work”.
+
+My hard rule:
+- **PR scope summary is always regenerated from PR diff**
+- **Newest session writes only a delta narrative and a session entry**
+
+This means:
+- Even if a user only runs the Skill from a “minor cleanup” session, the comment still describes the entire PR.
+
+---
+
+## 7) Session discovery problem (my current approach)
+
+### What I can do today (best-effort)
+
+I have `scripts/list-sessions.py` to print a **human-readable session picker** (Markdown table) and ask the user which sessions to include.
+
+How it works:
+- It resolves the “project root” via `git rev-parse --show-toplevel` (fallback to `--project` path).
+- Codex: scans `$CODEX_HOME/sessions/**/*.jsonl` and extracts:
+  - session id, cwd, timestamps, first meaningful user prompt snippet (redacted)
+- Claude Code: scans `$CLAUDE_HOME/projects/.../*.jsonl` (and falls back to scanning all projects if the derived project key isn’t found) and extracts:
+  - sessionId, cwd, gitBranch, timestamps, first meaningful user prompt snippet (redacted)
+
+Key: it’s **human-in-the-loop**. If I can’t safely choose sessions, I show a table and let the user choose. That’s how I avoid the “most recent minor session trap” in multi-tool/multi-session scenarios.
+
+### The gap / what I want your help with
+
+I’m not happy relying on filesystem scanning forever. I want stable, officially supported hooks where possible:
+
+#### Claude Code (best option)
+
+Claude Code status line scripts get JSON on stdin including `session_id` and `transcript_path`. Docs:  
+https://docs.anthropic.com/en/docs/claude-code/statusline
+
+My idea: ship an **optional** tiny script that users can set as status line to write `{session_id, transcript_path, cwd}` into a predictable file, so `--session-id auto` can be 100% reliable (no guessing).
+
+Question for you: can/should this be done via plugin-provided hooks/config, or must it be user-configured?
+
+#### Codex (possible option)
+
+OpenAI Codex supports `notify`: after each response, Codex can run a program with a JSON payload that includes a thread/session id and cwd. Docs:  
+https://developers.openai.com/codex/config-advanced/#notifications
+
+My idea: optionally configure `notify` to write `{thread-id, cwd, timestamp}` to a file, so “current session id” doesn’t require `/status` and doesn’t require scanning sessions.
+
+Question for you: is this the “right” direction, and is the payload stable enough to depend on?
+
+---
+
+## 8) The deterministic upsert script (how it works)
+
+File: `plugins/session-review-notes/skills/session-review-notes/scripts/upsert-pr-comment.py`
+
+Behavior:
+0) Validate + normalize the payload JSON (treat it as untrusted input; enforce types/lengths; downgrade tests to self-reported unless evidence).
+1) Resolve PR (`--pr auto|number|url`), fetch PR metadata (base/head/additions/deletions/commits).
+2) Find existing comment by marker, select most recently updated.
+3) Fetch existing comment body and extract markers/state/session block (self-heal when needed).
+4) Extract prior `head` from state marker; compute delta via compare endpoint:
+   - `GET /repos/{owner}/{repo}/compare/{prev_head}...{head_sha}`
+5) Merge session entries between markers; dedupe by per-entry meta marker key `(tool, session_id)`.
+6) Render comment:
+   - Distinct centered title
+   - `[!IMPORTANT]` callout about “single upserted comment”
+   - Summary table (Intent / PR coverage / PR size / sessions / delta / risk / tests)
+   - Everything else collapsed under `<details>`
+7) Redact:
+   - Tokens (GitHub PATs, gh tokens, `sk-*`, AWS keys, private key blocks, Slack tokens)
+   - URLs (allowlist GitHub host + PR host; replace others with `[URL]`)
+   - home directory path → `~`
+8) Update comment with bounded merge retries:
+   - fetch latest → merge → patch → fetch+verify (rev/hash + entry presence) → retry if needed
+9) Print comment URL only.
+
+If you want to sanity-check a few implementation choices, here are the key invariants I’m enforcing:
+- markers never change
+- session entries must include the per-entry marker
+- session log markers are inside wrapper (migration supported for older format)
+- the script is the only writer to GitHub
+
+---
+
+## 9) Payload JSON (LLM-owned content)
+
+The script expects a JSON payload containing human narrative only (no machine facts needed; it computes those).
+
+Fields I’m using:
+- `intent` (string)
+- `risk` (string)
+- `tests_summary` (string)
+- `pr_scope_bullets` (array of strings)
+- `hotspots` (array of strings)
+- `prompts` (string, optional)
+- `session_label` (string)
+- `human_steering` (array of strings)
+- `decisions` (array of strings)
+- `delta_narrative` (string)
+- `tests_markdown` (string, GitHub task list markdown)
+- `notes` (string)
+
+I’m explicitly trying to avoid overlap with PR description:
+- I keep `pr_scope_bullets` short and scannable, and everything is under `<details>`.
+- No “full narrative”; that’s PR body.
+
+---
+
+## 10) What I want from you (questions)
+
+Please be opinionated and practical—tell me what you would actually ship.
+
+### A) Claude Code specifics
+1) Is `${CLAUDE_PLUGIN_ROOT}` the correct/robust way to reference plugin scripts from slash commands (in real projects)? Any gotchas on Windows?
+2) Status line JSON includes `session_id` and `transcript_path`. Should I implement an optional status line helper script to write current session metadata to disk for 100% reliable `--session-id auto`?
+3) Is there a better official way to list sessions than scanning `~/.claude/projects`? (CLI flags? a “list sessions” command?)
+
+### B) Codex specifics
+1) For “current session id”: is `notify` the best official hook-like mechanism, or is there a more direct API?
+2) Is `history.jsonl` / `history.persistence` the right source for listing sessions without scanning `$CODEX_HOME/sessions`? (I currently scan sessions.)
+3) Any stable, official metadata fields I should rely on for session pickers?
+
+### C) Multi-tool correlation
+1) What’s the best way to correlate “these sessions belong to this PR” without reading full transcripts?
+   - I’m currently using: cwd within repo + timestamps + optional branch + optional PR URL/commit SHA grep.
+2) Would you store `included_sessions` in the comment state (I do) so future updates can preserve a stable set even on different machines?
+3) How would you handle a team scenario where multiple devs run updates from different machines (and don’t share transcript histories)?
+
+### D) GitHub comment correctness / merge
+1) Is `gh api` REST the best choice, or should I switch to GraphQL for comment enumeration/search?
+2) If the comment is manually edited and markers are broken:
+   - should I self-heal (rebuild the wrapper) silently, or should I add a visible warning in the comment?
+3) Concurrency:
+   - Is ETag/If-Match enough? Would you add a “rev” compare or checksum to detect stomped merges?
+
+### E) Security & redaction
+1) Are my regex patterns sufficient, or would you add more? (JWTs? OAuth bearer tokens? cookies?)
+2) URL policy:
+   - should I strip all URLs always, or allow only GitHub URLs?
+3) Any known “gotchas” where tool output can leak secrets (e.g., `gh auth status`) and how you’d guardrail the LLM from pasting it?
+
+### F) UX / information design
+1) How would you make the comment even more skimmable without losing trustworthiness?
+   - I’m using banner + summary table + everything else collapsed.
+2) Would you add a deterministic “hotspot map” table (top dirs by churn) computed from compare/file stats?
+3) How would you make “Tests” impossible to misread (e.g., `[x]` only with evidence)?
+
+---
+
+## 11) My next steps (unless you suggest otherwise)
+
+1) Optional: implement **Claude status line helper** to persist `{session_id, transcript_path}` for reliable `--session-id auto`.
+2) Optional: implement **Codex notify helper** to persist `{thread-id, cwd}` for reliable `--session-id auto`.
+3) Add a deterministic “hotspot map” table (compare stats → top dirs).
+4) Decide on backfill ordering:
+   - current behavior inserts new entries at top; for “backfill” this may mis-order entries.
+   - I could sort session entries by meta `created_at` (if you recommend it).
+
+---
+
+## 12) Key upstream docs I used (for your quick reference)
+
+- Claude Code plugins: `CLAUDE_PLUGIN_ROOT` env var  
+  https://docs.anthropic.com/en/docs/claude-code/plugins#environment-variables
+- Claude Code status line: `session_id` and `transcript_path`  
+  https://docs.anthropic.com/en/docs/claude-code/statusline
+- OpenAI Codex advanced config: `notify` payload  
+  https://developers.openai.com/codex/config-advanced/#notifications
+- OpenAI Codex config reference: `history.persistence` / `history.jsonl`  
+  https://developers.openai.com/codex/config-reference/

--- a/plugins/session-review-notes/commands/generate.md
+++ b/plugins/session-review-notes/commands/generate.md
@@ -1,0 +1,48 @@
+---
+description: Upsert a single PR comment with session review notes (create or update the existing one).
+argument-hint: "[--pr=<number|url|auto>] [--session-id=<id|auto>] [--dry-run] [--brief|--full] [--audience=<role>]"
+---
+
+Use your `session-review-notes` Skill to upsert a **single, auto-updating PR comment** via a **deterministic script** (hybrid approach):
+- You (LLM) write a **payload JSON** (human narrative only).
+- The script owns **idempotency, merging, markers, redaction, delta computation, and GitHub upsert**.
+
+User arguments: `$ARGUMENTS`
+
+Interpret flags (when present):
+- `--pr=<number|url|auto>`: target PR (default: `auto` for current branch).
+- `--session-id=<id|auto>`: session ID for the entry (default: `auto`).
+- `--dry-run`: render the final comment body to stdout (do not post to GitHub).
+- `--brief`: ~150-250 words, omit prompts section unless crucial.
+- `--full`: include prompts-to-reproduce and more detail (still keep it scannable).
+- `--audience=<role>`: tailor tone/terminology (e.g., "backend", "frontend", "data", "security", "EM").
+
+Requirements:
+- Focus on **what the human did** to steer the session (clarifications, constraints, corrections, tradeoffs).
+- Summarize **what changed** at PR scope (don’t paste diffs).
+- Avoid the “latest minor session trap”: the visible summary must cover the entire PR, while the newest session is logged as a delta.
+- Call out **review hotspots / risks** and **tests actually run** (or explicitly say none were run).
+- Redact secrets, tokens, customer PII, and internal URLs.
+- Post the output as a PR comment. Only one such comment should exist: **update the existing one** if present (script-enforced).
+- If the PR was built across multiple Codex/Claude sessions and you need help identifying them, run `/session-review-notes:list-sessions` first and ask the user which session IDs to backfill.
+
+Implementation (script-driven):
+1) Create a JSON payload for the script (human narrative only). Use this shape:
+   - `intent`: string
+   - `risk`: string (Low/Medium/High + 1-liner)
+   - `tests_summary`: string (short summary; treated as self-reported unless you have hard evidence)
+   - `pr_scope_bullets`: array of strings (short, PR-wide)
+   - `hotspots`: array of strings (review focus / risks)
+   - `prompts`: string (optional; redacted)
+   - `session_label`: string (short)
+   - `human_steering`: array of strings
+   - `decisions`: array of strings
+   - `delta_narrative`: string (short; what changed since prior update)
+   - `tests_markdown`: string (GitHub task-list markdown)
+   - `notes`: string
+2) Write it to a temp file (or pipe to stdin).
+3) Run the upsert script (Claude Code):
+   - `python3 "${CLAUDE_PLUGIN_ROOT}/skills/session-review-notes/scripts/upsert-pr-comment.py" --tool claude --session-id <auto|id> --pr <auto|number|url> --payload <path|->`
+   - If `CLAUDE_PLUGIN_ROOT` is unavailable, run the script from a marketplace checkout:
+     - `python3 plugins/session-review-notes/skills/session-review-notes/scripts/upsert-pr-comment.py --tool claude --session-id <auto|id> --pr <auto|number|url> --payload <path|->`
+4) Return a short confirmation with the comment URL (and do not re-print the entire comment body unless asked).

--- a/plugins/session-review-notes/commands/list-sessions.md
+++ b/plugins/session-review-notes/commands/list-sessions.md
@@ -1,0 +1,26 @@
+---
+description: List recent Codex + Claude Code sessions for this project (human-readable) so you can choose which ones to include.
+argument-hint: "[--limit=<n>] [--scan=<n>] [--tool=all|codex|claude] [--project=<path>]"
+---
+
+Use your `session-review-notes` Skill to produce a **human-readable session picker** for this project.
+
+User arguments: `$ARGUMENTS`
+
+Requirements:
+- Print a **Markdown table** of recent sessions for the current project with:
+  - tool (`codex` / `claude`)
+  - session ID
+  - last-active time (relative)
+  - start time (local)
+  - branch (if available)
+  - a short first-prompt snippet (redacted)
+- Redact secrets/tokens and URLs in the snippet.
+- After the table, ask the user which session IDs to include for backfilling the PR comment.
+
+Implementation note:
+- Prefer using the helper described in `skills/session-review-notes/references/transcripts.md` (it includes a script-based picker).
+- In Claude Code, run:
+  - `python3 "${CLAUDE_PLUGIN_ROOT}/skills/session-review-notes/scripts/list-sessions.py" --project "$PWD" --limit 15`
+  - If `CLAUDE_PLUGIN_ROOT` is unavailable, run from a marketplace checkout:
+    - `python3 plugins/session-review-notes/skills/session-review-notes/scripts/list-sessions.py --project "$PWD" --limit 15`

--- a/plugins/session-review-notes/skills/session-review-notes/SKILL.md
+++ b/plugins/session-review-notes/skills/session-review-notes/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: session-review-notes
+description: "Upsert a single PR comment that serves as an AI session ledger (human steering, deltas, tests) across Codex + Claude Code. Not a PR description."
+tools: [Bash, Read, Write, Grep, Glob]
+allowed-tools: Bash Read Write Grep Glob
+---
+
+# Session Review Notes Skill
+
+## When to Use This Skill
+
+Use this skill at the end of an AI-assisted coding session (Codex or Claude Code) when you want to:
+
+- Give reviewers the **intent and rationale** that a diff/PR alone can’t capture.
+- Make “prompt requests” practical by summarizing **how the human steered** the work.
+- Highlight **what to review** (risks, tricky areas, assumptions, tradeoffs).
+- Post a **single, auto-updating PR comment** (create-or-update) that stays scannable.
+
+This is **not** a replacement for a PR description:
+- Use `pr-description-writer` for the PR body (narrative, diagrams, full test plan).
+- Use `session-review-notes` for a single upserted comment that tracks **human steering across sessions** and avoids the “latest minor session” trap.
+
+## Inputs / Assumptions
+
+- You are in an active chat that includes the session’s conversation history.
+- If the work involves a git repo, you can access it via `Bash`.
+- You have GitHub CLI (`gh`) installed and authenticated for the target repo.
+- If you can’t reliably infer the PR, base branch, or commit range, ask the user.
+
+## Architecture (Hybrid: LLM + Deterministic Script)
+
+This skill is intentionally **hybrid**:
+
+- **LLM responsibility (high-level narrative only):** produce a small JSON payload capturing intent, human steering, decisions, tests, and reviewer hotspots.
+- **Script responsibility (invariants, no exceptions):** create-or-update the single PR comment, preserve/merge the session log, compute PR facts + delta, apply redaction, and talk to GitHub via `gh api`.
+
+Use the deterministic script:
+- `scripts/upsert-pr-comment.py`
+
+## Payload JSON (LLM-Owned)
+
+The script consumes a **small JSON payload** containing only human narrative (it will compute PR facts + delta itself).
+
+Minimum recommended shape:
+
+```json
+{
+  "intent": "1–2 sentences: what we were trying to do and why",
+  "risk": "Low/Medium/High + 1-liner justification",
+  "tests_summary": "Short, evidence-based summary (or 'None recorded')",
+  "pr_scope_bullets": ["PR-wide changes, not just this chat"],
+  "hotspots": ["Where reviewers should focus / risks"],
+  "prompts": "Optional. Minimal prompts-to-reproduce (redacted).",
+  "session_label": "Short label for this session entry",
+  "human_steering": ["Constraints, clarifications, reversals, corrections"],
+  "decisions": ["Tradeoffs chosen + why"],
+  "delta_narrative": "Short: what changed since prior update",
+  "tests_markdown": "- [ ] pytest ...\\n- [x] ruff ... (pass)",
+  "notes": "Anything reviewers should know (uncertainties, follow-ups)"
+}
+```
+
+Rules:
+- Keep `pr_scope_bullets` and `hotspots` scannable (short bullets, no diffs).
+- `tests_markdown` must be **GitHub task list** markdown. The script treats `[x]` as **self-reported**, not verified, and will render it explicitly as such.
+- Redact secrets/tokens, customer PII, and internal URLs (the script also redacts as a safety net).
+
+## Comment Identity (Distinct + Idempotent)
+
+This skill must ensure **only one** such comment exists per PR by using a hidden marker that you can search for and update:
+
+```text
+<!-- diversio:session-review-notes -->
+```
+
+Rules:
+- The marker must appear **once near the top** of the comment body.
+- Before posting, search existing PR comments for the marker:
+  - If found, **update** that comment (do not add another).
+  - If multiple are found, update the **most recently updated** one and call out the duplication as a follow-up.
+
+## Multi-Session Support (Codex + Claude Code)
+
+This skill assumes a PR may be produced across **multiple agent sessions**, possibly in **different tools** (Codex and Claude Code).
+
+Principle: the PR comment is a **living ledger** with two layers:
+- **PR scope (always regenerated):** derived from the full PR diff so it never “forgets” earlier work.
+- **Session log (cumulative):** each run adds (or updates) a session entry capturing **human steering** and the **delta since the prior update**.
+
+## Session Selection (Human-Readable)
+
+Sometimes you need to backfill earlier work (e.g., several Codex + Claude Code sessions happened but only the final session is open right now).
+
+If you can’t confidently identify which sessions matter:
+
+1. Generate a short, human-readable list of recent sessions for this project (tool, session ID, timestamp, branch, first-prompt snippet).
+   - Prefer the helper described in `references/transcripts.md`.
+2. Ask the user to pick the relevant session IDs (and optionally give each a 1-line label).
+3. Only then, selectively open/scan those transcript files to extract **human steering** + **tests run** (never paste transcripts verbatim; redact secrets).
+
+If transcript access is not available (sandbox / remote environment), fall back to asking the user to run:
+- `codex resume` / `codex resume --all`
+- `claude --resume`
+
+and share the chosen session IDs.
+
+## Avoiding the “Latest Minor Session” Trap
+
+Never let a tiny follow-up session overwrite the narrative:
+- The visible “What changed” section must reflect the **entire PR diff**, not just the current chat.
+- The most recent session should be logged as a **delta** plus a new (or updated) session entry.
+
+## Workflow
+
+1. **Resolve the target PR**
+   - Prefer `--pr auto` (PR for current branch) or accept a PR URL/number.
+   - If there is no PR, ask the user for the PR number or URL (stop until you have it).
+
+2. **If multi-session/backfill is needed, enumerate sessions**
+   - Use the helper described in `references/transcripts.md` to show a short table.
+   - Ask the user which session IDs to include (Codex + Claude Code may both be involved).
+
+3. **Write the payload JSON (LLM-owned content only)**
+   - Keep it short and structured (no walls of text).
+   - Do not claim tests ran unless you have evidence.
+   - Redact secrets/tokens/PII/internal URLs.
+
+4. **Run the deterministic upsert script**
+   - It finds/updates the single comment (by marker), merges session entries, computes delta via GitHub compare, redacts, and posts.
+   - Use `--dry-run` to preview without posting.
+
+5. **Return**
+   - Output only the comment URL (and do not re-print the entire comment body unless asked).
+
+## Output Format (Markdown)
+
+The script renders a single GitHub-flavored Markdown comment body in this shape (keep it scannable and keep the markers intact):
+
+````markdown
+<!-- diversio:session-review-notes -->
+<!-- diversio:session-review-notes:state {"schema":2,"base":"<baseRefName>","head":"<headRefOid>","prev_head":"<prior_head_or_null>","rev":<n>,"sessions_total":<n>,"codex":<n>,"claude":<n>,"included_sessions":[{"tool":"codex","id":"..."},{"tool":"claude","id":"..."}],"sessions_sha256":"<sha256>","repair_count":<n>,"last_repair_at":"<ISO8601>","generator":"session-review-notes","generator_version":"<ver_or_null>","last_updated":"<ISO8601>"} -->
+
+<div align="center">
+
+## SESSION REVIEW NOTES
+<sub>Single upserted PR comment • cumulative across Codex + Claude Code sessions</sub>
+
+</div>
+
+> [!IMPORTANT]
+> This comment is **updated**, not duplicated. Re-run `/session-review-notes:generate` to update it. Please do not create a second “SESSION REVIEW NOTES” comment.
+
+### Summary
+
+| Field | Value |
+| --- | --- |
+| **Intent** | <1–2 sentences> |
+| **PR coverage** | `<baseRefName>...<headRefOid_short>` |
+| **PR size** | <files changed + additions/deletions + commits> |
+| **Sessions** | `<n> (Codex×<n>, Claude×<n>)` |
+| **Latest delta** | <short stat since prior update (or “n/a — first entry”)> |
+| **Risk** | Low / Medium / High |
+| **Tests** | <Latest update summary; refer to session log for earlier runs> |
+
+<details>
+<summary><strong>What changed (full PR diff)</strong></summary>
+
+- <high-level change area 1>
+- <high-level change area 2>
+
+</details>
+
+<details>
+<summary><strong>Hotspot map (deterministic)</strong></summary>
+
+| Area | Files | + | - |
+| --- | ---: | ---: | ---: |
+| `src/` | 7 | 220 | 45 |
+
+</details>
+
+<details>
+<summary><strong>Review hotspots / risks</strong></summary>
+
+- <what reviewers should focus on>
+
+</details>
+
+<details>
+<summary><strong>Latest delta (since prior update)</strong></summary>
+
+- <small, scannable diffstat-style bullets; don’t paste diffs>
+
+</details>
+
+<details>
+<summary><strong>Provenance / integrity</strong></summary>
+
+- PR scope: GitHub diff `<baseRefName>...<headRefOid_short>`
+- Delta: compare `<prev_head_short>...<headRefOid_short>`
+- Generator: `session-review-notes` schema=2 rev=<n>
+
+</details>
+
+<details>
+<summary><strong>Session log (cumulative)</strong> <sub>(newest first)</sub></summary>
+
+<!-- diversio:session-review-notes:sessions:start -->
+<!-- diversio:session-review-notes:entry {"tool":"<codex|claude>","session_id":"<id>","created_at":"<ISO8601>"} -->
+<details>
+<summary><strong><YYYY-MM-DD HH:MM TZ></strong> • <Codex|Claude Code> • <short label></summary>
+
+**Human steering**
+- <clarification / constraint / correction>
+
+**Delta**
+- <what changed since prior update; keep it short>
+
+**Key decisions**
+- <decision + why>
+
+**Tests (this session)**
+- [ ] <test command> (not run)
+- [x] <test command> (pass)
+
+**Notes**
+- <anything a reviewer should know (tradeoffs, uncertainties, follow-ups)>
+
+</details>
+
+<!-- diversio:session-review-notes:sessions:end -->
+</details>
+
+<details>
+<summary><strong>Prompts (optional, redacted)</strong></summary>
+
+```text
+<minimal prompts someone could re-run to reproduce; redact secrets/PII/URLs>
+```
+
+</details>
+
+---
+
+<sub>Last updated: <YYYY-MM-DD HH:MM TZ> • No secrets/tokens/credentials in this comment</sub>
+````
+
+## Posting / Updating the Comment (Deterministic Script)
+
+Use the bundled script `scripts/upsert-pr-comment.py`. It:
+- finds the existing comment by marker (or creates it),
+- merges the session log safely,
+- computes PR facts + delta via GitHub compare,
+- redacts secrets/PII/URLs,
+- updates the comment with merge/verify retries to avoid lost updates.
+
+### Usage
+
+From a **Codex Skill install** (inside the skill directory):
+
+```bash
+python3 scripts/upsert-pr-comment.py --tool codex --session-id auto --pr auto --payload payload.json
+```
+
+From **Claude Code** (plugin install):
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/session-review-notes/scripts/upsert-pr-comment.py" --tool claude --session-id auto --pr auto --payload payload.json
+```
+
+Preview only (no GitHub write):
+
+```bash
+python3 scripts/upsert-pr-comment.py --dry-run --tool codex --session-id auto --pr auto --payload payload.json
+```
+
+Payload from stdin:
+
+```bash
+python3 scripts/upsert-pr-comment.py --tool codex --session-id auto --pr auto --payload - < payload.json
+```
+
+### Style Rules
+
+- **Never** paste raw secrets/tokens/credentials (including `Authorization:` headers, API keys, cookies, JWTs, or `gh` auth tokens).
+- Do not include customer PII. Redact aggressively.
+- Prefer **specificity over verbosity**:
+  - Mention modules, directories, and concepts.
+  - Avoid listing every file unless the change is tiny.
+- If you didn’t run tests, say so plainly (don’t imply).
+- If you are uncertain about a claim, mark it as **(uncertain)** and explain why.

--- a/plugins/session-review-notes/skills/session-review-notes/references/transcripts.md
+++ b/plugins/session-review-notes/skills/session-review-notes/references/transcripts.md
@@ -1,0 +1,155 @@
+# Session Transcripts (Codex + Claude Code)
+
+This skill primarily relies on the **live chat context** plus the **PR diff**.
+However, for multi-session work (especially across **Codex + Claude Code**), it’s useful to know where each tool stores session transcripts and how to enumerate them.
+
+**Important:** transcripts often contain sensitive content (customer details, internal links, secrets pasted by accident). Treat them like production logs and **never paste them verbatim into GitHub**.
+
+---
+
+## Human-Readable Session Picker (Recommended)
+
+If the agent can’t reliably discover which past sessions matter, generate a **short, human-readable list** and choose the relevant session IDs.
+
+### Option A: Use the helper script (prints a Markdown table)
+
+From the marketplace repo checkout:
+
+```bash
+python3 plugins/session-review-notes/skills/session-review-notes/scripts/list-sessions.py --project "$PWD" --limit 15
+```
+
+From a Codex skill install (typical path):
+
+```bash
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+python3 "$CODEX_HOME/skills/session-review-notes/scripts/list-sessions.py" --project "$PWD" --limit 15
+```
+
+From Claude Code (plugin install):
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/session-review-notes/scripts/list-sessions.py" --project "$PWD" --limit 15
+```
+
+The output includes:
+- tool (`codex` / `claude`)
+- session ID
+- last-active time (relative)
+- branch (Claude, when available)
+- a short snippet of the first user prompt (redacted)
+
+### Option B: Use the built-in interactive pickers
+
+From the project directory:
+
+- Codex: `codex resume` (or `codex resume --all` to include other directories)
+- Claude Code: `claude --resume` (you can type to search)
+
+When you’ve picked sessions, share just the **session IDs** (and optionally a 1-line label per session).
+
+---
+
+## Codex (OpenAI)
+
+### Find / resume past sessions (built-in)
+
+- Resume with an interactive selector:
+  - `codex resume`
+- Include sessions from outside the current working directory:
+  - `codex resume --all`
+
+### Current session ID
+
+- Inside a running Codex interactive session, use:
+  - `/status`
+
+Codex prints the current conversation’s session ID via `/status`.
+
+### Better-than-guessing: `notify` (optional)
+
+Codex can be configured to invoke an external program after each turn via `notify` (advanced config). The JSON payload includes a thread/session identifier plus working directory.
+
+If you want fully reliable “current session ID” capture without asking the user to run `/status`, configure `notify` to write the latest `{thread-id, cwd, timestamp}` to a local file your scripts can read.
+
+### Where transcripts live (files)
+
+Codex stores sessions under `$CODEX_HOME` (defaults to `~/.codex`) and writes session files under:
+
+- `$CODEX_HOME/sessions/` (files under date-based subfolders)
+
+Codex can also persist a transcript stream to a `history.jsonl` file via config (`history.persistence`).
+
+### Practical: list the most recent session files
+
+```bash
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+ls -t "$CODEX_HOME/sessions"/*/*/*/*.jsonl | head
+```
+
+### Practical: search across all Codex sessions
+
+```bash
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+rg -n "agent-skills-marketplace" "$CODEX_HOME/sessions"
+```
+
+Good search keys:
+- repo path fragments (`work/diversio/…`)
+- branch names
+- PR numbers
+- commit SHAs
+
+---
+
+## Claude Code (Anthropic)
+
+### Find / resume past sessions (built-in)
+
+Claude’s CLI supports:
+- An interactive session picker:
+  - `claude --resume`
+- Continue the most recent conversation:
+  - `claude --continue`
+- Resume a specific session:
+  - `claude -r "<session-id>"`
+
+### Current session ID + transcript path (most reliable)
+
+Claude Code can pass `session_id` and `transcript_path` to a status line command/script (as JSON on stdin).
+
+This is the most robust way to identify **the current session’s transcript file** without guessing based on timestamps.
+
+### Where transcripts live (files)
+
+In practice, Claude Code maintains transcript files on disk. Exact folder layout may change, so prefer `transcript_path` from status line / hooks when available.
+
+- `~/.claude/history.jsonl` (an index/metadata log used for resume/continue flows)
+- `~/.claude/projects/<normalized-project-path>/*.jsonl` (per-project session transcripts)
+
+Some sessions also have a folder named after the session ID containing sub-agent transcripts, e.g.:
+
+- `~/.claude/projects/<normalized-project-path>/<session-id>/subagents/*.jsonl`
+
+### Practical: list recent session transcripts for one project
+
+```bash
+PROJECT_KEY="-Users-<you>-path-to-your-repo"
+ls -t "$HOME/.claude/projects/$PROJECT_KEY"/*.jsonl | head
+```
+
+### Practical: search across all Claude Code sessions
+
+```bash
+rg -n "agent-skills-marketplace" "$HOME/.claude/projects"
+```
+
+---
+
+## Recommended Pattern for This Skill (Don’t Overfit to Chat Logs)
+
+To avoid missing earlier sessions or over-weighting the last “minor” session:
+
+1. Use the **PR diff** as the canonical “What changed (full PR diff)” scope.
+2. Use session transcripts only to enrich the **session log entries** (human steering + tests run).
+3. Persist prior session entries in the single PR comment (the comment becomes your cross-tool session ledger).

--- a/plugins/session-review-notes/skills/session-review-notes/scripts/list-sessions.py
+++ b/plugins/session-review-notes/skills/session-review-notes/scripts/list-sessions.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class SessionRow:
+    tool: str
+    session_id: str
+    start: dt.datetime | None
+    end: dt.datetime | None
+    branch: str | None
+    cwd: str | None
+    summary: str | None
+    source: str
+
+
+_URL_RE = re.compile(r"https?://\S+")
+_REDACT_REPLACEMENTS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"(?i)github_pat_[A-Za-z0-9_]{10,}"), "[REDACTED_GITHUB_PAT]"),
+    (re.compile(r"(?i)ghp_[A-Za-z0-9]{10,}"), "[REDACTED_GITHUB_TOKEN]"),
+    (re.compile(r"(?i)gho_[A-Za-z0-9]{10,}"), "[REDACTED_GITHUB_TOKEN]"),
+    (re.compile(r"(?i)ghu_[A-Za-z0-9]{10,}"), "[REDACTED_GITHUB_TOKEN]"),
+    (re.compile(r"(?i)ghs_[A-Za-z0-9]{10,}"), "[REDACTED_GITHUB_TOKEN]"),
+    (re.compile(r"(?i)sk-[A-Za-z0-9]{10,}"), "[REDACTED_API_KEY]"),
+    (re.compile(r"(?i)pk_[A-Za-z0-9]{10,}"), "[REDACTED_API_TOKEN]"),
+    (re.compile(r"(?i)AIza[0-9A-Za-z_-]{20,}"), "[REDACTED_GCP_API_KEY]"),
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "[REDACTED_AWS_ACCESS_KEY_ID]"),
+    (
+        re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----"
+        ),
+        "[REDACTED_PRIVATE_KEY_BLOCK]",
+    ),
+    (
+        re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"),
+        "[REDACTED_JWT]",
+    ),
+    (re.compile(r"(?i)xox[baprs]-[A-Za-z0-9-]{10,}"), "[REDACTED_SLACK_TOKEN]"),
+]
+
+
+def _git_root(path: Path) -> Path | None:
+    try:
+        cp = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+    except Exception:
+        return None
+    root = cp.stdout.strip()
+    if not root:
+        return None
+    try:
+        return Path(root).resolve()
+    except Exception:
+        return None
+
+
+def _resolve_project_filter_root(project_path: Path) -> Path:
+    return _git_root(project_path) or project_path
+
+
+def _cwd_matches_project(cwd: str | None, project_root: Path) -> bool:
+    if not cwd:
+        return False
+    try:
+        cwd_path = Path(cwd).expanduser().resolve()
+    except Exception:
+        return False
+    try:
+        cwd_path.relative_to(project_root)
+        return True
+    except Exception:
+        return False
+
+
+def _parse_iso8601(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        parsed = dt.datetime.fromisoformat(value)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=dt.timezone.utc)
+        return parsed
+    except Exception:
+        return None
+
+
+def _to_local(dt_value: dt.datetime | None) -> str:
+    if not dt_value:
+        return "-"
+    try:
+        local = dt_value.astimezone()
+    except Exception:
+        local = dt_value
+    return local.strftime("%Y-%m-%d %H:%M")
+
+
+def _human_age(dt_value: dt.datetime | None, now: dt.datetime) -> str:
+    if not dt_value:
+        return "-"
+    try:
+        delta = now - dt_value.astimezone(dt.timezone.utc)
+    except Exception:
+        return "-"
+    seconds = int(delta.total_seconds())
+    if seconds < 0:
+        return "in future"
+    minutes = seconds // 60
+    hours = minutes // 60
+    days = hours // 24
+    if days:
+        return f"{days}d ago"
+    if hours:
+        return f"{hours}h ago"
+    if minutes:
+        return f"{minutes}m ago"
+    return f"{seconds}s ago"
+
+
+def _redact(text: str | None) -> str | None:
+    if text is None:
+        return None
+    redacted = _URL_RE.sub("[URL]", text)
+    for pattern, replacement in _REDACT_REPLACEMENTS:
+        redacted = pattern.sub(replacement, redacted)
+    home = str(Path.home())
+    if home:
+        redacted = redacted.replace(home, "~")
+    return redacted
+
+
+def _first_non_trivial_line(text: str) -> str:
+    skip_prefixes = (
+        "# agents.md instructions",
+        "<environment_context",
+        "<instructions",
+        "user arguments:",
+    )
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        lower = line.lower()
+        if lower.startswith(skip_prefixes):
+            continue
+        if line.startswith("```"):
+            continue
+        return line
+    return (text.strip().splitlines() or [""])[0].strip()
+
+
+def _read_first_json(path: Path) -> dict[str, Any] | None:
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            first = handle.readline()
+            if not first:
+                return None
+            return json.loads(first)
+    except Exception:
+        return None
+
+
+def _read_last_json(path: Path) -> dict[str, Any] | None:
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            if size == 0:
+                return None
+            chunk = b""
+            step = 4096
+            while size > 0:
+                read_size = min(step, size)
+                size -= read_size
+                handle.seek(size)
+                chunk = handle.read(read_size) + chunk
+                if b"\n" in chunk:
+                    break
+            lines = [line for line in chunk.splitlines() if line.strip()]
+            if not lines:
+                return None
+            return json.loads(lines[-1].decode("utf-8", errors="replace"))
+    except Exception:
+        return None
+
+
+def _iter_recent_files(root: Path, pattern_suffix: str, scan_limit: int) -> list[Path]:
+    files: list[Path] = []
+    for dirpath, _, filenames in os.walk(root):
+        for filename in filenames:
+            if not filename.endswith(pattern_suffix):
+                continue
+            files.append(Path(dirpath) / filename)
+    files.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0, reverse=True)
+    if scan_limit > 0:
+        return files[:scan_limit]
+    return files
+
+
+def _extract_codex_prompt_snippet(path: Path, max_lines: int = 80) -> str | None:
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for idx, line in enumerate(handle):
+                if idx > max_lines:
+                    break
+                try:
+                    obj = json.loads(line)
+                except Exception:
+                    continue
+                payload = obj.get("payload") or {}
+                if (
+                    obj.get("type") == "response_item"
+                    and payload.get("type") == "message"
+                    and payload.get("role") == "user"
+                ):
+                    content = payload.get("content") or []
+                    texts: list[str] = []
+                    for item in content:
+                        if not isinstance(item, dict):
+                            continue
+                        if item.get("type") in {"input_text", "text"}:
+                            texts.append(str(item.get("text") or ""))
+                    combined = "\n".join(texts).strip()
+                    if combined:
+                        snippet = _first_non_trivial_line(combined)
+                        snippet = _redact(snippet)
+                        return snippet[:140] if snippet else None
+        return None
+    except Exception:
+        return None
+
+
+def _list_codex_sessions(project_path: Path, scan_limit: int) -> list[SessionRow]:
+    codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+    sessions_root = codex_home / "sessions"
+    if not sessions_root.exists():
+        return []
+
+    rows: list[SessionRow] = []
+    for session_file in _iter_recent_files(sessions_root, ".jsonl", scan_limit=scan_limit):
+        first = _read_first_json(session_file)
+        if not first or first.get("type") != "session_meta":
+            continue
+        payload = first.get("payload") or {}
+        cwd = payload.get("cwd")
+        if not _cwd_matches_project(cwd, project_path):
+            continue
+
+        session_id = payload.get("id") or "-"
+        start = _parse_iso8601(payload.get("timestamp") or first.get("timestamp"))
+        last = _read_last_json(session_file)
+        end = _parse_iso8601((last or {}).get("timestamp"))
+        summary = _extract_codex_prompt_snippet(session_file)
+        rows.append(
+            SessionRow(
+                tool="codex",
+                session_id=str(session_id),
+                start=start,
+                end=end,
+                branch=None,
+                cwd=cwd,
+                summary=summary,
+                source=str(session_file),
+            )
+        )
+    return rows
+
+
+def _extract_claude_prompt_snippet(path: Path, max_lines: int = 60) -> str | None:
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for idx, line in enumerate(handle):
+                if idx > max_lines:
+                    break
+                try:
+                    obj = json.loads(line)
+                except Exception:
+                    continue
+                if obj.get("type") != "user":
+                    continue
+                message = obj.get("message") or {}
+                content = message.get("content")
+                if isinstance(content, str):
+                    text = content.strip()
+                else:
+                    text = ""
+                if text:
+                    snippet = _first_non_trivial_line(text)
+                    snippet = _redact(snippet)
+                    return snippet[:140] if snippet else None
+        return None
+    except Exception:
+        return None
+
+
+def _list_claude_sessions(project_path: Path, scan_limit: int) -> list[SessionRow]:
+    claude_home = Path(os.environ.get("CLAUDE_HOME") or (Path.home() / ".claude"))
+    projects_root = claude_home / "projects"
+    if not projects_root.exists():
+        return []
+
+    project_key = "-" + str(project_path).lstrip(os.sep).replace(os.sep, "-")
+    project_dir = projects_root / project_key
+
+    def iter_transcripts() -> list[Path]:
+        if project_dir.exists():
+            files = [p for p in project_dir.glob("*.jsonl") if p.is_file()]
+            files.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0, reverse=True)
+            return files[:scan_limit] if scan_limit > 0 else files
+
+        per_project = max(1, min(30, scan_limit))
+        candidates: list[Path] = []
+        for maybe_project in projects_root.iterdir():
+            if not maybe_project.is_dir():
+                continue
+            files = [p for p in maybe_project.glob("*.jsonl") if p.is_file()]
+            files.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0, reverse=True)
+            candidates.extend(files[:per_project])
+        candidates.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0, reverse=True)
+        return candidates[:scan_limit] if scan_limit > 0 else candidates
+
+    grouped: dict[str, dict[str, Any]] = {}
+    for transcript in iter_transcripts():
+        first = _read_first_json(transcript)
+        if not first:
+            continue
+        session_id = first.get("sessionId")
+        if not session_id:
+            continue
+        cwd = first.get("cwd")
+        if not _cwd_matches_project(cwd, project_path):
+            continue
+
+        start = _parse_iso8601(first.get("timestamp"))
+        last = _read_last_json(transcript)
+        end = _parse_iso8601((last or {}).get("timestamp"))
+        branch = first.get("gitBranch")
+        snippet = _extract_claude_prompt_snippet(transcript)
+
+        key = str(session_id)
+        entry = grouped.get(key)
+        if entry is None:
+            entry = {
+                "session_id": key,
+                "cwd": cwd,
+                "branch": branch,
+                "start": start,
+                "end": end,
+                "snippet": snippet,
+                "sources": [],
+            }
+            grouped[key] = entry
+
+        entry["sources"].append(str(transcript))
+        entry["branch"] = entry.get("branch") or branch
+        entry["cwd"] = entry.get("cwd") or cwd
+        entry["snippet"] = entry.get("snippet") or snippet
+        if start and (entry.get("start") is None or start < entry["start"]):
+            entry["start"] = start
+        if end and (entry.get("end") is None or end > entry["end"]):
+            entry["end"] = end
+
+    rows: list[SessionRow] = []
+    for session_id, info in grouped.items():
+        rows.append(
+            SessionRow(
+                tool="claude",
+                session_id=session_id,
+                start=info.get("start"),
+                end=info.get("end"),
+                branch=info.get("branch"),
+                cwd=info.get("cwd"),
+                summary=info.get("snippet"),
+                source=str(info.get("sources", ["-"])[0]),
+            )
+        )
+    return rows
+
+
+def _print_markdown(rows: list[SessionRow]) -> None:
+    now = dt.datetime.now(tz=dt.timezone.utc)
+    print("| # | Tool | Last active | Start | Branch | Session ID | Summary |")
+    print("| -: | --- | --- | --- | --- | --- | --- |")
+    for idx, row in enumerate(rows, start=1):
+        last_active = _human_age(row.end or row.start, now)
+        start = _to_local(row.start)
+        branch = row.branch or "-"
+        summary = row.summary or "-"
+        print(
+            f"| {idx} | `{row.tool}` | {last_active} | `{start}` | `{branch}` | `{row.session_id}` | {summary} |"
+        )
+    print()
+    print("Pick sessions by ID:")
+    print("- Codex: `codex resume <session-id>`")
+    print("- Claude Code: `claude -r <session-id>`")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="List recent Codex + Claude Code sessions for the current project with human-readable metadata."
+    )
+    parser.add_argument(
+        "--project",
+        default=os.getcwd(),
+        help="Project path to filter sessions by (defaults to current working directory).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=15,
+        help="Max rows to print after filtering (default: 15).",
+    )
+    parser.add_argument(
+        "--scan",
+        type=int,
+        default=250,
+        help="Max transcript files to inspect per tool before filtering (default: 250).",
+    )
+    parser.add_argument(
+        "--tool",
+        choices=["all", "codex", "claude"],
+        default="all",
+        help="Which tool's sessions to include (default: all).",
+    )
+    args = parser.parse_args(argv)
+
+    project_path = _resolve_project_filter_root(Path(args.project).expanduser().resolve())
+    scan_limit = max(0, int(args.scan))
+    rows: list[SessionRow] = []
+
+    if args.tool in {"all", "codex"}:
+        rows.extend(_list_codex_sessions(project_path=project_path, scan_limit=scan_limit))
+    if args.tool in {"all", "claude"}:
+        rows.extend(_list_claude_sessions(project_path=project_path, scan_limit=scan_limit))
+
+    rows.sort(key=lambda r: (r.end or r.start or dt.datetime.min.replace(tzinfo=dt.timezone.utc)), reverse=True)
+    _print_markdown(rows[: max(0, int(args.limit))])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/session-review-notes/skills/session-review-notes/scripts/upsert-pr-comment.py
+++ b/plugins/session-review-notes/skills/session-review-notes/scripts/upsert-pr-comment.py
@@ -1,0 +1,1287 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+
+MARKER = "<!-- diversio:session-review-notes -->"
+STATE_PREFIX = "<!-- diversio:session-review-notes:state "
+SESSIONS_START = "<!-- diversio:session-review-notes:sessions:start -->"
+SESSIONS_END = "<!-- diversio:session-review-notes:sessions:end -->"
+ENTRY_META_PREFIX = "<!-- diversio:session-review-notes:entry "
+
+SCHEMA_VERSION = 2
+# GitHub PR comments hard-fail near ~65k chars; keep a safety buffer for markup and future schema growth.
+MAX_BODY_CHARS = 60000
+MAX_PROMPTS_CHARS = 2000
+MAX_TEXT_CHARS = 2000
+MAX_LIST_ITEMS = 25
+MAX_ITEM_CHARS = 280
+MAX_SESSION_LABEL_CHARS = 80
+
+STATE_RE = re.compile(r"<!-- diversio:session-review-notes:state\s+(\{.*?\})\s*-->")
+ENTRY_META_RE = re.compile(r"<!-- diversio:session-review-notes:entry\s+(\{.*?\})\s*-->")
+
+
+URL_RE = re.compile(r"https?://\S+")
+REDACT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"(?i)github_pat_[A-Za-z0-9_]{10,}"), "[REDACTED_GITHUB_PAT]"),
+    (re.compile(r"(?i)gh[pousr]_[A-Za-z0-9]{10,}"), "[REDACTED_GITHUB_TOKEN]"),
+    (re.compile(r"(?i)sk-[A-Za-z0-9]{10,}"), "[REDACTED_API_KEY]"),
+    (re.compile(r"(?i)AIza[0-9A-Za-z_-]{20,}"), "[REDACTED_GCP_API_KEY]"),
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "[REDACTED_AWS_ACCESS_KEY_ID]"),
+    (
+        re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----"
+        ),
+        "[REDACTED_PRIVATE_KEY_BLOCK]",
+    ),
+    (
+        re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"),
+        "[REDACTED_JWT]",
+    ),
+    (
+        re.compile(r"(?i)\bAuthorization:\s*(Bearer|Token)\s+\S+"),
+        "Authorization: [REDACTED_AUTH]",
+    ),
+    (re.compile(r"(?i)xox[baprs]-[A-Za-z0-9-]{10,}"), "[REDACTED_SLACK_TOKEN]"),
+]
+
+
+def _run(cmd: list[str], *, check: bool = True, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        input=input_text,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=check,
+    )
+
+
+def _gh(repo: str | None, args: list[str], *, check: bool = True, input_text: str | None = None) -> str:
+    cmd = ["gh"]
+    cmd.extend(args)
+    if repo:
+        # `-R` works for `gh api` and some other commands; safe to include only when applicable.
+        if cmd[1] == "api":
+            cmd[2:2] = ["-R", repo]
+    cp = _run(cmd, check=check, input_text=input_text)
+    return cp.stdout
+
+
+def _gh_json(repo: str | None, args: list[str]) -> Any:
+    return json.loads(_gh(repo, args))
+
+
+def _gh_api_json(repo: str, endpoint: str) -> Any:
+    return _gh_json(repo, ["api", endpoint])
+
+
+def _gh_api_json_paginated(repo: str, endpoint: str) -> list[Any]:
+    data = _gh_json(repo, ["api", endpoint, "--paginate", "--slurp"])
+    if isinstance(data, list) and data and isinstance(data[0], list):
+        flattened: list[Any] = []
+        for page in data:
+            flattened.extend(page)
+        return flattened
+    if isinstance(data, list):
+        return data
+    return [data]
+
+
+def _gh_api_including_headers(repo: str, endpoint: str) -> tuple[dict[str, str], str]:
+    raw = _gh(repo, ["api", "-i", endpoint])
+    if "\r\n\r\n" in raw:
+        header_blob, body = raw.split("\r\n\r\n", 1)
+        header_lines = header_blob.split("\r\n")
+    elif "\n\n" in raw:
+        header_blob, body = raw.split("\n\n", 1)
+        header_lines = header_blob.split("\n")
+    else:
+        return {}, raw
+
+    headers: dict[str, str] = {}
+    for line in header_lines:
+        if ":" not in line:
+            continue
+        k, v = line.split(":", 1)
+        headers[k.strip().lower()] = v.strip()
+    return headers, body
+
+
+def _redact(text: str, allowed_hosts: set[str]) -> str:
+    def _sub_url(m: re.Match[str]) -> str:
+        u = m.group(0)
+        try:
+            host = urlparse(u).netloc.lower()
+        except Exception:
+            host = ""
+        return u if host in allowed_hosts else "[URL]"
+
+    out = URL_RE.sub(_sub_url, text)
+    for pattern, replacement in REDACT_PATTERNS:
+        out = pattern.sub(replacement, out)
+    home = str(Path.home())
+    if home:
+        out = out.replace(home, "~")
+    return out
+
+
+def _redact_obj(value: Any, allowed_hosts: set[str]) -> Any:
+    if isinstance(value, str):
+        return _redact(value, allowed_hosts)
+    if isinstance(value, list):
+        return [_redact_obj(v, allowed_hosts) for v in value]
+    if isinstance(value, dict):
+        return {k: _redact_obj(v, allowed_hosts) for k, v in value.items()}
+    return value
+
+
+def _parse_pr_arg(pr: str) -> tuple[str | None, int | None]:
+    pr = pr.strip()
+    if pr.isdigit():
+        return None, int(pr)
+
+    parsed = urlparse(pr)
+    if not parsed.netloc:
+        return None, None
+    parts = [p for p in parsed.path.split("/") if p]
+    # /{owner}/{repo}/pull/{number}
+    if len(parts) >= 4 and parts[2] in {"pull", "pulls"} and parts[3].isdigit():
+        owner, repo = parts[0], parts[1]
+        return f"{owner}/{repo}", int(parts[3])
+    return None, None
+
+
+def _resolve_repo_fallback() -> str:
+    data = _gh_json(None, ["repo", "view", "--json", "nameWithOwner"])
+    return str(data["nameWithOwner"])
+
+
+def _resolve_pr_number(repo: str, pr_arg: str) -> int:
+    if pr_arg == "auto":
+        try:
+            data = _gh_json(None, ["pr", "view", "-R", repo, "--json", "number"])
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            extra = f"\n\n{stderr}" if stderr else ""
+            raise SystemExit(
+                "Unable to resolve the PR number automatically. "
+                "Run this script from within the target repo, or provide an explicit PR number/URL via --pr."
+                f"{extra}"
+            ) from None
+        return int(data["number"])
+
+    _, pr_number = _parse_pr_arg(pr_arg)
+    if pr_number is None:
+        raise SystemExit("Could not parse --pr. Provide a PR number, PR URL, or use --pr auto.")
+    return pr_number
+
+
+def _detect_generator_version() -> str | None:
+    try:
+        script_path = Path(__file__).resolve()
+        plugin_json = script_path.parents[4] / ".claude-plugin" / "plugin.json"
+        if not plugin_json.exists():
+            return None
+        data = json.loads(plugin_json.read_text(encoding="utf-8"))
+        version = data.get("version")
+        if not version:
+            return None
+        return str(version)
+    except Exception:
+        return None
+
+
+@dataclasses.dataclass(frozen=True)
+class ExistingComment:
+    comment_id: int
+    body: str
+    etag: str | None
+    updated_at: str | None
+    html_url: str | None
+    marker_comment_ids: tuple[int, ...]
+
+
+def _find_existing_comment(repo: str, pr_number: int) -> ExistingComment | None:
+    comments = _gh_api_json_paginated(repo, f"repos/{repo}/issues/{pr_number}/comments")
+    marked = [c for c in comments if isinstance(c.get("body"), str) and MARKER in c["body"]]
+    if not marked:
+        return None
+    marker_comment_ids: list[int] = []
+    for c in marked:
+        try:
+            marker_comment_ids.append(int(c.get("id")))
+        except Exception:
+            continue
+    marked.sort(key=lambda c: str(c.get("updated_at") or ""))
+    chosen = marked[-1]
+    comment_id = int(chosen["id"])
+    headers, body_text = _gh_api_including_headers(repo, f"repos/{repo}/issues/comments/{comment_id}")
+    data = json.loads(body_text)
+    return ExistingComment(
+        comment_id=comment_id,
+        body=str(data.get("body") or ""),
+        etag=headers.get("etag"),
+        updated_at=data.get("updated_at"),
+        html_url=data.get("html_url"),
+        marker_comment_ids=tuple(marker_comment_ids),
+    )
+
+
+def _extract_state_with_repairs(body: str) -> tuple[dict[str, Any], list[str]]:
+    match = STATE_RE.search(body)
+    if not match:
+        return {}, ["Missing state marker; state reinitialized."]
+    try:
+        parsed = json.loads(match.group(1))
+    except Exception:
+        return {}, ["Invalid state marker JSON; state reinitialized."]
+    if not isinstance(parsed, dict):
+        return {}, ["Invalid state marker shape; state reinitialized."]
+    return parsed, []
+
+
+def _extract_sessions_block_with_repairs(body: str) -> tuple[str, list[str]]:
+    start = body.find(SESSIONS_START)
+    end = body.find(SESSIONS_END)
+    if start == -1 or end == -1 or end < start:
+        recovered: list[str] = []
+        for match in re.finditer(re.escape(ENTRY_META_PREFIX), body):
+            entry_start = match.start()
+            entry_end = body.find("</details>", entry_start)
+            if entry_end == -1:
+                continue
+            recovered.append(body[entry_start : entry_end + len("</details>")].strip())
+        if recovered:
+            return (
+                "\n\n".join(recovered).strip("\n"),
+                [
+                    "Missing session markers; session log rebuilt by recovering existing entry markers.",
+                ],
+            )
+        return "", ["Missing session markers; session log reinitialized."]
+    block = body[start + len(SESSIONS_START) : end].strip("\n")
+
+    repairs: list[str] = []
+    if "Session log (cumulative)" in block and "<summary><strong>Session log" in block:
+        repairs.append("Legacy session marker layout detected; migrated to canonical layout.")
+        summary_end = block.find("</summary>")
+        if summary_end != -1:
+            block = block[summary_end + len("</summary>") :].strip()
+        if block.endswith("</details>"):
+            block = block[: -len("</details>")].rstrip()
+    return block.strip("\n"), repairs
+
+
+@dataclasses.dataclass(frozen=True)
+class SessionKey:
+    tool: str
+    session_id: str
+
+
+@dataclasses.dataclass(frozen=True)
+class SessionEntry:
+    key: SessionKey | None
+    created_at: dt.datetime | None
+    raw: str
+
+
+def _parse_entries(entries_block: str) -> list[SessionEntry]:
+    if ENTRY_META_PREFIX not in entries_block:
+        stripped = entries_block.strip()
+        return [SessionEntry(key=None, created_at=None, raw=stripped)] if stripped else []
+
+    parts = entries_block.split(ENTRY_META_PREFIX)
+    entries: list[SessionEntry] = []
+    pre = parts[0].strip()
+    if pre:
+        entries.append(SessionEntry(key=None, created_at=None, raw=pre))
+
+    for part in parts[1:]:
+        raw = (ENTRY_META_PREFIX + part).strip()
+        key: SessionKey | None = None
+        created_at: dt.datetime | None = None
+        match = ENTRY_META_RE.search(raw)
+        if match:
+            try:
+                meta = json.loads(match.group(1))
+                tool = str(meta.get("tool") or "").strip()
+                session_id = str(meta.get("session_id") or "").strip()
+                if tool and session_id:
+                    key = SessionKey(tool=tool, session_id=session_id)
+                created_at = _parse_iso8601(meta.get("created_at"))
+            except Exception:
+                key = None
+        entries.append(SessionEntry(key=key, created_at=created_at, raw=raw))
+    return entries
+
+
+def _merge_entries(
+    existing_entries_block: str,
+    new_entry_raw: str,
+    new_key: SessionKey,
+    *,
+    delta_empty: bool,
+) -> str:
+    existing_entries = _parse_entries(existing_entries_block)
+    merged: list[str] = []
+
+    if delta_empty:
+        replaced = False
+        for entry in existing_entries:
+            if (not replaced) and entry.key == new_key:
+                merged.append(new_entry_raw.strip())
+                replaced = True
+            else:
+                merged.append(entry.raw.strip())
+        if not replaced:
+            merged.insert(0, new_entry_raw.strip())
+    else:
+        merged.append(new_entry_raw.strip())
+        for entry in existing_entries:
+            if entry.key == new_key:
+                continue
+            merged.append(entry.raw.strip())
+
+    merged_clean = [m for m in merged if m.strip()]
+    return "\n\n".join(merged_clean).strip() + ("\n" if merged_clean else "")
+
+
+def _entries_to_block(entries: list[SessionEntry]) -> str:
+    parts = [e.raw.strip() for e in entries if e.raw.strip()]
+    if not parts:
+        return ""
+    return "\n\n".join(parts).strip() + "\n"
+
+
+def _sort_entries(entries: list[SessionEntry]) -> list[SessionEntry]:
+    if not entries:
+        return []
+
+    keyed = [e for e in entries if e.key]
+    unkeyed = [e for e in entries if not e.key]
+
+    keyed.sort(
+        key=lambda e: e.created_at
+        or dt.datetime.min.replace(tzinfo=dt.timezone.utc),
+        reverse=True,
+    )
+    return keyed + unkeyed
+
+
+def _normalize_entries_block(
+    entries_block: str, *, required_key: SessionKey | None = None, max_entries: int | None = None
+) -> str:
+    entries = _sort_entries(_parse_entries(entries_block))
+    if max_entries is None or max_entries <= 0:
+        return _entries_to_block(entries)
+
+    required: list[SessionEntry] = []
+    others: list[SessionEntry] = []
+    for entry in entries:
+        if required_key and entry.key == required_key:
+            required.append(entry)
+        else:
+            others.append(entry)
+
+    kept: list[SessionEntry] = []
+    kept.extend(required)
+    for entry in others:
+        if len(kept) >= max_entries:
+            break
+        kept.append(entry)
+
+    if required_key and not any(e.key == required_key for e in kept):
+        for entry in entries:
+            if entry.key == required_key:
+                kept.insert(0, entry)
+                break
+
+    return _entries_to_block(kept)
+
+
+def _count_entries(entries_block: str) -> tuple[int, int, int, list[dict[str, str]]]:
+    total = 0
+    codex = 0
+    claude = 0
+    included: list[dict[str, str]] = []
+    for match in ENTRY_META_RE.finditer(entries_block):
+        try:
+            meta = json.loads(match.group(1))
+            tool = str(meta.get("tool") or "").strip()
+            session_id = str(meta.get("session_id") or "").strip()
+        except Exception:
+            continue
+        if not tool or not session_id:
+            continue
+        total += 1
+        if tool == "codex":
+            codex += 1
+        if tool == "claude":
+            claude += 1
+        included.append({"tool": tool, "id": session_id})
+    # Deduplicate while preserving order
+    seen = set()
+    uniq: list[dict[str, str]] = []
+    for item in included:
+        key = (item["tool"], item["id"])
+        if key in seen:
+            continue
+        seen.add(key)
+        uniq.append(item)
+    return total, codex, claude, uniq
+
+
+def _parse_int(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value)
+        if isinstance(value, str) and value.strip().isdigit():
+            return int(value.strip())
+    except Exception:
+        return None
+    return None
+
+
+def _merge_included_sessions(
+    prev: Any, scanned: list[dict[str, str]]
+) -> list[dict[str, str]]:
+    merged: list[dict[str, str]] = []
+    if isinstance(prev, list):
+        for item in prev:
+            if not isinstance(item, dict):
+                continue
+            tool = str(item.get("tool") or "").strip()
+            sid = str(item.get("id") or item.get("session_id") or "").strip()
+            if tool and sid:
+                merged.append({"tool": tool, "id": sid})
+
+    merged.extend(scanned)
+    seen: set[tuple[str, str]] = set()
+    uniq: list[dict[str, str]] = []
+    for item in merged:
+        key = (item["tool"], item["id"])
+        if key in seen:
+            continue
+        seen.add(key)
+        uniq.append(item)
+    return uniq
+
+
+def _parse_iso8601(value: Any) -> dt.datetime | None:
+    if not value:
+        return None
+    if not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        parsed = dt.datetime.fromisoformat(raw)
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=dt.timezone.utc)
+        return parsed
+    except Exception:
+        return None
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    if max_chars <= 0:
+        return ""
+    if len(text) <= max_chars:
+        return text
+    if max_chars <= 3:
+        return text[:max_chars]
+    return text[: max_chars - 3] + "..."
+
+
+def _normalize_text(value: Any, *, max_chars: int) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, (list, dict)):
+        return ""
+    try:
+        text = str(value)
+    except Exception:
+        return ""
+    return _truncate(text.strip(), max_chars)
+
+
+def _normalize_list(value: Any, *, max_items: int, max_item_chars: int) -> list[str]:
+    if value is None:
+        return []
+    items: list[str] = []
+    if isinstance(value, list):
+        raw_items = value
+    elif isinstance(value, str):
+        raw_items = [value]
+    else:
+        raw_items = []
+
+    for raw in raw_items:
+        if raw is None:
+            continue
+        if isinstance(raw, (list, dict)):
+            continue
+        try:
+            item = str(raw).strip()
+        except Exception:
+            continue
+        if not item:
+            continue
+        items.append(_truncate(item, max_item_chars))
+        if len(items) >= max_items:
+            break
+    return items
+
+
+def _normalize_payload(payload_raw: Any) -> dict[str, Any]:
+    if not isinstance(payload_raw, dict):
+        raise SystemExit("Payload must be a JSON object.")
+
+    normalized: dict[str, Any] = {}
+    normalized["intent"] = _normalize_text(payload_raw.get("intent"), max_chars=MAX_TEXT_CHARS)
+    normalized["risk"] = _normalize_text(payload_raw.get("risk"), max_chars=MAX_TEXT_CHARS)
+    normalized["tests_summary"] = _normalize_text(payload_raw.get("tests_summary"), max_chars=MAX_TEXT_CHARS)
+    normalized["prompts"] = _normalize_text(payload_raw.get("prompts"), max_chars=MAX_PROMPTS_CHARS)
+    normalized["session_label"] = _truncate(
+        _normalize_text(payload_raw.get("session_label"), max_chars=MAX_SESSION_LABEL_CHARS),
+        MAX_SESSION_LABEL_CHARS,
+    )
+    normalized["delta_narrative"] = _normalize_text(payload_raw.get("delta_narrative"), max_chars=MAX_TEXT_CHARS)
+    normalized["tests_markdown"] = _normalize_text(payload_raw.get("tests_markdown"), max_chars=MAX_TEXT_CHARS)
+    normalized["notes"] = _normalize_text(payload_raw.get("notes"), max_chars=MAX_TEXT_CHARS)
+
+    normalized["pr_scope_bullets"] = _normalize_list(
+        payload_raw.get("pr_scope_bullets"), max_items=MAX_LIST_ITEMS, max_item_chars=MAX_ITEM_CHARS
+    )
+    normalized["hotspots"] = _normalize_list(
+        payload_raw.get("hotspots"), max_items=MAX_LIST_ITEMS, max_item_chars=MAX_ITEM_CHARS
+    )
+    normalized["human_steering"] = _normalize_list(
+        payload_raw.get("human_steering"), max_items=MAX_LIST_ITEMS, max_item_chars=MAX_ITEM_CHARS
+    )
+    normalized["decisions"] = _normalize_list(
+        payload_raw.get("decisions"), max_items=MAX_LIST_ITEMS, max_item_chars=MAX_ITEM_CHARS
+    )
+
+    normalized["entry_created_at"] = _normalize_text(payload_raw.get("entry_created_at"), max_chars=64)
+    return normalized
+
+
+_TEST_ITEM_RE = re.compile(r"^\s*-\s*\[([xX ])\]\s*(.+?)\s*$")
+
+
+def _parse_tests_markdown(tests_markdown: str) -> tuple[list[str], list[str]]:
+    if not tests_markdown.strip():
+        return [], []
+
+    self_reported: list[str] = []
+    not_run: list[str] = []
+    for raw_line in tests_markdown.splitlines():
+        line = raw_line.rstrip()
+        if not line.strip():
+            continue
+        match = _TEST_ITEM_RE.match(line)
+        if match:
+            checked = match.group(1).strip().lower() == "x"
+            item = match.group(2).strip()
+        else:
+            if not line.lstrip().startswith("- "):
+                continue
+            checked = False
+            item = line.lstrip()[2:].strip()
+        if not item:
+            continue
+        item = _truncate(item, MAX_ITEM_CHARS)
+        if checked:
+            self_reported.append(item)
+        else:
+            not_run.append(item)
+    return self_reported, not_run
+
+
+def _render_tests_section(tests_markdown: str) -> str:
+    self_reported, not_run = _parse_tests_markdown(tests_markdown)
+    if not self_reported and not not_run:
+        return "- None recorded"
+
+    lines: list[str] = []
+    if self_reported:
+        lines.append("- Self-reported:")
+        lines.extend([f"  - `{t}`" for t in self_reported])
+    if not_run:
+        lines.append("- Not run:")
+        lines.extend([f"  - `{t}`" for t in not_run])
+    return "\n".join(lines)
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+def _render_bullets(lines: Iterable[str] | None) -> str:
+    if not lines:
+        return "- (not provided)"
+    rendered = [f"- {line}" for line in lines if str(line).strip()]
+    return "\n".join(rendered) if rendered else "- (not provided)"
+
+
+def _render_comment(
+    *,
+    pr: dict[str, Any],
+    payload: dict[str, Any],
+    prev_head: str | None,
+    head_sha: str,
+    entries_block: str,
+    delta_summary: str,
+    delta_details: str,
+    hotspot_map: str,
+    provenance: str,
+    now: dt.datetime,
+    sessions_total: int,
+    codex_count: int,
+    claude_count: int,
+    included_sessions: list[dict[str, str]],
+    sessions_sha256: str | None,
+    repair_count: int | None,
+    last_repair_at: str | None,
+    generator: str,
+    generator_version: str | None,
+) -> str:
+    base_ref = str((pr.get("base") or {}).get("ref") or "")
+    head_short = head_sha[:7]
+    pr_url = str(pr.get("html_url") or "")
+
+    pr_stats = (
+        f'{int(pr.get("changed_files") or 0)} files • '
+        f'+{int(pr.get("additions") or 0)} / -{int(pr.get("deletions") or 0)} • '
+        f'{int(pr.get("commits") or 0)} commits'
+    )
+
+    state_obj: dict[str, Any] = {
+        "schema": SCHEMA_VERSION,
+        "base": base_ref,
+        "head": head_sha,
+        "prev_head": prev_head,
+        "rev": int(payload.get("_rev") or 0) or None,
+        "sessions_total": sessions_total,
+        "codex": codex_count,
+        "claude": claude_count,
+        "included_sessions": included_sessions,
+        "sessions_sha256": sessions_sha256,
+        "repair_count": repair_count,
+        "last_repair_at": last_repair_at,
+        "generator": generator,
+        "generator_version": generator_version,
+        "last_updated": now.isoformat(),
+    }
+    state_obj = {k: v for k, v in state_obj.items() if v is not None}
+    state_line = f"{STATE_PREFIX}{json.dumps(state_obj, separators=(',',':'))} -->"
+
+    intent = str(payload.get("intent") or "-")
+    risk = str(payload.get("risk") or "-")
+    tests_summary = str(payload.get("tests_summary") or "").strip()
+    if tests_summary:
+        tests_summary = f"Self-reported: {tests_summary}"
+    else:
+        tests_summary = "None recorded (see session log)"
+
+    pr_scope_bullets = payload.get("pr_scope_bullets") or []
+    hotspots = payload.get("hotspots") or []
+    prompts = str(payload.get("prompts") or "").strip()
+
+    updated_local = now.strftime("%Y-%m-%d %H:%M %Z").strip()
+
+    return f"""{MARKER}
+{state_line}
+
+<div align="center">
+
+## SESSION REVIEW NOTES
+<sub>Single upserted PR comment • cumulative across Codex + Claude Code sessions</sub>
+
+</div>
+
+> [!IMPORTANT]
+> This comment is **updated**, not duplicated. Re-run `/session-review-notes:generate` to update it. Please do not create a second “SESSION REVIEW NOTES” comment.
+
+### Summary
+
+| Field | Value |
+| --- | --- |
+| **Intent** | {intent} |
+| **PR coverage** | `{base_ref}...{head_short}` |
+| **PR size** | {pr_stats} |
+| **Sessions** | `{sessions_total}` (Codex×`{codex_count}`, Claude×`{claude_count}`) |
+| **Latest delta** | {delta_summary} |
+| **Risk** | {risk} |
+| **Tests** | {tests_summary} |
+
+<details>
+<summary><strong>What changed (full PR diff)</strong></summary>
+
+{_render_bullets(pr_scope_bullets)}
+
+</details>
+
+<details>
+<summary><strong>Hotspot map (deterministic)</strong></summary>
+
+{hotspot_map}
+
+</details>
+
+<details>
+<summary><strong>Review hotspots / risks</strong></summary>
+
+{_render_bullets(hotspots)}
+
+</details>
+
+<details>
+<summary><strong>Latest delta (since prior update)</strong></summary>
+
+{delta_details}
+
+</details>
+
+<details>
+<summary><strong>Provenance / integrity</strong></summary>
+
+{provenance}
+
+</details>
+
+<details>
+<summary><strong>Session log (cumulative)</strong> <sub>(newest first)</sub></summary>
+
+{SESSIONS_START}
+{entries_block.rstrip()}
+{SESSIONS_END}
+
+</details>
+
+<details>
+<summary><strong>Prompts (optional, redacted)</strong></summary>
+
+```text
+{prompts or "-"}
+```
+
+</details>
+
+---
+
+<sub>PR: {pr_url} • Last updated: {updated_local} • No secrets/tokens/credentials in this comment</sub>
+"""
+
+
+def _compute_delta(repo: str, prev_head: str | None, head_sha: str) -> tuple[str, str]:
+    if not prev_head:
+        return "n/a — first entry", "- n/a — first entry"
+    if prev_head == head_sha:
+        return "n/a — no PR head change since last update", "- n/a — no PR head change since last update"
+
+    try:
+        compare = _gh_api_json(repo, f"repos/{repo}/compare/{prev_head}...{head_sha}")
+        files = compare.get("files") or []
+        additions = sum(int(f.get("additions") or 0) for f in files)
+        deletions = sum(int(f.get("deletions") or 0) for f in files)
+        summary = f"`{len(files)}` files • +{additions} / -{deletions}"
+
+        top = sorted(files, key=lambda f: int(f.get("changes") or 0), reverse=True)[:8]
+        if not top:
+            return summary, "- (no file-level delta available)"
+        details = "\n".join(
+            [
+                f'- `{f.get("filename")}` (+{int(f.get("additions") or 0)}/-{int(f.get("deletions") or 0)})'
+                for f in top
+                if f.get("filename")
+            ]
+        )
+        return summary, details or "- (no file-level delta available)"
+    except Exception:
+        return "(unable to compute compare)", "- (unable to compute compare)"
+
+
+def _fetch_pr_files(repo: str, pr_number: int) -> list[dict[str, Any]]:
+    try:
+        return _gh_api_json_paginated(repo, f"repos/{repo}/pulls/{pr_number}/files?per_page=100")
+    except Exception:
+        return []
+
+
+def _area_for_path(filename: str) -> str:
+    if "/" not in filename:
+        return "(root)"
+    return filename.split("/", 1)[0] + "/"
+
+
+def _render_hotspot_map(pr_files: list[dict[str, Any]]) -> str:
+    if not pr_files:
+        return "- (unable to compute)"
+
+    grouped: dict[str, dict[str, Any]] = {}
+    for f in pr_files:
+        filename = f.get("filename")
+        if not isinstance(filename, str) or not filename:
+            continue
+        area = _area_for_path(filename)
+        stats = grouped.setdefault(area, {"files": set(), "additions": 0, "deletions": 0})
+        stats["files"].add(filename)
+        stats["additions"] += int(f.get("additions") or 0)
+        stats["deletions"] += int(f.get("deletions") or 0)
+
+    rows: list[tuple[str, int, int, int]] = []
+    for area, stats in grouped.items():
+        files_count = len(stats["files"])
+        additions = int(stats["additions"])
+        deletions = int(stats["deletions"])
+        rows.append((area, files_count, additions, deletions))
+
+    rows.sort(key=lambda r: (r[2] + r[3], r[1]), reverse=True)
+    top = rows[:10]
+    if not top:
+        return "- (no file-level data available)"
+
+    lines = [
+        "| Area | Files | + | - |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    for area, files_count, additions, deletions in top:
+        lines.append(f"| `{area}` | {files_count} | {additions} | {deletions} |")
+    return "\n".join(lines)
+
+
+def _guess_session_id(tool: str, project_path: Path) -> str | None:
+    # Best-effort only. If ambiguous, the caller should ask the user and/or run list-sessions.
+    if tool == "codex":
+        codex_home = Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))
+        sessions_root = codex_home / "sessions"
+        if not sessions_root.exists():
+            return None
+        newest: tuple[dt.datetime, str] | None = None
+        for session_file in sessions_root.rglob("*.jsonl"):
+            try:
+                with session_file.open("r", encoding="utf-8", errors="replace") as handle:
+                    first = json.loads(handle.readline() or "{}")
+                if first.get("type") != "session_meta":
+                    continue
+                payload = first.get("payload") or {}
+                cwd = str(payload.get("cwd") or "")
+                if not cwd:
+                    continue
+                try:
+                    cwd_path = Path(cwd).expanduser().resolve()
+                except Exception:
+                    continue
+                try:
+                    cwd_path.relative_to(project_path)
+                except Exception:
+                    if cwd_path != project_path:
+                        continue
+                session_id = str(payload.get("id") or "")
+                if not session_id:
+                    continue
+                mtime = dt.datetime.fromtimestamp(session_file.stat().st_mtime, tz=dt.timezone.utc)
+                if newest is None or mtime > newest[0]:
+                    newest = (mtime, session_id)
+            except Exception:
+                continue
+        return newest[1] if newest else None
+
+    if tool == "claude":
+        claude_home = Path(os.environ.get("CLAUDE_HOME") or (Path.home() / ".claude"))
+        projects_root = claude_home / "projects"
+        if not projects_root.exists():
+            return None
+        newest: tuple[dt.datetime, str] | None = None
+        for transcript in projects_root.rglob("*.jsonl"):
+            try:
+                with transcript.open("r", encoding="utf-8", errors="replace") as handle:
+                    first = json.loads(handle.readline() or "{}")
+                session_id = str(first.get("sessionId") or "")
+                cwd = str(first.get("cwd") or "")
+                if not session_id or not cwd:
+                    continue
+                try:
+                    cwd_path = Path(cwd).expanduser().resolve()
+                except Exception:
+                    continue
+                try:
+                    cwd_path.relative_to(project_path)
+                except Exception:
+                    if cwd_path != project_path:
+                        continue
+                mtime = dt.datetime.fromtimestamp(transcript.stat().st_mtime, tz=dt.timezone.utc)
+                if newest is None or mtime > newest[0]:
+                    newest = (mtime, session_id)
+            except Exception:
+                continue
+        return newest[1] if newest else None
+
+    return None
+
+
+def _entry_present(body: str, key: SessionKey) -> bool:
+    for match in ENTRY_META_RE.finditer(body):
+        try:
+            meta = json.loads(match.group(1))
+        except Exception:
+            continue
+        if str(meta.get("tool") or "").strip() != key.tool:
+            continue
+        if str(meta.get("session_id") or "").strip() != key.session_id:
+            continue
+        return True
+    return False
+
+
+def _fetch_comment_body(repo: str, comment_id: int) -> dict[str, Any]:
+    return _gh_api_json(repo, f"repos/{repo}/issues/comments/{comment_id}")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Upsert the single 'SESSION REVIEW NOTES' PR comment (create-or-update) with deterministic merging."
+    )
+    parser.add_argument("--repo", help="owner/repo. Optional if running in a git repo with gh context.")
+    parser.add_argument(
+        "--pr",
+        default="auto",
+        help='PR number, PR URL, or "auto" (default: auto).',
+    )
+    parser.add_argument(
+        "--payload",
+        required=True,
+        help="Path to JSON payload produced by the LLM (use '-' to read from stdin).",
+    )
+    parser.add_argument(
+        "--tool",
+        choices=["codex", "claude", "unknown"],
+        default="unknown",
+        help="Tool label for the current session entry (default: unknown).",
+    )
+    parser.add_argument(
+        "--session-id",
+        default="auto",
+        help='Session ID for this entry, or "auto" to guess, or an explicit ID.',
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Render the comment body to stdout, but do not create/update on GitHub.",
+    )
+    args = parser.parse_args(argv)
+
+    generator = "session-review-notes"
+    generator_version = _detect_generator_version()
+
+    repo_from_pr, _ = _parse_pr_arg(args.pr)
+    repo = args.repo or repo_from_pr or _resolve_repo_fallback()
+    pr_number = _resolve_pr_number(repo, args.pr)
+
+    pr = _gh_api_json(repo, f"repos/{repo}/pulls/{pr_number}")
+    pr_url = str(pr.get("html_url") or "")
+    allowed_hosts: set[str] = {"github.com"}
+    pr_host = urlparse(pr_url).netloc.lower()
+    if pr_host:
+        allowed_hosts.add(pr_host)
+
+    head_sha = str((pr.get("head") or {}).get("sha") or "")
+    if not head_sha:
+        raise SystemExit("Unable to resolve PR head SHA from GitHub API.")
+
+    pr_files = _fetch_pr_files(repo, pr_number)
+    hotspot_map = _render_hotspot_map(pr_files)
+
+    if args.payload == "-":
+        payload_text = sys.stdin.read()
+        if not payload_text.strip():
+            raise SystemExit("No JSON payload provided on stdin.")
+        payload_raw = json.loads(payload_text)
+    else:
+        payload_raw = json.loads(Path(args.payload).read_text(encoding="utf-8"))
+
+    payload = _redact_obj(_normalize_payload(payload_raw), allowed_hosts)
+
+    project_path = Path(os.getcwd()).resolve()
+    session_id = args.session_id
+    if session_id == "auto":
+        guessed = _guess_session_id(args.tool, project_path)
+        session_id = guessed or "unknown"
+
+    now = dt.datetime.now().astimezone()
+    entry_created_at = _parse_iso8601(payload.get("entry_created_at")) or now
+    new_key = SessionKey(tool=args.tool, session_id=session_id)
+
+    entry_meta = {
+        "tool": args.tool,
+        "session_id": session_id,
+        "created_at": entry_created_at.isoformat(),
+    }
+    session_label = str(payload.get("session_label") or "session update")
+    stamp = entry_created_at.astimezone().strftime("%Y-%m-%d %H:%M %Z").strip()
+
+    human_steering = payload.get("human_steering") or []
+    decisions = payload.get("decisions") or []
+    tests_markdown = str(payload.get("tests_markdown") or "")
+    delta_narrative = str(payload.get("delta_narrative") or "- (see delta section above)")
+    notes = str(payload.get("notes") or "-")
+
+    tests_section = _render_tests_section(tests_markdown)
+    if not payload.get("tests_summary"):
+        self_reported, not_run = _parse_tests_markdown(tests_markdown)
+        if self_reported:
+            sample = ", ".join([f"`{t}`" for t in self_reported[:3]])
+            suffix = "…" if len(self_reported) > 3 else ""
+            extra = f"; Not run: {len(not_run)}" if not_run else ""
+            payload["tests_summary"] = _truncate(f"{sample}{suffix}{extra}", MAX_TEXT_CHARS)
+
+    new_entry = f"""{ENTRY_META_PREFIX}{json.dumps(entry_meta, separators=(',',':'))} -->
+<details>
+<summary><strong>{stamp}</strong> • {args.tool} • {session_label}</summary>
+
+**Human steering**
+{_render_bullets(human_steering)}
+
+**Delta**
+{delta_narrative}
+
+**Key decisions**
+{_render_bullets(decisions)}
+
+**Tests (this session)**
+{tests_section}
+
+**Notes**
+{notes}
+
+</details>
+""".strip() + "\n"
+
+    def build(existing: ExistingComment | None) -> tuple[str, int, str]:
+        repairs: list[str] = []
+        prev_state: dict[str, Any] = {}
+        prev_head: str | None = None
+        prev_rev = 0
+        prev_repair_count = 0
+        last_repair_at: str | None = None
+
+        if existing:
+            prev_state, state_repairs = _extract_state_with_repairs(existing.body)
+            repairs.extend(state_repairs)
+            entries_block_raw, session_repairs = _extract_sessions_block_with_repairs(existing.body)
+            repairs.extend(session_repairs)
+            prev_head = str(prev_state.get("head") or "") or None
+            prev_rev = int(_parse_int(prev_state.get("rev")) or 0)
+            prev_repair_count = int(_parse_int(prev_state.get("repair_count")) or 0)
+            lr = prev_state.get("last_repair_at")
+            if isinstance(lr, str) and lr.strip():
+                last_repair_at = lr.strip()
+        else:
+            entries_block_raw = ""
+
+        delta_summary, delta_details = _compute_delta(repo, prev_head, head_sha)
+        delta_empty = bool(prev_head and prev_head == head_sha)
+
+        entry_existed = any(e.key == new_key for e in _parse_entries(entries_block_raw))
+        merged_entries_block = _merge_entries(entries_block_raw, new_entry, new_key, delta_empty=delta_empty)
+        merged_entries_block = _normalize_entries_block(merged_entries_block, required_key=new_key)
+
+        scanned_total, scanned_codex, scanned_claude, scanned_included = _count_entries(merged_entries_block)
+        sessions_total = scanned_total
+        codex_count = scanned_codex
+        claude_count = scanned_claude
+
+        prev_total = _parse_int(prev_state.get("sessions_total")) if "sessions_total" in prev_state else None
+        prev_codex = _parse_int(prev_state.get("codex")) if "codex" in prev_state else None
+        prev_claude = _parse_int(prev_state.get("claude")) if "claude" in prev_state else None
+
+        if prev_total is not None:
+            sessions_total = max(prev_total + (0 if entry_existed else 1), sessions_total)
+        if prev_codex is not None:
+            codex_count = max(prev_codex + (0 if (entry_existed or args.tool != "codex") else 1), codex_count)
+        if prev_claude is not None:
+            claude_count = max(prev_claude + (0 if (entry_existed or args.tool != "claude") else 1), claude_count)
+
+        if sessions_total <= 0:
+            sessions_total = max(scanned_total, 1)
+
+        included_sessions = _merge_included_sessions(prev_state.get("included_sessions"), scanned_included)
+
+        repair_count: int | None = None
+        if existing:
+            repair_count = prev_repair_count + (1 if repairs else 0)
+            if repairs:
+                last_repair_at = now.isoformat()
+        elif repairs:
+            repair_count = 1
+            last_repair_at = now.isoformat()
+
+        rev = prev_rev + 1
+        payload["_rev"] = rev
+
+        base_ref = str((pr.get("base") or {}).get("ref") or "")
+        head_short = head_sha[:7]
+        provenance_lines: list[str] = [
+            f"- PR scope: GitHub diff `{base_ref}...{head_short}`",
+        ]
+        if prev_head:
+            provenance_lines.append(f"- Delta: compare `{prev_head[:7]}...{head_short}`")
+        else:
+            provenance_lines.append("- Delta: n/a (first entry)")
+        provenance_lines.append(f"- Generator: `{generator}` schema={SCHEMA_VERSION} rev={rev}")
+        if generator_version:
+            provenance_lines.append(f"- Generator version: `{generator_version}`")
+        if existing and len(existing.marker_comment_ids) > 1:
+            provenance_lines.append(
+                f"- Duplicate marker comments: `{len(existing.marker_comment_ids)}` (updating most recent)."
+            )
+        if repairs:
+            provenance_lines.append("- Repairs:")
+            provenance_lines.extend([f"  - {r}" for r in repairs])
+
+        final_entries_block = merged_entries_block
+        truncated_notes: list[str] = []
+
+        def render(entries_block: str) -> tuple[str, str]:
+            sessions_sha = _sha256(entries_block.strip())
+            body = _render_comment(
+                pr=pr,
+                payload=payload,
+                prev_head=prev_head,
+                head_sha=head_sha,
+                entries_block=entries_block,
+                delta_summary=delta_summary,
+                delta_details=delta_details,
+                hotspot_map=hotspot_map,
+                provenance="\n".join(provenance_lines + truncated_notes) if provenance_lines else "-",
+                now=now,
+                sessions_total=sessions_total,
+                codex_count=codex_count,
+                claude_count=claude_count,
+                included_sessions=included_sessions,
+                sessions_sha256=sessions_sha,
+                repair_count=repair_count,
+                last_repair_at=last_repair_at,
+                generator=generator,
+                generator_version=generator_version,
+            )
+            return _redact(body, allowed_hosts), sessions_sha
+
+        comment_body, sessions_sha256 = render(final_entries_block)
+        if len(comment_body) > MAX_BODY_CHARS and payload.get("prompts"):
+            payload["prompts"] = ""
+            truncated_notes.append("- Prompts omitted to fit GitHub comment size limits.")
+            comment_body, sessions_sha256 = render(final_entries_block)
+
+        if len(comment_body) > MAX_BODY_CHARS:
+            entries = _sort_entries(_parse_entries(final_entries_block))
+            max_entries = len([e for e in entries if e.key]) + len([e for e in entries if not e.key])
+            for keep in range(max_entries, 0, -1):
+                candidate_block = _normalize_entries_block(
+                    final_entries_block, required_key=new_key, max_entries=keep
+                )
+                candidate_body, candidate_sha = render(candidate_block)
+                if len(candidate_body) <= MAX_BODY_CHARS:
+                    if keep < max_entries:
+                        truncated_notes.append(
+                            f"- Session log truncated to last `{keep}` entries to fit GitHub comment size limits."
+                        )
+                        final_entries_block = candidate_block
+                        comment_body, sessions_sha256 = render(final_entries_block)
+                    break
+
+        if len(comment_body) > MAX_BODY_CHARS:
+            raise SystemExit(
+                f"Generated comment is too large ({len(comment_body)} chars). Reduce payload verbosity and retry."
+            )
+
+        return comment_body, rev, sessions_sha256
+
+    if args.dry_run:
+        existing = _find_existing_comment(repo, pr_number)
+        comment_body, _, _ = build(existing)
+        print(comment_body)
+        return 0
+
+    for _ in range(3):
+        existing = _find_existing_comment(repo, pr_number)
+        comment_body, expected_rev, expected_sha = build(existing)
+
+        with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8") as tmp:
+            tmp.write(comment_body)
+            tmp_path = tmp.name
+
+        try:
+            if existing:
+                updated = _gh_json(
+                    repo,
+                    [
+                        "api",
+                        "-X",
+                        "PATCH",
+                        f"repos/{repo}/issues/comments/{existing.comment_id}",
+                        "-F",
+                        f"body=@{tmp_path}",
+                    ],
+                )
+                comment_id = int(updated.get("id") or existing.comment_id)
+            else:
+                created = _gh_json(
+                    repo,
+                    [
+                        "api",
+                        "-X",
+                        "POST",
+                        f"repos/{repo}/issues/{pr_number}/comments",
+                        "-F",
+                        f"body=@{tmp_path}",
+                    ],
+                )
+                comment_id = int(created.get("id"))
+
+            fetched = _fetch_comment_body(repo, comment_id)
+            fetched_body = str(fetched.get("body") or "")
+            state, _ = _extract_state_with_repairs(fetched_body)
+            fetched_rev = _parse_int(state.get("rev"))
+            fetched_sha = str(state.get("sessions_sha256") or "")
+
+            if fetched_rev == expected_rev and fetched_sha == expected_sha and _entry_present(fetched_body, new_key):
+                print(fetched.get("html_url") or "updated")
+                return 0
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except Exception:
+                pass
+
+    raise SystemExit("Failed to update PR comment after merge/verify retries.")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(list(sys.argv[1:])))


### PR DESCRIPTION
## Summary

This PR adds a new **session-review-notes** plugin that creates and maintains a single, auto-updating PR comment serving as an AI session ledger across Codex + Claude Code sessions.

### Key Features

| Feature | Description |
|---------|-------------|
| **Hybrid Architecture** | LLM writes narrative payload JSON; deterministic script owns invariants (markers, merging, redaction, GitHub upsert) |
| **Single-Comment Idempotency** | Hidden marker ensures exactly one session ledger comment per PR |
| **Multi-Session Support** | Cumulative session log tracks human steering across multiple Codex/Claude sessions |
| **Cross-Tool Compatibility** | Works with both OpenAI Codex and Claude Code via unified scripts |
| **Comprehensive Redaction** | Automatically strips secrets, tokens, API keys, JWTs, and internal URLs |

---

## Architecture

```
┌─────────────────────────────────────────────────────────────────────────┐
│                        session-review-notes                              │
├─────────────────────────────────────────────────────────────────────────┤
│                                                                          │
│   ┌──────────────────┐          ┌───────────────────────────────────┐   │
│   │   LLM (Agent)    │          │   Deterministic Script            │   │
│   │                  │          │   (upsert-pr-comment.py)          │   │
│   │ • Intent         │ payload  │                                   │   │
│   │ • Human steering │ ──JSON──►│ • Marker-based idempotency        │   │
│   │ • Decisions      │          │ • Session entry merging/dedup     │   │
│   │ • Tests run      │          │ • PR facts via GitHub API         │   │
│   │ • Hotspots       │          │ • Delta computation (compare)     │   │
│   └──────────────────┘          │ • Secret redaction                │   │
│                                 │ • GitHub comment upsert           │   │
│                                 └───────────────────────────────────┘   │
│                                              │                           │
│                                              ▼                           │
│                                 ┌───────────────────────┐               │
│                                 │   GitHub PR Comment   │               │
│                                 │   (single, upserted)  │               │
│                                 └───────────────────────┘               │
└─────────────────────────────────────────────────────────────────────────┘
```

### Why Hybrid?

The hybrid architecture permanently eliminates common LLM failure modes:

| Failure Mode | How Script Prevents It |
|--------------|------------------------|
| Marker deletion | Script owns all markers; LLM never touches them |
| Duplicate comments | Marker search + update-only logic |
| Overwritten session log | Merge strategy preserves prior entries |
| Implied tests | Script treats `[x]` as "self-reported" unless evidence |
| Secret leakage | Regex redaction on all output |

---

## PR Comment Structure

The generated comment serves as a mini-database with:

1. **Hidden state marker** – JSON with schema version, base/head SHAs, session counts
2. **Summary table** – Intent, PR coverage, size, sessions, delta, risk, tests
3. **Collapsible sections** – What changed, hotspot map, review risks, delta, provenance
4. **Cumulative session log** – Per-session entries with human steering + decisions + tests

```markdown
<!-- diversio:session-review-notes -->
<!-- diversio:session-review-notes:state {"schema":2,"base":"main",...} -->

## SESSION REVIEW NOTES
> [!IMPORTANT]
> This comment is **updated**, not duplicated.

### Summary
| Field | Value |
| Intent | ... |
| PR coverage | `main...abc1234` |
| Sessions | `3` (Codex×1, Claude×2) |
...

<details><summary>Session log (cumulative)</summary>
<!-- diversio:session-review-notes:sessions:start -->
...entries...
<!-- diversio:session-review-notes:sessions:end -->
</details>
```

---

## Commands

| Command | Description |
|---------|-------------|
| `/session-review-notes:generate` | Generate/update the PR session ledger comment |
| `/session-review-notes:list-sessions` | List recent Codex + Claude sessions for backfilling |

---

## Files Changed

<details>
<summary>Plugin configuration (3 files)</summary>

- `.claude-plugin/marketplace.json` – Adds plugin entry to marketplace
- `plugins/session-review-notes/.claude-plugin/plugin.json` – Plugin manifest
- `AGENTS.md` – Documents new plugin in repo instructions

</details>

<details>
<summary>Skill definition (2 files)</summary>

- `plugins/session-review-notes/skills/session-review-notes/SKILL.md` – Full skill specification
- `plugins/session-review-notes/skills/session-review-notes/references/transcripts.md` – Codex/Claude transcript location docs

</details>

<details>
<summary>Commands (2 files)</summary>

- `plugins/session-review-notes/commands/generate.md` – Slash command for generating notes
- `plugins/session-review-notes/commands/list-sessions.md` – Slash command for session picker

</details>

<details>
<summary>Scripts (2 files)</summary>

- `plugins/session-review-notes/skills/session-review-notes/scripts/upsert-pr-comment.py` – Deterministic upsert script (1287 lines)
- `plugins/session-review-notes/skills/session-review-notes/scripts/list-sessions.py` – Session discovery script (460 lines)

</details>

<details>
<summary>Documentation (2 files)</summary>

- `plugins/session-review-notes/HANDOFF.md` – Design rationale and implementation notes
- `README.md` – Updated with new plugin

</details>

---

## How to Test

### Install the plugin

```bash
/plugin install session-review-notes@diversiotech
```

### Generate session notes (dry-run)

```bash
python3 plugins/session-review-notes/skills/session-review-notes/scripts/upsert-pr-comment.py \
  --tool claude --session-id auto --pr auto --dry-run \
  --payload <(echo '{"intent":"Test run","risk":"Low","session_label":"test"}')
```

### List sessions

```bash
python3 plugins/session-review-notes/skills/session-review-notes/scripts/list-sessions.py \
  --project "$PWD" --limit 10
```

### Manual Testing

1. Create a test PR in any repo
2. Run `/session-review-notes:generate`
3. Verify single comment created with correct structure
4. Run again → verify comment **updated** (not duplicated)
5. Run `/session-review-notes:list-sessions` → verify session table renders

---

## Notes

- **No breaking changes**: New plugin, additive only
- **Python 3.10+**: Scripts use `|` union syntax in type hints
- **Requires `gh` CLI**: For GitHub API interactions
- **Version**: Starting at `0.1.9` (internal iterations)

---

🤖 Generated with [Claude Code](https://claude.ai/code)