### PR TITLE
[GH-4845]: Update login-cta-attribution and mixpanel-analytics skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -98,7 +98,7 @@
     {
       "name": "mixpanel-analytics",
       "description": "MixPanel analytics tracking implementation and review Skill for Django4Lyfe optimo_analytics module with PII protection and pattern enforcement.",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "author": {
         "name": "Diversio Devs"
       },
@@ -164,7 +164,7 @@
     {
       "name": "login-cta-attribution-skill",
       "description": "CTA login attribution implementation Skill for Django4Lyfe: guides adding new CTA sources, button/tab attribution, and enum registration.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "author": {
         "name": "Diversio Devs"
       },

--- a/mixpanel_and_login_cta_skill_update_plan.md
+++ b/mixpanel_and_login_cta_skill_update_plan.md
@@ -1,0 +1,175 @@
+# Plan: Update `login-cta-attribution-skill` and `mixpanel-analytics` Skills
+
+## Context
+
+PR #2623 (GH-4376) moved CTA choice enums from `optimo_integrations/*/cta_choices.py` into `optimo_core/models/login_attribution.py` and renamed the URL helper functions for disambiguation. The two Claude Code skills that reference these files are now stale:
+
+- **`login-cta-attribution-skill` (v0.1.0)**: References deleted `cta_choices.py` files and old function names throughout SKILL.md, references/architecture-and-signatures.md, and commands/implement.md.
+- **`mixpanel-analytics` (v0.1.3)**: Has no awareness of CTA attribution enums, session context fields, or the testing guides created in this PR.
+
+Dev repo: `~/DiversioMonolith/claude-plugins/plugins/`
+
+---
+
+## Part A: `login-cta-attribution-skill` — Fix Stale References
+
+### A1. `skills/login-cta-attribution-skill/SKILL.md`
+
+**Environment & Context Gathering (lines 58-64)**: Remove deleted files, keep canonical path.
+
+| Current (stale) | New |
+|---|---|
+| `optimo_integrations/slack/cta_choices.py` | *(delete line)* |
+| `optimo_integrations/teams/cta_choices.py` | *(delete line)* |
+
+Keep `optimo_core/models/login_attribution.py` (already listed).
+
+**Step 6 (line 188)**: Rename function reference.
+
+| Current | New |
+|---|---|
+| `update_cta_url_with_button_info()` | `update_slack_cta_url_with_button_info()` / `update_teams_cta_url_with_button_info()` |
+
+**Step 7 code examples (lines 197-243)**: Update import paths.
+
+| Current import | New import |
+|---|---|
+| `from optimo_integrations.slack.cta_choices import SlackButtonChoices, SlackTabChoices` | `from optimo_core.models import SlackButtonChoices, SlackTabChoices` |
+| `from optimo_integrations.teams.cta_choices import TeamsButtonChoices` | `from optimo_core.models import TeamsButtonChoices` |
+
+All three code examples (Slack Layer 1, Teams Layer 1, direct magic-link builder) need this update.
+
+### A2. `skills/login-cta-attribution-skill/references/architecture-and-signatures.md`
+
+**Layer 2 description (line 22)**: Rename function.
+
+| Current | New |
+|---|---|
+| `update_cta_url_with_button_info(cta_url, ...)` | `update_slack_cta_url_with_button_info(cta_url, ...)` / `update_teams_cta_url_with_button_info(cta_url, ...)` |
+
+**Key Files table (lines 155-171)**: Remove deleted file rows, add canonical row.
+
+| Current rows to remove | Replacement |
+|---|---|
+| `Slack choices and helpers \| optimo_integrations/slack/cta_choices.py` | `Slack/Teams CTA enums + helpers \| optimo_core/models/login_attribution.py` |
+| `Teams choices and helpers \| optimo_integrations/teams/cta_choices.py` | *(merged into row above)* |
+
+### A3. `commands/implement.md`
+
+**Line 22**: Rename Layer 2 function reference.
+
+| Current | New |
+|---|---|
+| `update_cta_url_with_button_info()` | `update_slack_cta_url_with_button_info()` / `update_teams_cta_url_with_button_info()` |
+
+### A4. `.claude-plugin/plugin.json`
+
+Bump version `0.1.0` → `0.2.0`.
+
+---
+
+## Part B: `mixpanel-analytics` — Add CTA Attribution Awareness
+
+### B1. `skills/mixpanel-analytics/SKILL.md`
+
+**Environment & Context Gathering section** — add to the "Read key reference files" list:
+
+```
+- `optimo_core/models/login_attribution.py` – CTA attribution enums (SlackButtonChoices, SlackTabChoices, TeamsButtonChoices) and URL helpers
+- `optimo_analytics/docs/LoginCTA_AttributionTestingGuide.md` – CTA attribution testing scenarios
+- `optimo_analytics/docs/BackendMixpanelTestingGuideV2.md` – Survey lifecycle & MAP event testing scenarios
+```
+
+### B2. `skills/mixpanel-analytics/references/implementation.md`
+
+**After Step 7** — add a new section:
+
+```markdown
+## CTA Attribution Context (Login Events)
+
+Login/session events include CTA attribution fields in `MixpanelSessionContextSchema`:
+
+| Field | Source | Values |
+|---|---|---|
+| `login_source` | `LoginSourceChoices` | `slack`, `teams`, `email`, `direct` |
+| `login_source_detail` | `LoginSourceDetailChoices` | `weekly_digest`, `survey_complete`, etc. |
+| `magic_link_action` | `MagicLinkActionChoices` | `login`, `invite`, `signup`, `verify_email` |
+| `slack_button` | `SlackButtonChoices` | Button label from Slack CTA |
+| `slack_tab` | `SlackTabChoices` | `messages`, `home` |
+| `teams_button` | `TeamsButtonChoices` | Button label from Teams CTA |
+| `cta_parse_failed` | `bool` | `True` if source param parsing failed |
+
+All enums live in `optimo_core/models/login_attribution.py`.
+
+When implementing events that extend `MixpanelSessionContextSchema`, these fields
+are auto-populated from the auth token's session context — no manual wiring needed.
+
+Testing guides:
+- `optimo_analytics/docs/LoginCTA_AttributionTestingGuide.md`
+- `optimo_analytics/docs/BackendMixpanelTestingGuideV2.md`
+```
+
+### B3. `skills/mixpanel-analytics/references/review.md`
+
+**After section 10 (Export Completeness)** — add:
+
+```markdown
+### 11. CTA Attribution Fields (P2)
+
+For events extending `MixpanelSessionContextSchema`:
+
+**MUST VERIFY**:
+- [ ] Attribution fields are NOT manually set (they flow from session context)
+- [ ] `login_source` uses `LoginSourceChoices` enum, not raw strings
+- [ ] `slack_button`/`teams_button` use their respective enum labels
+- [ ] Test scenarios cover attributed and non-attributed login paths
+```
+
+### B4. `.claude-plugin/plugin.json`
+
+Bump version `0.1.3` → `0.1.4`.
+
+---
+
+## Files Modified (Summary)
+
+| Plugin | File | Change |
+|---|---|---|
+| `login-cta-attribution-skill` | `SKILL.md` | Remove deleted file refs, update imports + function names |
+| `login-cta-attribution-skill` | `references/architecture-and-signatures.md` | Update Key Files table, rename Layer 2 function |
+| `login-cta-attribution-skill` | `commands/implement.md` | Rename Layer 2 function reference |
+| `login-cta-attribution-skill` | `.claude-plugin/plugin.json` | Bump `0.1.0` → `0.2.0` |
+| `mixpanel-analytics` | `SKILL.md` | Add CTA attribution to context gathering |
+| `mixpanel-analytics` | `references/implementation.md` | Add CTA Attribution Context section |
+| `mixpanel-analytics` | `references/review.md` | Add CTA Attribution Fields review check |
+| `mixpanel-analytics` | `.claude-plugin/plugin.json` | Bump `0.1.3` → `0.1.4` |
+
+---
+
+## What We're NOT Changing
+
+- No changes to the `commands/implement.md` or `commands/review.md` for `mixpanel-analytics` (they delegate to SKILL.md which delegates to references).
+- No structural reorganization of either skill — just content updates.
+
+---
+
+## Verification
+
+1. Grep both skills for any remaining references to `cta_choices.py`:
+   ```bash
+   grep -r "cta_choices" ~/DiversioMonolith/claude-plugins/plugins/login-cta-attribution-skill/
+   grep -r "cta_choices" ~/DiversioMonolith/claude-plugins/plugins/mixpanel-analytics/
+   ```
+
+2. Grep for old function name:
+   ```bash
+   grep -r "update_cta_url_with_button_info" ~/DiversioMonolith/claude-plugins/plugins/login-cta-attribution-skill/
+   ```
+
+3. Verify JSON validity of both `plugin.json` files:
+   ```bash
+   python3 -m json.tool ~/DiversioMonolith/claude-plugins/plugins/login-cta-attribution-skill/.claude-plugin/plugin.json
+   python3 -m json.tool ~/DiversioMonolith/claude-plugins/plugins/mixpanel-analytics/.claude-plugin/plugin.json
+   ```
+
+4. After publishing updated plugins, invoke each skill once to verify it loads without errors.

--- a/plugins/login-cta-attribution-skill/.claude-plugin/plugin.json
+++ b/plugins/login-cta-attribution-skill/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "login-cta-attribution-skill",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CTA login attribution implementation Skill for Django4Lyfe: guides adding new CTA sources, button/tab attribution, and enum registration.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/login-cta-attribution-skill/commands/implement.md
+++ b/plugins/login-cta-attribution-skill/commands/implement.md
@@ -18,7 +18,8 @@ Focus on:
 - **Choosing the correct layer for button attribution:**
   - **Layer 1:** Use `build_stable_slack_cta_url()` / `build_stable_teams_cta_url()`
     with button params baked in (for single-button CTAs like Home Tab).
-  - **Layer 2:** Use `update_cta_url_with_button_info()` to append button params
+  - **Layer 2:** Use `update_slack_cta_url_with_button_info()` /
+    `update_teams_cta_url_with_button_info()` to append button params
     to a base URL (for multi-button contexts like Digests).
 - Using correct function signatures:
   - `build_login_magic_link_for_user()` takes **enum types** for

--- a/plugins/login-cta-attribution-skill/skills/login-cta-attribution-skill/SKILL.md
+++ b/plugins/login-cta-attribution-skill/skills/login-cta-attribution-skill/SKILL.md
@@ -58,8 +58,6 @@ Read these files first:
 
 - `optimo_core/models/login_attribution.py`
 - `optimo_core/auth/magic_link.py`
-- `optimo_integrations/slack/cta_choices.py`
-- `optimo_integrations/teams/cta_choices.py`
 - `optimo_integrations/utils/platform_magic_links.py`
 
 Also read local policy docs when present:
@@ -185,7 +183,8 @@ Enum labels must match actual UI button text.
 - Layer 1 (single-button contexts): pass button/tab directly into stable URL
   builders.
 - Layer 2 (multi-button contexts like digests): append button/tab at render
-  time with `update_cta_url_with_button_info()`.
+  time with `update_slack_cta_url_with_button_info()` /
+  `update_teams_cta_url_with_button_info()`.
 
 Never apply both layers on the same CTA path.
 
@@ -198,7 +197,7 @@ Example (Slack, Layer 1):
 
 ```python
 from optimo_core.models.login_attribution import CTA_SOURCE_{PLATFORM}_{ACTION}
-from optimo_integrations.slack.cta_choices import SlackButtonChoices, SlackTabChoices
+from optimo_core.models import SlackButtonChoices, SlackTabChoices
 from optimo_integrations.utils.platform_magic_links import build_stable_slack_cta_url
 
 url = build_stable_slack_cta_url(
@@ -213,7 +212,7 @@ Example (Teams, Layer 1):
 
 ```python
 from optimo_core.models.login_attribution import CTA_SOURCE_{PLATFORM}_{ACTION}
-from optimo_integrations.teams.cta_choices import TeamsButtonChoices
+from optimo_core.models import TeamsButtonChoices
 from optimo_integrations.utils.platform_magic_links import build_stable_teams_cta_url
 
 url = build_stable_teams_cta_url(
@@ -230,7 +229,7 @@ from optimo_core.models.login_attribution import (
     LoginSourceChoices,
     LoginSourceDetailChoices,
 )
-from optimo_integrations.slack.cta_choices import SlackButtonChoices, SlackTabChoices
+from optimo_core.models import SlackButtonChoices, SlackTabChoices
 from optimo_integrations.utils.platform_magic_links import build_login_magic_link_for_user
 
 url = build_login_magic_link_for_user(

--- a/plugins/login-cta-attribution-skill/skills/login-cta-attribution-skill/references/architecture-and-signatures.md
+++ b/plugins/login-cta-attribution-skill/skills/login-cta-attribution-skill/references/architecture-and-signatures.md
@@ -19,7 +19,8 @@ Use for one-CTA-per-button contexts (for example, Home tab links):
 Use for multi-button contexts sharing a base link (for example, digest
 formatters):
 
-- `update_cta_url_with_button_info(cta_url, ...)`
+- `update_slack_cta_url_with_button_info(cta_url, ...)` (Slack)
+- `update_teams_cta_url_with_button_info(cta_url, ...)` (Teams)
 
 Applying both layers on the same path can cause double-attribution.
 
@@ -155,9 +156,8 @@ If new attribution keys are introduced, confirm refresh path copies them.
 | Purpose | Path |
 | --- | --- |
 | Core attribution enums/constants/parser | `optimo_core/models/login_attribution.py` |
+| Slack/Teams CTA enums + URL helpers | `optimo_core/models/login_attribution.py` |
 | Metadata TypedDict and builder | `optimo_core/auth/magic_link.py` |
-| Slack choices and helpers | `optimo_integrations/slack/cta_choices.py` |
-| Teams choices and helpers | `optimo_integrations/teams/cta_choices.py` |
 | Stable URL builders | `optimo_integrations/utils/platform_magic_links.py` |
 | Slack CTA view | `optimo_integrations/slack/views.py` |
 | Teams CTA view | `optimo_integrations/teams/views.py` |

--- a/plugins/mixpanel-analytics/.claude-plugin/plugin.json
+++ b/plugins/mixpanel-analytics/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-analytics",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MixPanel analytics tracking implementation and review Skills for Django4Lyfe optimo_analytics module.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/mixpanel-analytics/skills/mixpanel-analytics/SKILL.md
+++ b/plugins/mixpanel-analytics/skills/mixpanel-analytics/SKILL.md
@@ -70,6 +70,9 @@ Read key reference files:
 - `optimo_analytics/schemas.py` – existing schema patterns
 - `optimo_analytics/service/AGENTS.md` – service layer patterns
 - `optimo_analytics/tests/AGENTS.md` – test patterns
+- `optimo_core/models/login_attribution.py` – CTA attribution enums (SlackButtonChoices, SlackTabChoices, TeamsButtonChoices) and URL helpers
+- `optimo_analytics/docs/LoginCTA_AttributionTestingGuide.md` – CTA attribution testing scenarios
+- `optimo_analytics/docs/BackendMixpanelTestingGuideV2.md` – Survey lifecycle & MAP event testing scenarios
 
 Type gate policy:
 - Detect Python type checker in this order unless repo docs/CI differ:

--- a/plugins/mixpanel-analytics/skills/mixpanel-analytics/references/implementation.md
+++ b/plugins/mixpanel-analytics/skills/mixpanel-analytics/references/implementation.md
@@ -342,6 +342,29 @@ properties = MxpNewEventSchema(
 )
 ```
 
+## CTA Attribution Context (Login Events)
+
+Login/session events include CTA attribution fields in `MixpanelSessionContextSchema`:
+
+| Field | Source | Values |
+|---|---|---|
+| `login_source` | `LoginSourceChoices` | `slack`, `teams`, `email`, `direct` |
+| `login_source_detail` | `LoginSourceDetailChoices` | `weekly_digest`, `survey_complete`, etc. |
+| `magic_link_action` | `MagicLinkActionChoices` | `login`, `invite`, `signup`, `verify_email` |
+| `slack_button` | `SlackButtonChoices` | Button label from Slack CTA |
+| `slack_tab` | `SlackTabChoices` | `messages`, `home` |
+| `teams_button` | `TeamsButtonChoices` | Button label from Teams CTA |
+| `cta_parse_failed` | `bool` | `True` if source param parsing failed |
+
+All enums live in `optimo_core/models/login_attribution.py`.
+
+When implementing events that extend `MixpanelSessionContextSchema`, these fields
+are auto-populated from the auth token's session context — no manual wiring needed.
+
+Testing guides:
+- `optimo_analytics/docs/LoginCTA_AttributionTestingGuide.md`
+- `optimo_analytics/docs/BackendMixpanelTestingGuideV2.md`
+
 ## Post-Implementation Validations
 
 ```bash

--- a/plugins/mixpanel-analytics/skills/mixpanel-analytics/references/review.md
+++ b/plugins/mixpanel-analytics/skills/mixpanel-analytics/references/review.md
@@ -99,6 +99,16 @@ This file is referenced from `SKILL.md` to keep the main Skill short and portabl
 - [ ] New helper classes exported in `service/__init__.py`
 - [ ] Added to `__all__` list
 
+### 11. CTA Attribution Fields (P2)
+
+For events extending `MixpanelSessionContextSchema`:
+
+**MUST VERIFY**:
+- [ ] Attribution fields are NOT manually set (they flow from session context)
+- [ ] `login_source` uses `LoginSourceChoices` enum, not raw strings
+- [ ] `slack_button`/`teams_button` use their respective enum labels
+- [ ] Test scenarios cover attributed and non-attributed login paths
+
 ## Automated Checks
 
 ```bash


### PR DESCRIPTION
## Summary

- **login-cta-attribution-skill** (0.1.0 → 0.1.1): Fix stale references after PR [Django4Lyfe#2623](https://github.com/DiversioTeam/Django4Lyfe/pull/2623) moved CTA enums from `optimo_integrations/*/cta_choices.py` to `optimo_core/models/login_attribution.py`
- **mixpanel-analytics** (0.1.3 → 0.1.4): Add CTA attribution awareness — context gathering, implementation reference, and review checklist

## Changes

### login-cta-attribution-skill
- Remove deleted `cta_choices.py` file references from environment context gathering
- Update all import paths from `optimo_integrations.slack.cta_choices` / `optimo_integrations.teams.cta_choices` → `optimo_core.models`
- Rename `update_cta_url_with_button_info()` → `update_slack_cta_url_with_button_info()` / `update_teams_cta_url_with_button_info()`
- Consolidate Key Files table entries for Slack/Teams CTA enums into single canonical path
- Bump version 0.1.0 → 0.1.1

### mixpanel-analytics
- Add `optimo_core/models/login_attribution.py` and testing guides to context gathering
- Add CTA Attribution Context section to implementation reference (field table, auto-population note)
- Add CTA Attribution Fields review checklist (P2 severity)
- Bump version 0.1.3 → 0.1.4

### marketplace.json
- Sync versions for both plugins to match their `plugin.json`

## Test plan
- [x] No remaining `cta_choices` references in either skill (`grep -r` clean)
- [x] No remaining old function name references (`grep -r` clean)
- [x] All JSON files are valid (`python3 -m json.tool`)
- [x] `plugin.json` versions match `marketplace.json` for both plugins
- [x] Install updated plugins and invoke each skill to verify loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)