### PR TITLE
868hdmdr1: standardize typing-gate policy across skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "monty-code-review",
       "description": "Hyper-pedantic Django4Lyfe backend code review Skill (Monty's taste).",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "Diversio Devs"
       },
@@ -32,7 +32,7 @@
     {
       "name": "backend-pr-workflow",
       "description": "Enforces Diversio backend ClickUp-linked PR workflow, branch naming, safe Django migrations, and downtime-safe schema changes.",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "author": {
         "name": "Diversio Devs"
       },
@@ -43,7 +43,7 @@
     {
       "name": "backend-atomic-commit",
       "description": "Pedantic backend pre-commit and atomic-commit Skill with an iterative convergence protocol (budgets + stuck detection), enforcing AGENTS.md, pre-commit hooks (including djlint), .security/* helpers, and Monty's backend taste without AI commit signatures.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "Diversio Devs"
       },
@@ -54,7 +54,7 @@
     {
       "name": "bruno-api",
       "description": "Comprehensive API documentation generator from Bruno (.bru) files that maps endpoints to Django4Lyfe implementations (DRF/Django Ninja).",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "author": {
         "name": "Diversio Devs"
       },
@@ -65,7 +65,7 @@
     {
       "name": "plan-directory",
       "description": "Create and maintain structured plan directories with a master PLAN.md index and numbered task files (001-*.md) containing checklists, tests, and completion criteria. Includes backend-ralph-plan for RALPH loop execution.",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "author": {
         "name": "Diversio Devs"
       },
@@ -87,7 +87,7 @@
     {
       "name": "process-code-review",
       "description": "Process code review findings - interactively fix or skip issues from monty-code-review output with status tracking.",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "author": {
         "name": "Diversio Devs"
       },
@@ -98,7 +98,7 @@
     {
       "name": "mixpanel-analytics",
       "description": "MixPanel analytics tracking implementation and review Skill for Django4Lyfe optimo_analytics module with PII protection and pattern enforcement.",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "author": {
         "name": "Diversio Devs"
       },
@@ -120,7 +120,7 @@
     {
       "name": "repo-docs",
       "description": "Generate and canonicalize repository documentation with quality-gate awareness. Create new docs or audit existing AGENTS.md/CLAUDE.md to enforce single-source-of-truth pattern.",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "author": {
         "name": "Diversio Devs"
       },
@@ -131,7 +131,7 @@
     {
       "name": "backend-release",
       "description": "Manages the full release workflow for Django4Lyfe backend - creating release PRs, version bumping (YYYY.MM.DD), conflict resolution, and GitHub releases.",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "author": {
         "name": "Diversio Devs"
       },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,14 +134,32 @@ When working in this repo, Claude Code should:
      ---
      ```
 
-4. **Follow existing naming and structure.**
+4. **Treat Python typing as a strict quality gate in code-touching skills.**
+   - Skills that edit or review Python code must define type-gate detection and
+     enforcement explicitly.
+   - Detection precedence should be:
+     - `ty` first, then `pyright`, then `mypy` (unless target repo docs/CI say
+       otherwise).
+   - If `ty` is configured in the target repo (`[tool.ty]`, `ty.toml`,
+     `.bin/ty`, or CI/pre-commit usage), treat it as mandatory and blocking.
+   - Do not document or encourage "baseline acceptable" behavior for touched
+     files.
+   - Prefer narrow, justified suppressions only when no better typing solution
+     exists; do not default to blanket `# noqa` or broad type-ignore patterns.
+   - Canonical marketplace policy reference:
+     - `docs/python-typing-and-ty-best-practices.md`
+   - In target codebases, also read local policy docs when present (for example
+     `docs/python-typing-3.14-best-practices.md`, `TY_MIGRATION_GUIDE.md`,
+     `AGENTS.md`).
+
+5. **Follow existing naming and structure.**
    - New plugins should mirror the structure of `monty-code-review`:
      - `plugins/<plugin>/`
        - `.claude-plugin/plugin.json`
        - `skills/<skill-name>/SKILL.md`
    - Use `kebab-case` for plugin folder names where possible.
 
-5. **Do not modify application behavior here.**
+6. **Do not modify application behavior here.**
    - This repo should not contain Django/React/Terraform or other app logic.
    - If a plugin needs to describe behavior in another repo, document it here but
      change the actual code in that other repo.

--- a/docs/python-typing-and-ty-best-practices.md
+++ b/docs/python-typing-and-ty-best-practices.md
@@ -1,0 +1,169 @@
+# Python Typing + `ty` Best Practices (Skill Authoring Baseline)
+
+Last reviewed: 2026-02-07
+
+This document defines a project-agnostic typing policy for skills in this
+marketplace that read, modify, or review Python code.
+
+## Why This Exists
+
+Skills were previously inconsistent about type gates (for example, allowing
+"baseline acceptable" checks in one skill while another treated type failures
+as blocking). This creates drift and repeated regressions.
+
+The policy below standardizes behavior so every code-touching skill:
+
+- Detects the repository's active type checker correctly.
+- Treats that checker as a strict quality gate.
+- Avoids "shortcut" suppressions (`noqa`/broad ignores) as a default workflow.
+- Stays portable across projects and ecosystems.
+
+## Non-Negotiable Rules
+
+1. If a repository has `ty` configured, `ty` is mandatory and blocking.
+2. "Baseline acceptable" is not allowed for files touched by the current change.
+3. No blanket suppressions as a quick escape hatch.
+4. Scoped checks are fine for iteration speed, but final merge/release gates must
+   satisfy the repository's required checker(s).
+5. Skills must prefer local repository policy documents when present.
+
+## Type Gate Detection (Project-Agnostic)
+
+Use this precedence order for Python repositories:
+
+1. `ty` (preferred when configured)
+2. `pyright`
+3. `mypy`
+
+### How To Detect
+
+Treat `ty` as active if any of these exist:
+
+- `pyproject.toml` with `[tool.ty]`
+- `ty.toml`
+- `.bin/ty`
+- CI/pre-commit invokes `ty`
+
+Treat `pyright` as active if any of these exist:
+
+- `pyrightconfig.json`
+- `[tool.pyright]` in `pyproject.toml`
+- CI/pre-commit invokes `pyright`
+
+Treat `mypy` as active if any of these exist:
+
+- `mypy.ini`
+- `.mypy.ini`
+- `[tool.mypy]` in `pyproject.toml`
+- CI/pre-commit invokes `mypy`
+
+If multiple are present, follow repository docs/CI order. If that is unclear,
+prefer `ty` > `pyright` > `mypy`.
+
+## Recommended Command Resolution
+
+Prefer repository wrappers first, then tool runners:
+
+1. `.bin/<tool>`
+2. `uv run <tool>`
+3. `<tool>` directly
+
+Examples:
+
+```bash
+# ty
+.bin/ty check <paths>
+uv run ty check <paths>
+ty check <paths>
+
+# pyright
+.bin/pyright <paths>
+uv run pyright <paths>
+pyright <paths>
+
+# mypy
+.bin/mypy <paths>
+uv run mypy <paths>
+mypy <paths>
+```
+
+## Strictness Policy
+
+For touched files:
+
+- Zero type diagnostics is the target.
+- Do not leave known type errors in files edited by the change.
+- Do not convert concrete types to `Any` to silence errors.
+
+For repository-level gates:
+
+- If CI/pre-commit enforces repo-wide type checks, mirror that before merge.
+- If local execution is constrained, explicitly report which gate could not run.
+
+## Python 3.14+ Typing Guidance
+
+These guidelines are aligned with current Python docs and typing spec:
+
+1. Prefer modern syntax:
+   - `list[str]`, `dict[str, int]`, `str | None`.
+2. Use `TypedDict`, `Protocol`, dataclasses, and well-typed objects over
+   `dict[str, Any]` and shape-shifting payloads.
+3. Keep `Any` explicit and narrowly justified.
+4. Use runtime narrowing (`isinstance`, explicit `None` guards, small helper
+   functions returning `NoReturn`) before reaching for `cast`.
+5. Use `cast` as a last resort, with a short comment explaining why narrowing
+   cannot be expressed more directly.
+6. Keep type aliases explicit and reusable for repeated structural contracts.
+7. Prefer precise return types for public functions and boundary-layer helpers.
+8. Avoid annotation patterns that depend on fragile runtime behavior.
+
+## Django-Oriented Typing Guidance
+
+1. Prefer helper functions for request/user narrowing over repeated ad-hoc casts.
+2. Guard `None` results from queryset lookups explicitly before attribute access.
+3. Keep dynamic framework attributes wrapped behind typed helpers/protocols.
+4. Avoid broad exception swallowing that hides type and control-flow bugs.
+5. Keep model/query contracts explicit at the call boundary (querysets, serializers,
+   services).
+
+## `ty`-Specific Guidance
+
+1. Enable strict warning behavior when repository policy expects it:
+   - `[tool.ty] error-on-warning = true`
+2. Keep ignores narrow and code-specific.
+3. Prefer fixing root type issues over adding ignore comments.
+4. In code review, treat new suppressions as design debt unless justified.
+
+## Skill Authoring Requirements
+
+Any skill that edits or reviews Python must:
+
+1. Include a "Type Gate Detection" section with the precedence policy above.
+2. State that touched files must pass the active type gate.
+3. Avoid wording like "baseline acceptable."
+4. Reference local repo typing docs when present, especially:
+   - `docs/python-typing-3.14-best-practices.md`
+   - `TY_MIGRATION_GUIDE.md`
+   - `AGENTS.md` / `CLAUDE.md`
+5. Report unresolved type-gate blockers explicitly with file-level detail.
+
+## References (Primary Sources)
+
+- Python typing docs:
+  - https://docs.python.org/3/library/typing.html
+- Python "What's New in 3.14" (annotation behavior changes):
+  - https://docs.python.org/3/whatsnew/3.14.html
+- Typing specification:
+  - https://typing.python.org/
+- Typing best practices:
+  - https://typing.python.org/en/latest/reference/best_practices.html
+- Typing annotations HOWTO:
+  - https://docs.python.org/3/howto/annotations.html
+- Astral `ty` docs:
+  - https://docs.astral.sh/ty/
+- Agent Skills open specification:
+  - https://agentskills.io/specification/
+- OpenAI Codex Skills docs:
+  - https://developers.openai.com/codex/skills/
+- Anthropic Claude skills docs:
+  - https://docs.anthropic.com/en/docs/claude-code/tutorials/use-skills

--- a/plugins/backend-atomic-commit/.claude-plugin/plugin.json
+++ b/plugins/backend-atomic-commit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-atomic-commit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Pedantic backend pre-commit and atomic-commit Skill for Django/Optimo-style repos, enforcing local AGENTS.md, pre-commit hooks (including djlint), and Monty’s backend taste with an explicit fix-retry convergence protocol.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/backend-atomic-commit/commands/atomic-commit.md
+++ b/plugins/backend-atomic-commit/commands/atomic-commit.md
@@ -12,7 +12,7 @@ Do everything the `/backend-atomic-commit:pre-commit` command would do, plus:
   - `.security/ruff_pr_diff.sh`
   - `.security/local_imports_pr_diff.sh`
   - Ruff lint + format
-  - ty / type checks
+  - Active type gate checks (`ty` if configured; else `pyright`; else `mypy`)
   - Django system checks
   - Relevant pytest subsets
   - Pre-commit hooks

--- a/plugins/backend-atomic-commit/commands/commit.md
+++ b/plugins/backend-atomic-commit/commands/commit.md
@@ -14,8 +14,9 @@ Workflow:
    staged, do **not** guess: either stage what the user explicitly intends, or ask
    them to stage/select files first (atomic commits must stay atomic).
 2. Run the full `atomic-commit` convergence loop (pre-commit hooks, `.security/*`,
-   Ruff, ty, Django checks, relevant pytest subsets), fixing and re-running until
-   everything is green and hooks stop rewriting files.
+   Ruff, active type gate checks (`ty`/`pyright`/`mypy`), Django checks,
+   relevant pytest subsets), fixing and re-running until everything is green and
+   hooks stop rewriting files.
    - Apply the Skill’s explicit iteration budgets + stuck protocol (3 attempts per
      failing gate, 10 total pipeline passes). If a gate is stuck, stop and report
      it as `[BLOCKING]` with the exact error + what was tried.

--- a/plugins/backend-atomic-commit/commands/pre-commit.md
+++ b/plugins/backend-atomic-commit/commands/pre-commit.md
@@ -12,8 +12,9 @@ Focus on:
   type-hint problems.
 - Running the following checks in order:
   1. `.bin/ruff check --fix` and `.bin/ruff format` on modified Python files.
-  2. `.bin/ty check` on **modified Python files only** to catch type errors
-     before CI (avoids baseline errors in unmodified code).
+  2. Active type gate (`ty` if configured; else `pyright`; else `mypy`) on
+     **modified Python files only** during iteration, then any repo-required
+     wider type gate before final readiness.
   3. `python manage.py check --fail-level WARNING` for Django system checks.
   4. Any pre-commit hooks defined in `.pre-commit-config.yaml`.
 - Treat the above as a **convergence loop** (not one pass): if a check fails or
@@ -22,9 +23,10 @@ Focus on:
   passes**. If a check still fails after 3 real fix attempts, report it as
   `[BLOCKING]` and move on to other issues.
 - Do **not** use TodoWrite to track gate results — report directly in output.
-- **IMPORTANT**: For any file you touch, resolve **ALL** ruff and ty errors in
-  that file—not just the ones you introduced. CI will fail on pre-existing
-  errors in modified files. Do not dismiss errors as "pre-existing".
+- **IMPORTANT**: For any file you touch, resolve **ALL** ruff and active
+  type-check errors in that file—not just the ones you introduced. CI will fail
+  on pre-existing errors in modified files. Do not dismiss errors as
+  "pre-existing".
 
 Do **not** propose a commit message in this mode; just leave the working tree
 and index in the cleanest, most standards-compliant state you can, and report:

--- a/plugins/backend-pr-workflow/.claude-plugin/plugin.json
+++ b/plugins/backend-pr-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-pr-workflow",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Enforces Diversio backend ClickUp-linked PR workflow, branch naming, safe Django migrations, and downtime-safe schema changes.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md
+++ b/plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md
@@ -217,13 +217,18 @@ Prompt the author to confirm they have checked:
   - No `print()` / `ipdb` / `pdb` left behind.
 - Tests have been added or updated for new functionality.
 - Tests are passing in CI.
+- Active Python type gate is passing for touched files:
+  - Detect in this order unless repo docs/CI differ: `ty`, then `pyright`,
+    then `mypy`.
+  - If `ty` is configured, it is mandatory and blocking.
 - Pre-commit hooks and coding conventions have been applied.
 - Code coverage has not regressed significantly.
 - For Django changes: migrations have been cleaned up and regenerated if there
   were multiple schema iterations.
 
 If any of these fail obviously based on the PR description or user input, emit
-appropriate `[SHOULD_FIX]` or `[BLOCKING]` bullets.
+appropriate `[SHOULD_FIX]` or `[BLOCKING]` bullets. Type-gate failures should
+generally be `[BLOCKING]` for merge readiness.
 
 ## Checklist 4 – Releases, Hotfixes, and Tags
 

--- a/plugins/backend-release/.claude-plugin/plugin.json
+++ b/plugins/backend-release/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-release",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Manages the full release workflow for Django4Lyfe backend - creating release PRs, version bumping, conflict resolution, and GitHub releases with date-based versioning (YYYY.MM.DD).",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/backend-release/skills/release-manager/SKILL.md
+++ b/plugins/backend-release/skills/release-manager/SKILL.md
@@ -187,7 +187,15 @@ Before creating a release PR, verify:
    .bin/ruff format <file>
    ```
 
-2. **RLS policies for new models:**
+2. **Active Python type gate passes (strict):**
+   - Detect in this order unless repo docs/CI differ:
+     - `ty` (mandatory if configured)
+     - `pyright`
+     - `mypy`
+   - Run on touched paths at minimum, and run any repo-required broad gate
+     before final release readiness.
+
+3. **RLS policies for new models:**
    ```bash
    # Check status
    .bin/django optimo_bootstrap_support_shell_rls

--- a/plugins/bruno-api/.claude-plugin/plugin.json
+++ b/plugins/bruno-api/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bruno-api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Comprehensive API documentation generator from Bruno (.bru) files that maps endpoints to Django4Lyfe implementations (DRF/Django Ninja).",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/bruno-api/skills/bruno-api/SKILL.md
+++ b/plugins/bruno-api/skills/bruno-api/SKILL.md
@@ -130,6 +130,9 @@ Rules:
 - Include at least one realistic example request and success response.
 - If response shape is dynamic or large, document the stable contract and
   include a representative sample, not the entire universe of fields.
+- If you recommend follow-up code changes, mention the repo's active type gate
+  (`ty` first when configured, else `pyright`, else `mypy`) and avoid
+  recommending blanket suppressions.
 - When you’re unsure, be explicit about assumptions and mark with `[SHOULD_FIX]`.
 
 ### Step 5 — Handle `--output` and `--scan`

--- a/plugins/mixpanel-analytics/.claude-plugin/plugin.json
+++ b/plugins/mixpanel-analytics/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-analytics",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "MixPanel analytics tracking implementation and review Skills for Django4Lyfe optimo_analytics module.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/mixpanel-analytics/commands/implement.md
+++ b/plugins/mixpanel-analytics/commands/implement.md
@@ -20,6 +20,8 @@ Focus on:
 
 After implementation:
 
-- Run post-implementation validations (Ruff, ty, Django check, pytest).
+- Run post-implementation validations (Ruff, active type gate, Django check,
+  pytest). Type gate detection order: `ty` (if configured), then `pyright`,
+  then `mypy`.
 - Report what was created and any remaining issues.
 - Suggest running `/mixpanel-analytics:review` to validate the implementation.

--- a/plugins/mixpanel-analytics/commands/review.md
+++ b/plugins/mixpanel-analytics/commands/review.md
@@ -27,6 +27,7 @@ Generate a structured review report with:
 - Summary table showing pass/fail status per category.
 - Issues found with severity tags (`[P0]`, `[P1]`, `[P2]`, `[P3]`).
 - Specific file:line references and recommended fixes.
-- Quality gate status (Ruff, ty, Django check, tests).
+- Quality gate status (Ruff, active type gate, Django check, tests). Type gate
+  detection order: `ty` (if configured), then `pyright`, then `mypy`.
 
 If issues found, suggest using `/mixpanel-analytics:implement` to fix them.

--- a/plugins/mixpanel-analytics/skills/mixpanel-analytics/SKILL.md
+++ b/plugins/mixpanel-analytics/skills/mixpanel-analytics/SKILL.md
@@ -71,6 +71,14 @@ Read key reference files:
 - `optimo_analytics/service/AGENTS.md` – service layer patterns
 - `optimo_analytics/tests/AGENTS.md` – test patterns
 
+Type gate policy:
+- Detect Python type checker in this order unless repo docs/CI differ:
+  `ty`, then `pyright`, then `mypy`.
+- If `ty` is configured, it is mandatory and blocking.
+- For touched files, do not accept "baseline acceptable" type-check outcomes.
+- Read local typing policy docs when present (for example
+  `docs/python-typing-3.14-best-practices.md`, `TY_MIGRATION_GUIDE.md`).
+
 ---
 
 # Implementation Mode

--- a/plugins/mixpanel-analytics/skills/mixpanel-analytics/references/implementation.md
+++ b/plugins/mixpanel-analytics/skills/mixpanel-analytics/references/implementation.md
@@ -349,8 +349,10 @@ properties = MxpNewEventSchema(
 .bin/ruff check optimo_analytics/ --fix
 .bin/ruff format optimo_analytics/
 
-# 2. Type checking
-.bin/ty check optimo_analytics/
+# 2. Type checking (strict)
+# Prefer ty when configured; else pyright; else mypy.
+.bin/ty check optimo_analytics/          # or: .bin/pyright optimo_analytics/
+                                         # or: .bin/mypy optimo_analytics/
 
 # 3. Django checks
 DJANGO_CONFIGURATION=DevApp uv run python manage.py check
@@ -360,4 +362,3 @@ DJANGO_CONFIGURATION=DevApp uv run python manage.py check
 ```
 
 ---
-

--- a/plugins/monty-code-review/.claude-plugin/plugin.json
+++ b/plugins/monty-code-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monty-code-review",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Hyper-pedantic Django4Lyfe backend code review Skill (Monty's taste).",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/monty-code-review/skills/monty-code-review/SKILL.md
+++ b/plugins/monty-code-review/skills/monty-code-review/SKILL.md
@@ -85,6 +85,9 @@ When this skill is active and you are asked to review a change or diff, follow t
 5. Check tooling & static analysis
    - Where possible, run or mentally simulate relevant tooling (e.g., `ruff`, type
      checkers, and pre-commit hooks) for the changed files.
+   - Detect Python type checker in this order unless repo docs/CI differ:
+     - `ty`, then `pyright`, then `mypy`.
+   - If `ty` is configured in the repo, treat it as mandatory and blocking.
    - Treat any violations that indicate correctness, security, or contract issues as
      at least `[SHOULD_FIX]`, and often `[BLOCKING]`.
    - Avoid introducing new `# noqa` or similar suppressions unless there is a clear,
@@ -165,6 +168,8 @@ Use these tags consistently:
     per-row queries).
   - Missing tests for critical branches or regression scenarios.
   - Confusing control flow or naming that obscures invariants or intent.
+- Type-check debt that is not currently breaking merge gates but should be
+  reduced before follow-up work.
 - `[NIT]`
   - Docstring tone/punctuation, minor style deviations, f-string usage, import order.
   - Non-critical duplication that could be refactored later.

--- a/plugins/plan-directory/.claude-plugin/plugin.json
+++ b/plugins/plan-directory/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "plan-directory",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Create and maintain structured plan directories with a master PLAN.md index and numbered task files (001-*.md) containing checklists, tests, and completion criteria. Includes backend-ralph-plan for RALPH loop execution.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/plan-directory/commands/backend-ralph-plan.md
+++ b/plugins/plan-directory/commands/backend-ralph-plan.md
@@ -38,7 +38,7 @@ Specify your project's commands (defaults shown):
 |---------|---------|---------------------------|
 | Lint | `ruff check` | `.bin/ruff check` |
 | Format | `ruff format` | `.bin/ruff format` |
-| Types | `ty` | `.bin/ty` |
+| Types | Auto-detect (`ty` → `pyright` → `mypy`) | `.bin/ty` when configured |
 | Tests | `pytest` | `.bin/pytest` |
 | Django | `django` | `.bin/django` |
 | Test config | (none) | `--dc=TestLocalApp` |

--- a/plugins/plan-directory/skills/backend-ralph-plan/SKILL.md
+++ b/plugins/plan-directory/skills/backend-ralph-plan/SKILL.md
@@ -71,12 +71,21 @@ Optional: `/plan-directory:run <slug> --max-iterations 50`
 |-------|---------|-------------|
 | Lint command | `ruff check` | Prefix with `.bin/` if needed |
 | Format command | `ruff format` | |
-| Type check | `ty` | Or `mypy`, `pyright` |
+| Type gate | Auto-detect (`ty` → `pyright` → `mypy`) | `ty` is mandatory if configured |
 | Test command | `pytest` | |
 | Test config | `` | e.g., `--dc=TestLocalApp` |
 | Django command | `django` | |
 | Coverage target | `90` | Minimum percentage |
 | Max iterations | `100` | Ralph loop limit |
+
+Type policy for generated plans:
+
+- Detect type checker in this order unless repo docs/CI specify otherwise:
+  `ty`, then `pyright`, then `mypy`.
+- If `ty` is configured (`[tool.ty]`, `ty.toml`, `.bin/ty`, CI/pre-commit), it
+  is mandatory and blocking.
+- Generated tasks should not use "baseline acceptable" language for touched
+  files.
 
 ## Task Granularity Guidelines
 

--- a/plugins/plan-directory/skills/backend-ralph-plan/references/quality-gates.md
+++ b/plugins/plan-directory/skills/backend-ralph-plan/references/quality-gates.md
@@ -53,15 +53,22 @@ ruff format <path>
 ### Type Checking
 
 ```bash
-# Using ty (if available)
-ty <path>
+# Detect in this order unless repo docs/CI differ:
+# 1) ty, 2) pyright, 3) mypy
 
-# Using mypy
-mypy <path>
+# Using ty (preferred when configured)
+ty check <path>
 
 # Using pyright
 pyright <path>
+
+# Using mypy
+mypy <path>
 ```
+
+Rules:
+- If `ty` is configured in the repo, treat it as mandatory and blocking.
+- Do not use "baseline acceptable" language for touched files.
 
 ### Testing
 
@@ -117,7 +124,7 @@ Many projects use wrapper scripts. Common patterns:
 ```bash
 .bin/ruff check <path>
 .bin/ruff format <path>
-.bin/ty <path>
+.bin/ty check <path>
 .bin/pytest <args>
 .bin/django <command>
 ```

--- a/plugins/process-code-review/.claude-plugin/plugin.json
+++ b/plugins/process-code-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "process-code-review",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Process code review findings - interactively fix or skip issues from monty-code-review output",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/process-code-review/skills/process-code-review/SKILL.md
+++ b/plugins/process-code-review/skills/process-code-review/SKILL.md
@@ -30,6 +30,10 @@ Step 2: /process-code-review:process-review *_review.md → Fix/skip issues
 Step 3: /backend-atomic-commit:pre-commit → Run pre-commit checks and fix issues
 ```
 
+Before applying fixes, read local typing policy docs when present (for example
+`docs/python-typing-3.14-best-practices.md`, `TY_MIGRATION_GUIDE.md`,
+`AGENTS.md`) and align type-check behavior with those rules.
+
 ## Example Prompts
 
 ### Basic Usage
@@ -162,8 +166,12 @@ After each fix, run quality checks:
 
 - `ruff check <file> --fix` - Auto-fix linting issues
 - `ruff format <file>` - Format code
-- `ty check <file>` - Type check (baseline acceptable)
+- Active type gate (`ty` if configured; else `pyright`; else `mypy`) - Type check
 - `python manage.py check` - Django system checks (if applicable)
+
+For touched files, "baseline acceptable" is not allowed. Resolve all active
+type-gate errors before moving on. If repo policy requires wider type checks
+before merge, run them before final completion.
 
 If quality checks reveal additional issues, fix them before moving on.
 
@@ -233,7 +241,8 @@ Before marking a review as complete, verify:
 2. All [SHOULD_FIX] issues are addressed or have a documented deferral reason
 3. Linting passes: `.bin/ruff check --fix`
 4. Formatting is correct: `.bin/ruff format`
-5. Type checks pass baseline: `.bin/ty check`
+5. Active type gate passes for touched files, and any repo-required broad type
+   gate is satisfied before merge
 6. Relevant tests still pass
 
 ## Handling Arguments

--- a/plugins/repo-docs/.claude-plugin/plugin.json
+++ b/plugins/repo-docs/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-docs",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Generate and canonicalize repository documentation. Create new AGENTS.md/README.md/CLAUDE.md from scratch, or audit existing docs to make AGENTS.md canonical and normalize CLAUDE.md to minimal stubs.",
   "author": {
     "name": "Diversio Devs"


### PR DESCRIPTION
## Summary

This PR standardizes Python type-gate policy across marketplace skills, updates affected plugin docs/commands/manifests, and syncs marketplace versions. It also resolves the two review findings around staged-only atomic checks and `pyright` discovery in repo-doc canonicalization.

### Key Features

| Feature | Description |
|---------|-------------|
| **Global typing policy** | Adds a canonical marketplace typing policy doc and AGENTS guidance for `ty` > `pyright` > `mypy` precedence. |
| **Atomic/pre-commit type-gate consistency** | Updates code-touching skills (and command wrappers) to use active type-gate wording and strict touched-file expectations. |
| **Review-fix alignment** | Fixes staged-only `pyright`/`mypy` examples in atomic mode and adds `pyright` to repo-doc quality-gate discovery grep. |
| **Version synchronization** | Bumps plugin versions and keeps `.claude-plugin/marketplace.json` aligned with each plugin manifest. |

## Type-Gate Flow

```
Detect active checker
      │
      ├─ ty configured? ───────► use ty (blocking)
      │
      ├─ pyright configured? ──► use pyright
      │
      └─ else if mypy configured► use mypy

Scope selection
      │
      ├─ atomic-commit mode ───► staged files (`git diff --cached`)
      └─ pre-commit mode ──────► modified files (`git diff`)
```

---

## 1) Marketplace Policy Baseline

- Added canonical policy doc: `docs/python-typing-and-ty-best-practices.md`.
- Updated `AGENTS.md` with strict marketplace-level typing rules for code-touching skills:
  - enforce detector precedence (`ty`, then `pyright`, then `mypy`),
  - treat configured `ty` as mandatory,
  - avoid baseline-acceptable language for touched files,
  - prefer narrow suppressions,
  - read local typing policy docs when present.

---

## 2) Skill + Command Updates

- Updated skill docs and command wrappers to use active type-gate language instead of `ty`-only wording where appropriate.
- Updated plugin manifests and marketplace entries with patch-version bumps.
- Kept plugin/version sync consistent between:
  - `plugins/*/.claude-plugin/plugin.json`
  - `.claude-plugin/marketplace.json`

---

## 3) Explicit Review Fixes

- **P2 resolved** (`backend-atomic-commit`):
  - atomic-mode examples for `pyright` and `mypy` now use staged-only diff (`git diff --cached --name-only ...`),
  - pre-commit variants remain non-cached (`git diff --name-only ...`).
- **P3 resolved** (`repo-docs`):
  - quality-gate discovery grep now includes `pyright` in both discovery blocks.

---

## Files Changed

<details>
<summary>Marketplace and governance</summary>

- `.claude-plugin/marketplace.json` - plugin version sync updates.
- `AGENTS.md` - strict typing policy section for code-touching skills.
- `docs/python-typing-and-ty-best-practices.md` - new canonical typing policy reference.

</details>

<details>
<summary>Backend/PR/release/review skills</summary>

- `plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md`
- `plugins/backend-atomic-commit/commands/atomic-commit.md`
- `plugins/backend-atomic-commit/commands/commit.md`
- `plugins/backend-atomic-commit/commands/pre-commit.md`
- `plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md`
- `plugins/backend-release/skills/release-manager/SKILL.md`
- `plugins/monty-code-review/skills/monty-code-review/SKILL.md`
- `plugins/process-code-review/skills/process-code-review/SKILL.md`

</details>

<details>
<summary>Other affected skills</summary>

- `plugins/repo-docs/skills/repo-docs-generator/SKILL.md`
- `plugins/bruno-api/skills/bruno-api/SKILL.md`
- `plugins/mixpanel-analytics/skills/mixpanel-analytics/SKILL.md`
- `plugins/mixpanel-analytics/skills/mixpanel-analytics/references/implementation.md`
- `plugins/mixpanel-analytics/commands/implement.md`
- `plugins/mixpanel-analytics/commands/review.md`
- `plugins/plan-directory/skills/backend-ralph-plan/SKILL.md`
- `plugins/plan-directory/skills/backend-ralph-plan/references/quality-gates.md`
- `plugins/plan-directory/commands/backend-ralph-plan.md`

</details>

<details>
<summary>Manifest version bumps</summary>

- `plugins/backend-atomic-commit/.claude-plugin/plugin.json`
- `plugins/backend-pr-workflow/.claude-plugin/plugin.json`
- `plugins/backend-release/.claude-plugin/plugin.json`
- `plugins/bruno-api/.claude-plugin/plugin.json`
- `plugins/mixpanel-analytics/.claude-plugin/plugin.json`
- `plugins/monty-code-review/.claude-plugin/plugin.json`
- `plugins/plan-directory/.claude-plugin/plugin.json`
- `plugins/process-code-review/.claude-plugin/plugin.json`
- `plugins/repo-docs/.claude-plugin/plugin.json`

</details>

## How to Test

```bash
bash /tmp/validate_marketplace_local.sh
git diff --cached --check
```

Expected:
- JSON and marketplace/plugin consistency checks pass.
- No whitespace/errors in staged diff.

## Notes

- No application/runtime code changes; this PR is documentation/manifests/policy only.
- Unrelated local file intentionally not included in this PR: `docs/slack-lists-migration-proposal.md`.
- Related ClickUp ticket: https://app.clickup.com/t/868hdmdr1
