### PR TITLE
Avoid redundant gate reruns in backend-atomic-commit flow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "backend-atomic-commit",
       "description": "Pedantic backend pre-commit and atomic-commit Skill with an iterative convergence protocol (budgets + stuck detection), enforcing AGENTS.md, pre-commit hooks (including djlint), .security/* helpers, and Monty's backend taste without AI commit signatures.",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "author": {
         "name": "Diversio Devs"
       },

--- a/plugins/backend-atomic-commit/.claude-plugin/plugin.json
+++ b/plugins/backend-atomic-commit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-atomic-commit",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Pedantic backend pre-commit and atomic-commit Skill for Django/Optimo-style repos, enforcing local AGENTS.md, pre-commit hooks (including djlint), and Monty’s backend taste with an explicit fix-retry convergence protocol.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/backend-atomic-commit/commands/atomic-commit.md
+++ b/plugins/backend-atomic-commit/commands/atomic-commit.md
@@ -16,6 +16,9 @@ Do everything the `/backend-atomic-commit:pre-commit` command would do, plus:
   - Django system checks
   - Relevant pytest subsets
   - Pre-commit hooks
+- Run pre-commit first for the staged set. A passing hook execution counts as
+  satisfying the matching gate; do not rerun duplicate direct commands unless
+  diagnosing a hook failure.
 - Use `./.security/gate_cache.sh` for heavy deterministic checks (type gates,
   Django checks, and other wrapped hooks) when the repo provides it.
 - Treat the above as a **convergence loop** (not one pass): if any gate fails,

--- a/plugins/backend-atomic-commit/commands/commit.md
+++ b/plugins/backend-atomic-commit/commands/commit.md
@@ -17,6 +17,9 @@ Workflow:
    Ruff, active type gate checks (`ty`/`pyright`/`mypy`), Django checks,
    relevant pytest subsets), fixing and re-running until everything is green and
    hooks stop rewriting files.
+   - Start with pre-commit hook execution on staged files; treat passing hooks
+     as satisfying those gates without duplicate direct reruns.
+   - Use direct commands only for targeted diagnosis of failing hooks or absent hooks.
    - If `./.security/gate_cache.sh` exists, use it for heavy deterministic
      checks by default.
    - Keep diff-helper fetch behavior fail-closed unless the user explicitly

--- a/plugins/backend-atomic-commit/commands/pre-commit.md
+++ b/plugins/backend-atomic-commit/commands/pre-commit.md
@@ -11,16 +11,11 @@ Focus on:
 - Eliminating local imports, debug statements, PII-in-logs issues, and obvious
   type-hint problems.
 - Running the following checks in order:
-  1. `./.security/ruff_pr_diff.sh` and `./.security/local_imports_pr_diff.sh`
-     (these include local staged/unstaged tracked files and cache-aware runs).
-  2. `.bin/ruff check --fix` and `.bin/ruff format` on modified Python files.
-  3. Active type gate (`ty` if configured; else `pyright`; else `mypy`) on
-     **modified Python files only** during iteration, then any repo-required
-     wider type gate before final readiness. If available, run heavy checks
-     through `./.security/gate_cache.sh`.
-  4. `python manage.py check --fail-level WARNING` for Django system checks
-     (prefer `./.security/gate_cache.sh --gate django-system-check --scope index -- ...` when available).
-  5. Any pre-commit hooks defined in `.pre-commit-config.yaml`.
+  1. Run pre-commit hooks first on the changed file set.
+  2. If hooks pass, do not rerun equivalent direct commands.
+  3. If specific hooks fail, run targeted direct commands only for those failing gates
+     (for example Ruff/local-import/type/django), then re-run pre-commit.
+  4. Use `./.security/gate_cache.sh` for heavy deterministic checks when direct invocation is needed.
 - Treat the above as a **convergence loop** (not one pass): if a check fails or
   rewrites files, fix/restage, then re-run until all checks pass cleanly.
 - Budget: up to **3 attempts per failing check** and **10 total pipeline


### PR DESCRIPTION
## Summary

This PR updates the `backend-atomic-commit` skill workflow to avoid redundant internal command execution when users ask to run pre-commit mode.

### Key Features

| Feature | Description |
|---------|-------------|
| Hook-first execution model | Runs pre-commit hooks first for the selected file scope and treats passing hooks as satisfying those gates. |
| Targeted fallback only | Direct commands (`.security/*`, Ruff, type, Django) are now fallback paths for failed/missing hooks, not default duplicate runs. |
| Manifest/version sync | Bumps plugin metadata from `0.2.2` to `0.2.3` in both plugin and marketplace manifests. |

## Execution Flow

```text
User: "run pre-commit skill"
            |
            v
   Run pre-commit hooks first
            |
      +-----+-----+
      |           |
   all pass      fail
      |           |
      v           v
   stop here   run targeted direct checks
               only for failing/absent hooks
               then re-run pre-commit
```

---

## Detailed Changes

## 1) Skill pipeline changes

Updated `plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md`:
- Adds explicit **pre-commit-first** primary execution path.
- Adds explicit **direct command fallback** section (non-duplicative).
- Clarifies that passing pre-commit hooks satisfy matching gates.
- Keeps strict fetch and cache controls while removing redundant run patterns.

## 2) Command entrypoint alignment

Updated command wrappers to match the new non-redundant flow:
- `plugins/backend-atomic-commit/commands/pre-commit.md`
- `plugins/backend-atomic-commit/commands/atomic-commit.md`
- `plugins/backend-atomic-commit/commands/commit.md`

## 3) Version bump

Updated plugin version to `0.2.3` in:
- `plugins/backend-atomic-commit/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`

---

## Files Changed

<details>
<summary>Skill behavior docs</summary>

- `plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md`

</details>

<details>
<summary>Command docs</summary>

- `plugins/backend-atomic-commit/commands/pre-commit.md`
- `plugins/backend-atomic-commit/commands/atomic-commit.md`
- `plugins/backend-atomic-commit/commands/commit.md`

</details>

<details>
<summary>Manifest/version metadata</summary>

- `plugins/backend-atomic-commit/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`

</details>

---

## How to Test

```bash
# from agent-skills-marketplace/

git diff --name-only origin/main...HEAD
jq empty plugins/backend-atomic-commit/.claude-plugin/plugin.json
jq empty .claude-plugin/marketplace.json
jq -r '.version' plugins/backend-atomic-commit/.claude-plugin/plugin.json
jq -r '.plugins[] | select(.name=="backend-atomic-commit") | .version' .claude-plugin/marketplace.json
```

### Manual Verification

1. Read the updated skill section and confirm it says pre-commit first, targeted fallback second.
2. Confirm command docs no longer prescribe always running internal gates in duplicate.
3. Confirm plugin version is `0.2.3` in both metadata files.

---

## Notes

- This PR intentionally changes workflow guidance only (no runtime app code).
- Local `.claude/settings.json` remains uncommitted and is not part of this PR.
