### PR TITLE
CI: validate marketplace and plugin manifests

### DIFF
--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -1,0 +1,92 @@
+name: Validate Marketplace
+
+on:
+  pull_request:
+    paths:
+      - ".claude-plugin/**"
+      - "plugins/**"
+      - ".github/workflows/validate-marketplace.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".claude-plugin/**"
+      - "plugins/**"
+      - ".github/workflows/validate-marketplace.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate JSON and plugin consistency
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Validating marketplace.json is valid JSON..."
+          jq -e . .claude-plugin/marketplace.json >/dev/null
+
+          echo "Validating plugin list has unique names..."
+          DUPLICATE_NAMES="$(jq -r '.plugins[].name' .claude-plugin/marketplace.json | sort | uniq -d || true)"
+          if [[ -n "${DUPLICATE_NAMES}" ]]; then
+            echo "Duplicate plugin names in .claude-plugin/marketplace.json:"
+            echo "${DUPLICATE_NAMES}"
+            exit 1
+          fi
+
+          MARKETPLACE_PLUGINS="$(jq -r '.plugins[].name' .claude-plugin/marketplace.json | sort -u)"
+          PLUGIN_DIRS="$(ls -1 plugins | sort -u)"
+
+          echo "Validating marketplace entries match plugin directories..."
+          EXTRA_DIRS="$(comm -23 <(echo "${PLUGIN_DIRS}") <(echo "${MARKETPLACE_PLUGINS}") || true)"
+          if [[ -n "${EXTRA_DIRS}" ]]; then
+            echo "Plugin directories missing from .claude-plugin/marketplace.json:"
+            echo "${EXTRA_DIRS}"
+            exit 1
+          fi
+
+          echo "Validating each marketplace plugin entry..."
+          for NAME in ${MARKETPLACE_PLUGINS}; do
+            if [[ ! -d "plugins/${NAME}" ]]; then
+              echo "Missing plugin directory: plugins/${NAME}"
+              exit 1
+            fi
+
+            SOURCE="$(jq -r --arg name "${NAME}" '.plugins[] | select(.name == $name) | .source' .claude-plugin/marketplace.json)"
+            if [[ "${SOURCE}" != "./plugins/${NAME}" ]]; then
+              echo "Marketplace source mismatch for ${NAME}: expected ./plugins/${NAME}, got ${SOURCE}"
+              exit 1
+            fi
+
+            PLUGIN_JSON="plugins/${NAME}/.claude-plugin/plugin.json"
+            if [[ ! -f "${PLUGIN_JSON}" ]]; then
+              echo "Missing plugin manifest: ${PLUGIN_JSON}"
+              exit 1
+            fi
+
+            jq -e . "${PLUGIN_JSON}" >/dev/null
+
+            PLUGIN_NAME="$(jq -r '.name' "${PLUGIN_JSON}")"
+            if [[ "${PLUGIN_NAME}" != "${NAME}" ]]; then
+              echo "plugin.json name mismatch for ${NAME}: got ${PLUGIN_NAME}"
+              exit 1
+            fi
+
+            PLUGIN_VERSION="$(jq -r '.version' "${PLUGIN_JSON}")"
+            MARKETPLACE_VERSION="$(jq -r --arg name "${NAME}" '.plugins[] | select(.name == $name) | .version' .claude-plugin/marketplace.json)"
+            if [[ "${PLUGIN_VERSION}" != "${MARKETPLACE_VERSION}" ]]; then
+              echo "Version mismatch for ${NAME}: plugin.json=${PLUGIN_VERSION} marketplace=${MARKETPLACE_VERSION}"
+              exit 1
+            fi
+
+            SKILL_COUNT="$(find "plugins/${NAME}/skills" -type f -name 'SKILL.md' | wc -l | tr -d ' ')"
+            if [[ "${SKILL_COUNT}" -eq 0 ]]; then
+              echo "No SKILL.md found under plugins/${NAME}/skills"
+              exit 1
+            fi
+          done
+
+          echo "All marketplace validation checks passed."
+


### PR DESCRIPTION
## Summary

Adds a lightweight GitHub Actions gate that validates our marketplace metadata so broken JSON, missing manifests, or version mismatches can’t merge.

### Key Features

| Feature | Description |
|---------|-------------|
| **Marketplace consistency** | Ensures `.claude-plugin/marketplace.json` matches `plugins/*` directories and each `plugins/*/.claude-plugin/plugin.json` `name`/`version` |
| **Skill presence** | Ensures every plugin has at least one `SKILL.md` under `plugins/<plugin>/skills/` |

## CI Flow

```
PR/Push (plugins/, .claude-plugin/)
        │
        v
Validate Marketplace (GitHub Actions)
        │
        ├─ jq: JSON validity
        ├─ uniqueness: plugin names
        ├─ parity: marketplace ↔ plugins/ directories
        ├─ per-plugin: plugin.json exists + name/version match
        └─ skills: at least one SKILL.md
```

---

## Validation: Marketplace + plugin manifests

What it does:
- Verifies `.claude-plugin/marketplace.json` is valid JSON.
- Verifies plugin names are unique.
- Verifies every marketplace entry points to an existing `plugins/<name>` directory (and that there are no “orphan” plugin dirs).
- Verifies each `plugins/<name>/.claude-plugin/plugin.json` exists, is valid JSON, and matches the marketplace `name` + `version`.
- Verifies each plugin includes at least one `SKILL.md`.

Why this approach:
- Uses only built-in tooling (`bash` + `jq`) so CI stays fast and dependency-light.
- Catches the most common marketplace breakages at PR time.

## Files Changed

<details>
<summary>GitHub Actions (click to expand)</summary>

- `.github/workflows/validate-marketplace.yml` - validates marketplace + plugin manifests on PR/push

</details>

## How to Test

This is exercised automatically in GitHub Actions on PRs.

Optional local spot-check:

```bash
jq -e . .claude-plugin/marketplace.json
```

## Notes

- No changes to skill content or plugin behavior.
- No secrets added.
