### PR TITLE
backend-release: require merge commits and post-release branch sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -130,8 +130,8 @@
     },
     {
       "name": "backend-release",
-      "description": "Manages the full release workflow for Django4Lyfe backend - creating release PRs, version bumping (YYYY.MM.DD), conflict resolution, and GitHub releases.",
-      "version": "0.1.2",
+      "description": "Manages the full release workflow for Django4Lyfe backend - creating release PRs, version bumping (YYYY.MM.DD), conflict resolution, GitHub releases, and post-release branch sync.",
+      "version": "0.2.0",
       "author": {
         "name": "Diversio Devs"
       },

--- a/plugins/backend-release/.claude-plugin/plugin.json
+++ b/plugins/backend-release/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "backend-release",
-  "version": "0.1.2",
-  "description": "Manages the full release workflow for Django4Lyfe backend - creating release PRs, version bumping, conflict resolution, and GitHub releases with date-based versioning (YYYY.MM.DD).",
+  "version": "0.2.0",
+  "description": "Manages the full release workflow for Django4Lyfe backend - creating release PRs, version bumping, conflict resolution, GitHub releases with date-based versioning (YYYY.MM.DD), and post-release branch sync.",
   "author": {
     "name": "Diversio Devs"
   }

--- a/plugins/backend-release/commands/create.md
+++ b/plugins/backend-release/commands/create.md
@@ -32,4 +32,8 @@ Creates a release PR using the clean cherry-pick method:
 - Runs `./.security/ruff_pr_diff.sh`
 - Checks RLS policies with `.bin/django optimo_bootstrap_support_shell_rls`
 
+**Merge strategy:**
+- Release PRs to master MUST be merged using **"Create a merge commit"** (not squash)
+- Squash merging breaks commit ancestry and causes `master..release` divergence
+
 See the SKILL.md for full workflow details.

--- a/plugins/backend-release/commands/publish.md
+++ b/plugins/backend-release/commands/publish.md
@@ -9,6 +9,7 @@ After a release PR is merged to master, this command:
 1. Verifies the PR is actually merged
 2. Gets the PR body (list of included PRs)
 3. Creates a GitHub release with matching tag
+4. Merges master back into release to keep branches in sync
 
 **Arguments:**
 - `[PR_NUMBER]` - The merged release PR number
@@ -30,5 +31,12 @@ After a release PR is merged to master, this command:
 - Tag must match version in `pyproject.toml`
 - Release notes contain the list of PR URLs from the release PR body
 - Always verify with `gh release list --limit 3` after publishing
+- **Always merge master back into release** after publishing — this prevents `master..release` from growing unboundedly. The publish step does this automatically:
+  ```bash
+  git fetch origin
+  git checkout release
+  git merge origin/master --no-edit
+  git push origin release
+  ```
 
 See the SKILL.md for complete workflow.


### PR DESCRIPTION
## Summary

This PR updates the `backend-release` plugin workflow so release ancestry stays correct over time: release PRs must use merge commits, and publish flow now includes merging `origin/master` back into `release` after each release.

### Key Features

| Feature | Description |
|---------|-------------|
| **Merge strategy guardrail** | Adds explicit "Create a merge commit" guidance and warns against squash merging for release PRs. |
| **Post-release ancestry sync** | Adds a mandatory `master -> release` merge-back step after publishing to keep `master..release` accurate. |
| **Docs + metadata alignment** | Updates `SKILL.md`, `create.md`, `publish.md`, and bumps `backend-release` version/description to `0.2.0` in both manifest files. |

## Release Flow (Updated)

```text
release branch changes
        |
        v
release PR -> master (must use merge commit)
        |
        v
publish GitHub release tag
        |
        v
merge origin/master back into release
        |
        v
next release diff only shows genuinely new commits
```

---

## Feature 1: Enforce merge-commit strategy

The release skill now explicitly documents that release PRs to `master` must be merged with **Create a merge commit**.

Why:
- Squash merges flatten ancestry for the release branch workflow.
- Flattened ancestry causes `master..release` to accumulate already-shipped commits.

---

## Feature 2: Add mandatory merge-back after publish

A new mandatory step was added to the release manager workflow:

```bash
git fetch origin
git checkout release
git merge origin/master --no-edit
git push origin release
```

Why:
- After a merge-commit release PR, `master` has a merge commit that `release` does not.
- The merge-back closes that ancestry loop so the next release PR is clean and accurate.

---

## Feature 3: Keep command docs and versions consistent

Command docs now reflect the updated behavior:
- `create.md` includes merge strategy guidance.
- `publish.md` includes merge-back as part of publish flow.

Plugin metadata now reflects the behavior change:
- `backend-release` bumped from `0.1.2` to `0.2.0` in both plugin manifest and marketplace entry.
- Description updated to mention post-release branch sync.

## Files Changed

<details>
<summary>Release workflow docs (click to expand)</summary>

- `plugins/backend-release/skills/release-manager/SKILL.md` - Adds merge strategy warning, mandatory merge-back section, new workflow rules, and end-to-end example updates.
- `plugins/backend-release/commands/create.md` - Adds merge strategy requirement note.
- `plugins/backend-release/commands/publish.md` - Adds publish step for merging `master` back into `release` with exact commands.

</details>

<details>
<summary>Plugin metadata (click to expand)</summary>

- `plugins/backend-release/.claude-plugin/plugin.json` - Version `0.2.0` and description update.
- `.claude-plugin/marketplace.json` - Matching `backend-release` version/description update.

</details>

## How to Test

```bash
# CI-equivalent marketplace/plugin consistency validation
bash -lc '
set -euo pipefail
jq -e . .claude-plugin/marketplace.json >/dev/null
DUPLICATE_NAMES="$(jq -r '\'' .plugins[].name '\'' .claude-plugin/marketplace.json | sort | uniq -d || true)"
[ -z "$DUPLICATE_NAMES" ]
MARKETPLACE_PLUGINS="$(jq -r '\'' .plugins[].name '\'' .claude-plugin/marketplace.json | sort -u)"
PLUGIN_DIRS="$(ls -1 plugins | sort -u)"
EXTRA_DIRS="$(comm -23 <(echo "$PLUGIN_DIRS") <(echo "$MARKETPLACE_PLUGINS") || true)"
[ -z "$EXTRA_DIRS" ]
for NAME in $MARKETPLACE_PLUGINS; do
  [ -d "plugins/$NAME" ]
  SOURCE="$(jq -r --arg name "$NAME" '\'' .plugins[] | select(.name == $name) | .source '\'' .claude-plugin/marketplace.json)"
  [ "$SOURCE" = "./plugins/$NAME" ]
  PLUGIN_JSON="plugins/$NAME/.claude-plugin/plugin.json"
  [ -f "$PLUGIN_JSON" ]
  jq -e . "$PLUGIN_JSON" >/dev/null
  [ "$(jq -r '\'' .name '\'' "$PLUGIN_JSON")" = "$NAME" ]
  [ "$(jq -r '\'' .version '\'' "$PLUGIN_JSON")" = "$(jq -r --arg name "$NAME" '\'' .plugins[] | select(.name == $name) | .version '\'' .claude-plugin/marketplace.json)" ]
  [ "$(find "plugins/$NAME/skills" -type f -name SKILL.md | wc -l | tr -d '\'' '\'' )" -gt 0 ]
done
'

# JSON parse checks from CONTRIBUTING.md guidance
python3 -m json.tool .claude-plugin/marketplace.json >/dev/null
python3 -m json.tool plugins/backend-release/.claude-plugin/plugin.json >/dev/null
```

### Manual Verification

1. Confirm both version fields are `0.2.0` for `backend-release`.
2. Confirm `create.md` states release PRs must use merge commits.
3. Confirm `publish.md` includes merge-back commands.
4. Confirm `SKILL.md` includes mandatory merge-back and no-squash rule.

## Notes

- No runtime application code changes.
- No migrations or deploy-time app behavior changes.
- This is a workflow/documentation + metadata release for plugin consumers.
