### PR TITLE
chore: harden backend-release release-check guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -131,7 +131,7 @@
     {
       "name": "backend-release",
       "description": "Manages the full release workflow for Django4Lyfe backend - creating release PRs, version bumping (YYYY.MM.DD), conflict resolution, GitHub releases, and post-release branch sync.",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "Diversio Devs"
       },

--- a/plugins/backend-release/.claude-plugin/plugin.json
+++ b/plugins/backend-release/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-release",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Manages the full release workflow for Django4Lyfe backend - creating release PRs, version bumping, conflict resolution, GitHub releases with date-based versioning (YYYY.MM.DD), and post-release branch sync.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/backend-release/commands/check.md
+++ b/plugins/backend-release/commands/check.md
@@ -4,12 +4,51 @@ description: Check what commits are pending release (on release branch but not o
 
 Use your `release-manager` Skill in **check** mode.
 
-Shows commits that are on the `release` branch but not yet on `master`:
+Shows what is on the `release` branch but not yet on `master`:
 
 ```bash
 git fetch origin master release
-git log origin/master..origin/release --oneline
+
+# PRIMARY CHECK — are there actual code differences?
+git diff --stat origin/master origin/release
 ```
+
+`git diff --stat` compares actual file contents between branches. It is the only
+reliable way to determine whether there is something to release. If the output
+is empty, there is nothing to release — stop here.
+
+If there are differences, identify which PRs they belong to using GitHub's PR
+metadata (merge timestamps):
+
+```bash
+# Get the merge date of the last release PR (the definitive cutoff)
+LAST_RELEASE_DATE=$(gh pr list --base master --state merged --limit 100 \
+  --json number,title,mergedAt \
+  --jq '[.[] | select(.title | test("^(Release|Hotfix)"))] | sort_by(.mergedAt) | last | .mergedAt // empty' \
+  2>/dev/null || echo "")
+
+# List PRs merged to release since that date
+if [ -n "${LAST_RELEASE_DATE}" ]; then
+  gh pr list --base release --state merged --limit 100 --json number,title,mergedAt \
+    --jq "[.[] | select(.mergedAt > \"${LAST_RELEASE_DATE}\")] | sort_by(.mergedAt) | .[] | \"#\\(.number): \\(.title)\""
+else
+  # No previous release — list recent merged PRs as candidates
+  gh pr list --base release --state merged --limit 20 --json number,title \
+    --jq '.[] | "#\(.number): \(.title)"'
+fi
+```
+
+**Why the release PR's `mergedAt`?** GitHub release `publishedAt` is when a
+human clicks "Publish" — which can lag behind the actual release PR merge. PRs
+merged to release in that gap would be missed. The release PR's `mergedAt` is
+the definitive cutoff: `git merge origin/release` captured the exact state of
+release at that moment.
+
+**Why GitHub metadata instead of `git log`?** All `git log`-based approaches
+(`master..release`, `--cherry-pick`, `--first-parent` with tags) can return
+stale results due to historical cherry-pick artifacts and because release tags
+live on master's ancestry, not release's first-parent chain. PR merge
+timestamps from GitHub are immune to git ancestry issues.
 
 Also checks:
 - Current version in `pyproject.toml`
@@ -17,7 +56,8 @@ Also checks:
 - Any pending release PRs
 
 **Output:**
-- List of commits pending release
+- Diff stat of pending changes (or empty if nothing to release)
+- List of PRs pending release
 - Current version
 - Recommended next version (YYYY.MM.DD format)
 

--- a/plugins/backend-release/commands/create.md
+++ b/plugins/backend-release/commands/create.md
@@ -1,16 +1,21 @@
 ---
-description: Create a release PR against master using the clean cherry-pick method.
+description: Create a release PR against master by merging the release branch.
 ---
 
 Use your `release-manager` Skill in **create** mode.
 
-Creates a release PR using the clean cherry-pick method:
+Creates a release PR by merging release into a branch from master:
 
 1. Creates branch from `origin/master`
-2. Cherry-picks new commits from release branch
+2. Merges `origin/release` into it
 3. Bumps version in `pyproject.toml` (YYYY.MM.DD format)
 4. Runs `uv lock` to update lock file
 5. Pushes and creates PR against `master`
+
+**Why merge (not cherry-pick)?** Cherry-picking creates duplicate commits with
+different SHAs on master vs release. This causes `git log master..release` to
+permanently show already-shipped commits as "pending". Merging preserves the
+original commit objects so ancestry tracking works correctly.
 
 **Version numbering:**
 | Scenario | Format | Example |

--- a/plugins/backend-release/commands/publish.md
+++ b/plugins/backend-release/commands/publish.md
@@ -31,7 +31,7 @@ After a release PR is merged to master, this command:
 - Tag must match version in `pyproject.toml`
 - Release notes contain the list of PR URLs from the release PR body
 - Always verify with `gh release list --limit 3` after publishing
-- **Always merge master back into release** after publishing — this prevents `master..release` from growing unboundedly. The publish step does this automatically:
+- **Always merge master back into release** after publishing — without this, `git diff --stat origin/master origin/release` shows the version bump as a pending difference and the next release merge will conflict on `pyproject.toml` / `uv.lock`. The publish step does this automatically:
   ```bash
   git fetch origin
   git checkout release


### PR DESCRIPTION
## Summary

This PR hardens the `backend-release` plugin guidance to eliminate stale release-candidate detection and align docs/commands around the merge-based release workflow.

### Key Features

| Feature | Description |
|---------|-------------|
| **Diff-first release check** | Replaces ancestry-based pending-release checks with `git diff --stat origin/master origin/release` as the source of truth. |
| **Robust PR attribution cutoff** | Uses the last merged release/hotfix PR's `mergedAt` timestamp (from `gh pr list --base master`) to identify PRs merged into `release` since the last release cut. |
| **Merge workflow consistency** | Updates release creation guidance from cherry-pick to merge (`git merge origin/release --no-edit`) across skill + command docs. |
| **Version/rationale consistency** | Updates merge-back rationale (version bump divergence/conflicts) and bumps `backend-release` version `0.2.0 -> 0.3.0` in both manifests. |

## Release Check Flow

```text
Start
  |
  v
git diff --stat origin/master origin/release
  |
  +-- empty  ----> nothing to release
  |
  +-- non-empty --> fetch last merged Release/Hotfix PR mergedAt (base=master)
                      |
                      +-- found ----> list merged PRs on base=release with mergedAt > cutoff
                      |
                      +-- not found -> list recent merged PR candidates on base=release
```

---

## Details

### 1) Make release check patch-state based (not ancestry based)

- `check.md` and `SKILL.md` now explicitly define `git diff --stat` as the authoritative release check.
- Added explanation for why `git log` variants are unreliable in repos with historical cherry-pick artifacts.

### 2) Use release PR `mergedAt` as cutoff (not release `publishedAt`)

- Switched metadata source from GitHub release publication timestamp to merged release/hotfix PR timestamp.
- Added null-safe jq expression (`.mergedAt // empty`) and branch-safe fallback behavior when no prior release PR is found.
- Increased master-side release PR lookup to `--limit 100` to avoid cutoff misses.

### 3) Align all workflow docs with merge method

- Updated create flow to merge-based branch prep (`releases/YYYY.MM.DD[-N]` + merge).
- Updated conflict-recovery sections to merge conflict handling.
- Updated end-to-end example and quick reference command blocks accordingly.

### 4) Keep publish rationale and plugin versioning consistent

- Updated publish rationale to the real failure mode (version bump remains on `master`, causing false diff + merge conflicts without merge-back).
- Bumped `backend-release` version in:
  - `plugins/backend-release/.claude-plugin/plugin.json`
  - `.claude-plugin/marketplace.json`

---

## Files Changed

<details>
<summary>Plugin metadata</summary>

- `.claude-plugin/marketplace.json` - bump `backend-release` marketplace version to `0.3.0`
- `plugins/backend-release/.claude-plugin/plugin.json` - bump plugin manifest version to `0.3.0`

</details>

<details>
<summary>Backend release command docs</summary>

- `plugins/backend-release/commands/check.md` - new diff-first check + PR attribution via merged release PR cutoff
- `plugins/backend-release/commands/create.md` - merge-based create flow wording
- `plugins/backend-release/commands/publish.md` - corrected merge-back rationale

</details>

<details>
<summary>Skill documentation</summary>

- `plugins/backend-release/skills/release-manager/SKILL.md` - full workflow rewrite for check/create/conflict/example/quick-reference consistency

</details>

## How to Test

```bash
# Marketplace/plugin consistency check (CI-equivalent local validation)
# (Executed locally in bash)
validate-marketplace: PASS

# Whitespace/syntax sanity
git diff --check
```

### Manual Verification

1. Open updated command docs and confirm all release-check examples use `git diff --stat` first.
2. Confirm cutoff query uses merged release/hotfix PR timestamp (`base=master`, title filter, `.mergedAt // empty`).
3. Confirm fallback path exists when no prior release/hotfix PR is found.
4. Confirm `backend-release` version is `0.3.0` in both plugin manifest and marketplace entry.

## Notes

- No application/runtime code changes; docs + plugin metadata only.
- No migrations, infra, or API behavior changes.
