### PR TITLE
Document gate-cache workflow in backend-atomic-commit plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "backend-atomic-commit",
       "description": "Pedantic backend pre-commit and atomic-commit Skill with an iterative convergence protocol (budgets + stuck detection), enforcing AGENTS.md, pre-commit hooks (including djlint), .security/* helpers, and Monty's backend taste without AI commit signatures.",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "author": {
         "name": "Diversio Devs"
       },

--- a/plugins/backend-atomic-commit/.claude-plugin/plugin.json
+++ b/plugins/backend-atomic-commit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-atomic-commit",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Pedantic backend pre-commit and atomic-commit Skill for Django/Optimo-style repos, enforcing local AGENTS.md, pre-commit hooks (including djlint), and Monty’s backend taste with an explicit fix-retry convergence protocol.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/backend-atomic-commit/commands/atomic-commit.md
+++ b/plugins/backend-atomic-commit/commands/atomic-commit.md
@@ -16,12 +16,17 @@ Do everything the `/backend-atomic-commit:pre-commit` command would do, plus:
   - Django system checks
   - Relevant pytest subsets
   - Pre-commit hooks
+- Use `./.security/gate_cache.sh` for heavy deterministic checks (type gates,
+  Django checks, and other wrapped hooks) when the repo provides it.
 - Treat the above as a **convergence loop** (not one pass): if any gate fails,
   fix the reported issue, re-run the same gate, and keep going until everything
   is green and hooks stop rewriting files.
 - Budget: up to **3 attempts per failing gate** and **10 total pipeline
   passes**. If a gate is stuck (same error after 3 fix attempts), report it as
   `[BLOCKING]` and continue with other gates.
+- Keep fetch failures fail-closed by default in diff helpers; only use
+  `CHECKS_ALLOW_FETCH_SKIP=1` when the user explicitly accepts a local skip.
+- Use `CHECK_CACHE_BUST=1` only when explicitly requested or debugging.
 - Do **not** use TodoWrite to track gate results — report directly in output.
 - Propose a commit message that:
   - Extracts the ticket ID from the branch name using local `AGENTS.md`

--- a/plugins/backend-atomic-commit/commands/commit.md
+++ b/plugins/backend-atomic-commit/commands/commit.md
@@ -17,6 +17,11 @@ Workflow:
    Ruff, active type gate checks (`ty`/`pyright`/`mypy`), Django checks,
    relevant pytest subsets), fixing and re-running until everything is green and
    hooks stop rewriting files.
+   - If `./.security/gate_cache.sh` exists, use it for heavy deterministic
+     checks by default.
+   - Keep diff-helper fetch behavior fail-closed unless the user explicitly
+     accepts a local skip via `CHECKS_ALLOW_FETCH_SKIP=1`.
+   - Use `CHECK_CACHE_BUST=1` only when explicitly requested or debugging.
    - Apply the Skill’s explicit iteration budgets + stuck protocol (3 attempts per
      failing gate, 10 total pipeline passes). If a gate is stuck, stop and report
      it as `[BLOCKING]` with the exact error + what was tried.

--- a/plugins/backend-atomic-commit/commands/pre-commit.md
+++ b/plugins/backend-atomic-commit/commands/pre-commit.md
@@ -11,17 +11,24 @@ Focus on:
 - Eliminating local imports, debug statements, PII-in-logs issues, and obvious
   type-hint problems.
 - Running the following checks in order:
-  1. `.bin/ruff check --fix` and `.bin/ruff format` on modified Python files.
-  2. Active type gate (`ty` if configured; else `pyright`; else `mypy`) on
+  1. `./.security/ruff_pr_diff.sh` and `./.security/local_imports_pr_diff.sh`
+     (these include local staged/unstaged tracked files and cache-aware runs).
+  2. `.bin/ruff check --fix` and `.bin/ruff format` on modified Python files.
+  3. Active type gate (`ty` if configured; else `pyright`; else `mypy`) on
      **modified Python files only** during iteration, then any repo-required
-     wider type gate before final readiness.
-  3. `python manage.py check --fail-level WARNING` for Django system checks.
-  4. Any pre-commit hooks defined in `.pre-commit-config.yaml`.
+     wider type gate before final readiness. If available, run heavy checks
+     through `./.security/gate_cache.sh`.
+  4. `python manage.py check --fail-level WARNING` for Django system checks
+     (prefer `./.security/gate_cache.sh --gate django-system-check --scope index -- ...` when available).
+  5. Any pre-commit hooks defined in `.pre-commit-config.yaml`.
 - Treat the above as a **convergence loop** (not one pass): if a check fails or
   rewrites files, fix/restage, then re-run until all checks pass cleanly.
 - Budget: up to **3 attempts per failing check** and **10 total pipeline
   passes**. If a check still fails after 3 real fix attempts, report it as
   `[BLOCKING]` and move on to other issues.
+- Keep fetch failures fail-closed by default for diff helpers. Use
+  `CHECKS_ALLOW_FETCH_SKIP=1` only when the user explicitly accepts a local skip.
+- Force cache bust only when explicitly requested (`CHECK_CACHE_BUST=1`).
 - Do **not** use TodoWrite to track gate results — report directly in output.
 - **IMPORTANT**: For any file you touch, resolve **ALL** ruff and active
   type-check errors in that file—not just the ones you introduced. CI will fail


### PR DESCRIPTION
## Summary

This PR updates the `backend-atomic-commit` plugin docs to align with the backend gate-cache rollout, so agent workflows now explicitly favor cache-wrapped heavy checks and the stricter diff-helper behavior.

### Key Features

| Feature | Description |
|---------|-------------|
| Cache-first heavy checks guidance | Documents `./.security/gate_cache.sh` as the default wrapper for heavy deterministic gates (type checks, Django checks) when available. |
| Diff-helper policy clarity | Documents fail-closed fetch behavior and the staged+unstaged tracked file union model for Ruff/local-import diff helpers. |
| Versioned plugin release | Bumps `backend-atomic-commit` plugin version from `0.2.1` to `0.2.2` in both plugin and marketplace manifests. |

## Workflow View

```text
/backend-atomic-commit command
          |
          v
  Select gates to run
          |
   +------+---------------------------+
   |                                  |
   v                                  v
Diff helpers                     Heavy deterministic gates
(ruff/local-imports scripts)     (ty, django check, etc.)
   |                                  |
   | fail-closed fetch by default     | wrap with gate_cache.sh when available
   | include base diff + local edits  |
   v                                  v
Run checks                        CACHE HIT -> skip safely
                                  CACHE MISS -> run + cache success
```

---

## Detailed Changes

## 1) backend-atomic-commit skill guidance updates

Updated `plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md` to:
- Detect and prefer `./.security/gate_cache.sh` for heavy gates.
- Add concrete `gate_cache.sh` usage examples (`ty-check`, `django-system-check`).
- Clarify when to use `scope=index` vs `scope=working`.
- Document explicit cache bust / clear controls.
- Clarify fail-closed fetch behavior and local override expectations.
- Clarify that diff helpers intentionally include `origin/<base>..HEAD` + staged + unstaged tracked Python files.

## 2) Command entrypoint alignment

Updated command wrappers to match the new standard:
- `plugins/backend-atomic-commit/commands/pre-commit.md`
- `plugins/backend-atomic-commit/commands/atomic-commit.md`
- `plugins/backend-atomic-commit/commands/commit.md`

Each command now explicitly calls out:
- cache wrapper usage for heavy deterministic checks,
- fail-closed fetch defaults for diff helpers,
- strict opt-in use of `CHECKS_ALLOW_FETCH_SKIP=1`,
- strict opt-in use of `CHECK_CACHE_BUST=1`.

## 3) Plugin manifest synchronization

Version bumped from `0.2.1` to `0.2.2` in:
- `plugins/backend-atomic-commit/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`

This keeps marketplace metadata and plugin manifest in lockstep.

---

## Files Changed

<details>
<summary>Plugin manifests</summary>

- `.claude-plugin/marketplace.json` - updates published plugin version (`0.2.2`).
- `plugins/backend-atomic-commit/.claude-plugin/plugin.json` - plugin manifest version bump.

</details>

<details>
<summary>Skill docs</summary>

- `plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md` - cache-first heavy-gate guidance, fetch policy, scope/use examples.

</details>

<details>
<summary>Command docs</summary>

- `plugins/backend-atomic-commit/commands/pre-commit.md` - updated sequence/policy for cached gates and diff helpers.
- `plugins/backend-atomic-commit/commands/atomic-commit.md` - same policy updates for atomic mode.
- `plugins/backend-atomic-commit/commands/commit.md` - same policy updates for commit mode.

</details>

---

## How to Test

```bash
# from agent-skills-marketplace/

# 1) ensure branch diff contains expected files only
git diff --name-only origin/main...HEAD

# 2) validate JSON manifests
jq empty plugins/backend-atomic-commit/.claude-plugin/plugin.json
jq empty .claude-plugin/marketplace.json

# 3) verify version sync
jq -r '.version' plugins/backend-atomic-commit/.claude-plugin/plugin.json
jq -r '.plugins[] | select(.name=="backend-atomic-commit") | .version' .claude-plugin/marketplace.json
```

### Manual Validation

1. Open the updated skill and command docs and confirm they consistently mention:
   - `gate_cache.sh` for heavy deterministic checks,
   - fail-closed fetch defaults,
   - explicit opt-in overrides (`CHECKS_ALLOW_FETCH_SKIP=1`, `CHECK_CACHE_BUST=1`).
2. Confirm plugin version appears as `0.2.2` in both manifest files.

---

## Notes

- No runtime code paths changed in this repository; this is plugin/skill documentation and metadata alignment only.
- Local uncommitted `.claude/settings.json` is intentionally **not** part of this PR.
