### PR TITLE
Improve skill posting protocols and enforce SKILL.md size guardrails

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "monty-code-review",
       "description": "Hyper-pedantic Django4Lyfe backend code review Skill (Monty's taste).",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "author": {
         "name": "Diversio Devs"
       },
@@ -87,7 +87,7 @@
     {
       "name": "process-code-review",
       "description": "Process code review findings - interactively fix or skip issues from monty-code-review output with status tracking.",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "author": {
         "name": "Diversio Devs"
       },

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - ".claude-plugin/**"
       - "plugins/**"
+      - "scripts/**"
       - ".github/workflows/validate-marketplace.yml"
   push:
     branches: [main]
     paths:
       - ".claude-plugin/**"
       - "plugins/**"
+      - "scripts/**"
       - ".github/workflows/validate-marketplace.yml"
 
 jobs:
@@ -19,6 +21,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Validate JSON and plugin consistency
         shell: bash
@@ -90,3 +94,9 @@ jobs:
 
           echo "All marketplace validation checks passed."
 
+      - name: Validate SKILL.md size budgets
+        shell: bash
+        env:
+          GITHUB_BEFORE: ${{ github.event.before }}
+        run: |
+          bash scripts/validate-skills.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,13 @@ When working in this repo, Claude Code should:
      wrapper that references the Skill by name). This ensures the plugin
      appears as a `/plugin-name:command` entry in Claude Code's slash command
      palette.
+   - **SKILL.md size and progressive disclosure guardrail (CI-enforced):**
+     - Keep each changed `SKILL.md` at or below 500 lines.
+     - Keep `SKILL.md` focused on activation workflow, priorities, and output shape.
+     - Move long procedures/examples into `references/*.md`.
+     - Move reusable command logic into `scripts/`.
+     - Keep references one level deep where possible.
+     - Run `bash scripts/validate-skills.sh` locally after Skill edits.
 
    - **SKILL.md YAML frontmatter:** Always quote string values in the YAML
      frontmatter that contain special characters (colons, brackets, commas,
@@ -423,6 +430,7 @@ marketplace), respond with instructions that avoid hardcoded paths:
 
 - [Agent Skills Standard](https://agentskills.io/specification)
 - [Agent Skills Best Practices](https://agentskills.io/best-practices)
+- [Claude Agent Skills Best Practices](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices)
 - [OpenAI Codex Skills](https://developers.openai.com/codex/skills)
 - [OpenAI Codex Skills (Install new skills)](https://developers.openai.com/codex/skills#install-new-skills)
 - [Claude Agent Skills Overview](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ To keep Skills portable across both OpenAI Codex and Claude Code:
 - Avoid `anthropic`/`claude` in Skill names and don’t include XML tags in `name`/`description` (Claude).
 - Keep `SKILL.md` reasonably small (≈<500 lines); move deep docs into `references/`.
 
+### SKILL.md Size Guardrail (CI-Enforced)
+
+To keep Skills reliable and LLM-friendly, treat `SKILL.md` as an orchestrator, not a dump:
+- Hard limit: each changed `SKILL.md` in a PR/push must stay at or below 500 lines (CI fails above this).
+- Keep only activation workflow, core priorities, and output contract in `SKILL.md`.
+- Move long procedures/examples into `references/*.md`.
+- Move reusable command logic into `scripts/`.
+- Keep reference depth shallow (one level deep where possible) for progressive disclosure.
+
+Run the guard locally before opening a PR:
+
+```bash
+bash scripts/validate-skills.sh
+```
+
+This default mode validates changed and untracked `SKILL.md` files in your working tree.
+Use `bash scripts/validate-skills.sh --all` for a full-repo audit.
+
 ## Working on Skills (LLM checklist)
 
 - Start with `AGENTS.md` (source of truth); `CLAUDE.md` only includes it.
@@ -492,6 +510,7 @@ echo "Done. Restart Codex and reinstall skills."
 
 - [Agent Skills Standard](https://agentskills.io/specification)
 - [Agent Skills Best Practices](https://agentskills.io/best-practices)
+- [Claude Agent Skills Best Practices](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices)
 - [OpenAI Codex Skills](https://developers.openai.com/codex/skills)
 - [OpenAI Codex Skills (Install new skills)](https://developers.openai.com/codex/skills#install-new-skills)
 - [Claude Agent Skills Overview](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview)

--- a/plugins/monty-code-review/.claude-plugin/plugin.json
+++ b/plugins/monty-code-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monty-code-review",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Hyper-pedantic Django4Lyfe backend code review Skill (Monty's taste).",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/monty-code-review/commands/code-review.md
+++ b/plugins/monty-code-review/commands/code-review.md
@@ -13,3 +13,6 @@ Focus order:
 4. Tests and regression coverage.
 5. Maintainability and smaller nits.
 
+If asked to post review comments to GitHub, apply the Skill's `GitHub Posting Protocol`
+(`MUST_*`, `SHOULD_*`, and `STEP_*` rules) from
+`skills/monty-code-review/references/github-posting-protocol.md` before posting.

--- a/plugins/monty-code-review/skills/monty-code-review/SKILL.md
+++ b/plugins/monty-code-review/skills/monty-code-review/SKILL.md
@@ -106,6 +106,20 @@ When this skill is active and you are asked to review a change or diff, follow t
      “needs tests”).
    - State whether you would “approve after nits”, “request changes”, or “approve as-is”.
 
+## GitHub Posting Protocol (When User Asks To Post Review Comments)
+
+When user intent includes posting comments/reviews to GitHub PRs, load and follow:
+
+- `references/github-posting-protocol.md`
+
+Non-negotiables:
+
+- Keep one authoritative top-level summary review.
+- Keep one inline anchor per root-cause cluster.
+- Run duplicate audits before and after posting.
+- Use slurped pagination (`--paginate --slurp`) for post-audit dedupe commands.
+- Treat pass condition as strict: both post-audit duplicate detector results must be empty.
+
 ## Output Shape, Severity Tags & Markdown File
 
 When producing a full review with this skill, you **must** write the review into a Markdown

--- a/plugins/monty-code-review/skills/monty-code-review/references/github-posting-protocol.md
+++ b/plugins/monty-code-review/skills/monty-code-review/references/github-posting-protocol.md
@@ -1,0 +1,84 @@
+# GitHub Posting Protocol (monty-code-review)
+
+Use this protocol only when user intent includes posting comments/reviews to a GitHub PR.
+
+## INPUTS_REQUIRED
+
+- `OWNER`
+- `REPO`
+- `PR`
+- `ME` (derive from `gh api user`)
+
+## RULES_MUST
+
+- `MUST_01`: keep one authoritative top-level summary review.
+- `MUST_02`: keep one inline anchor per root-cause cluster.
+- `MUST_03`: run dedupe audit before and after posting.
+- `MUST_04`: keep ascii/diagram content inside fenced `text` blocks.
+- `MUST_05`: if line anchor fails (`422`), fallback to file-level inline comment.
+
+## RULES_SHOULD
+
+- `SHOULD_01`: default inline comment cap is 5 unless user asks for more.
+- `SHOULD_02`: update existing review in place for formatting fixes; do not add extra summary comments.
+- `SHOULD_03`: avoid PR-level issue comments for meta status updates.
+
+## STEP_01_PRE_AUDIT
+
+```bash
+OWNER="<owner>"; REPO="<repo>"; PR="<pr_number>"
+ME="$(gh api user --jq '.login')"
+
+gh api "repos/$OWNER/$REPO/pulls/$PR/reviews" --paginate \
+  --jq ".[] | select(.user.login == \"$ME\") | {id, state, submitted_at}"
+gh api "repos/$OWNER/$REPO/pulls/$PR/comments" --paginate \
+  --jq ".[] | select(.user.login == \"$ME\") | {id, path, line, created_at}"
+gh api "repos/$OWNER/$REPO/issues/$PR/comments" --paginate \
+  --jq ".[] | select(.user.login == \"$ME\") | {id, created_at}"
+```
+
+## STEP_02_DRAFT
+
+- Prepare one review body with sections:
+  1. `What's great`
+  2. `Findings` (severity-tagged)
+  3. `Open questions` (optional)
+  4. `Validation`
+- Fence diagrams:
+
+```text
++--------+      +--------+
+| issue  | ---> | action |
++--------+      +--------+
+```
+
+## STEP_03_POST
+
+- Post review/comments once.
+- If partial failure occurs, audit current state and post only missing anchors.
+
+## STEP_04_POST_AUDIT
+
+```bash
+gh api "repos/$OWNER/$REPO/pulls/$PR/comments" --paginate --slurp \
+  | jq --arg me "$ME" '
+      map(if type == "array" then . else [.] end)
+      | flatten
+      | map(select(.user.login == $me))
+      | group_by([.path, (.line // -1), ((.body // "") | split("\n")[0])])
+      | map(select(length > 1) | {count: length, path: .[0].path, line: .[0].line, ids: map(.id)})
+    '
+```
+
+```bash
+gh api "repos/$OWNER/$REPO/issues/$PR/comments" --paginate --slurp \
+  | jq --arg me "$ME" '
+      map(if type == "array" then . else [.] end)
+      | flatten
+      | map(select(.user.login == $me))
+      | group_by(((.body // "") | split("\n")[0]))
+      | map(select(length > 1) | {count: length, first_line: ((.[0].body // "") | split("\n")[0]), ids: map(.id)})
+    '
+```
+
+Pass condition: both duplicate detector results are empty.

--- a/plugins/process-code-review/.claude-plugin/plugin.json
+++ b/plugins/process-code-review/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "process-code-review",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Process code review findings - interactively fix or skip issues from monty-code-review output",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/process-code-review/commands/process-review.md
+++ b/plugins/process-code-review/commands/process-review.md
@@ -17,5 +17,8 @@ Focus order:
 5. Update the review document with status markers.
 6. Summarize what was fixed vs skipped.
 
+If asked to post processed findings to GitHub PR comments, follow the Skill's
+`GitHub Review Comment Posting Mode` (`MUST_*`/`SHOULD_*`/`STEP_*` rules).
+
 If `--dry-run` is provided, show all issues without modifying files.
 If `--auto` is provided, apply all fixes without prompting (use with caution).

--- a/plugins/process-code-review/skills/process-code-review/SKILL.md
+++ b/plugins/process-code-review/skills/process-code-review/SKILL.md
@@ -316,3 +316,30 @@ The three-step workflow ensures:
 1. Thorough review generation
 2. Systematic fix application
 3. Pre-commit validation before any commit
+
+## GitHub Review Comment Posting Mode
+
+Use this mode only when the user explicitly asks to post processed findings to GitHub PR comments.
+
+### RULES_MUST
+
+- `MUST_01`: use one authoritative top-level review summary.
+- `MUST_02`: avoid redundant inline comments (one anchor per root-cause cluster).
+- `MUST_03`: run pre/post dedupe audit against both endpoints:
+  - `/pulls/{pr}/comments`
+  - `/issues/{pr}/comments`
+- `MUST_04`: keep diagrams/ascii blocks fenced in markdown.
+- `MUST_05`: if line anchor fails with `422`, fallback to file-level inline comment.
+
+### RULES_SHOULD
+
+- `SHOULD_01`: default inline comment cap is 5 unless user requests more.
+- `SHOULD_02`: prefer editing existing submitted review in place for formatting fixes.
+- `SHOULD_03`: do not post extra PR-level chatter comments.
+
+### STEP_CHECKLIST
+
+1. `STEP_01`: pre-audit existing reviews and comments by current user.
+2. `STEP_02`: map findings to non-overlapping anchor set.
+3. `STEP_03`: post review/comments once.
+4. `STEP_04`: run duplicate detector and delete redundant comments if any.

--- a/scripts/validate-skills.sh
+++ b/scripts/validate-skills.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+MAX_LINES="${SKILL_MAX_LINES:-500}"
+WARN_LINES="${SKILL_WARN_LINES:-450}"
+SCOPE="${1:-}"
+
+if [[ -n "${SCOPE}" && "${SCOPE}" != "--all" ]]; then
+  echo "Usage: bash scripts/validate-skills.sh [--all]"
+  exit 2
+fi
+
+SKILL_FILES=()
+if [[ "${SCOPE}" == "--all" ]]; then
+  while IFS= read -r skill_file; do
+    SKILL_FILES+=("${skill_file}")
+  done < <(find plugins -type f -name 'SKILL.md' | sort)
+else
+  skill_path_regex='^plugins/.+/SKILL\.md$'
+  changed_candidates=""
+  if [[ "${CI:-}" == "true" && -n "${GITHUB_BASE_REF:-}" ]]; then
+    base_ref="origin/${GITHUB_BASE_REF}"
+    if ! git rev-parse --verify "${base_ref}" >/dev/null 2>&1; then
+      git fetch --no-tags --depth=1 origin "${GITHUB_BASE_REF}" >/dev/null 2>&1 || true
+    fi
+    if ! git rev-parse --verify "${base_ref}" >/dev/null 2>&1; then
+      echo "::error::Unable to resolve base ref ${base_ref} for SKILL.md validation."
+      exit 1
+    fi
+    changed_candidates="$(git diff --name-only "${base_ref}...HEAD" | grep -E "${skill_path_regex}" || true)"
+  elif [[ "${CI:-}" == "true" && -n "${GITHUB_BEFORE:-}" && "${GITHUB_BEFORE}" != "0000000000000000000000000000000000000000" ]] && git rev-parse --verify "${GITHUB_BEFORE}" >/dev/null 2>&1; then
+    changed_candidates="$(git diff --name-only "${GITHUB_BEFORE}..HEAD" | grep -E "${skill_path_regex}" || true)"
+  elif [[ "${CI:-}" == "true" ]] && git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    changed_candidates="$(git diff --name-only HEAD~1..HEAD | grep -E "${skill_path_regex}" || true)"
+  else
+    changed_candidates="$(
+      {
+        git diff --name-only | grep -E "${skill_path_regex}" || true
+        git diff --cached --name-only | grep -E "${skill_path_regex}" || true
+        git ls-files --others --exclude-standard | grep -E "${skill_path_regex}" || true
+      } | sort -u
+    )"
+  fi
+
+  seen=" "
+  while IFS= read -r skill_file; do
+    [[ -z "${skill_file}" ]] && continue
+    case "${seen}" in
+      *" ${skill_file} "*) continue ;;
+    esac
+    seen="${seen}${skill_file} "
+    SKILL_FILES+=("${skill_file}")
+  done < <(printf '%s\n' "${changed_candidates}" | sort -u)
+fi
+
+if [[ "${#SKILL_FILES[@]}" -eq 0 ]]; then
+  if [[ "${SCOPE}" == "--all" ]]; then
+    echo "No SKILL.md files found under plugins/."
+  else
+    echo "No changed SKILL.md files detected."
+  fi
+  exit 0
+fi
+
+if [[ "${SCOPE}" == "--all" ]]; then
+  echo "Validating SKILL.md size budget for all skills (max=${MAX_LINES}, warn=${WARN_LINES})..."
+else
+  echo "Validating SKILL.md size budget for changed skills (max=${MAX_LINES}, warn=${WARN_LINES})..."
+fi
+
+has_error=0
+for skill_file in "${SKILL_FILES[@]}"; do
+  if [[ ! -f "${skill_file}" ]]; then
+    echo "::notice file=${skill_file}::Skipping missing SKILL.md path from diff set."
+    continue
+  fi
+
+  line_count="$(wc -l < "${skill_file}" | tr -d ' ')"
+
+  if (( line_count > MAX_LINES )); then
+    has_error=1
+    echo "::error file=${skill_file}::SKILL.md has ${line_count} lines (max ${MAX_LINES}). Move deep guidance to references/ and scripts/, keep SKILL.md focused on activation workflow and output contract."
+    continue
+  fi
+
+  if (( line_count > WARN_LINES )); then
+    echo "::warning file=${skill_file}::SKILL.md has ${line_count} lines (warn threshold ${WARN_LINES}). Consider splitting now to stay within the ${MAX_LINES}-line hard limit."
+  fi
+done
+
+if (( has_error )); then
+  cat <<'EOF'
+
+Skill size validation failed.
+How to fix:
+1. Keep SKILL.md as an orchestrator: when to use, priorities, and output shape.
+2. Move long procedures/examples to references/*.md.
+3. Move reusable command logic to scripts/.
+4. Keep references one level deep from SKILL.md.
+5. Re-run: bash scripts/validate-skills.sh
+EOF
+  exit 1
+fi
+
+echo "SKILL.md size validation passed."


### PR DESCRIPTION
## Summary

This PR improves skill-authoring quality and GitHub review-comment posting guidance across marketplace plugins. It introduces a CI-backed `SKILL.md` size guardrail, refactors heavy protocol content into a reference file for progressive disclosure, and keeps plugin metadata/versioning aligned.

### Key Features

| Feature | Description |
|---------|-------------|
| **GitHub posting protocol hardening (Monty)** | Adds a dedicated posting protocol reference and requires slurped pagination (`--paginate --slurp`) for duplicate audits. |
| **Process review posting mode** | Adds explicit `MUST_*` / `SHOULD_*` / `STEP_*` guidance for posting processed findings to PR comments. |
| **SKILL.md size guardrail (CI + local)** | Adds `scripts/validate-skills.sh` and wires it into workflow validation to enforce focused, LLM-friendly skills. |
| **Documentation + metadata alignment** | Updates `README.md` / `AGENTS.md` with progressive disclosure rules and syncs plugin versions in marketplace + manifests. |

## Validation Flow

```text
Author edits Skill docs
        |
        v
Run local check: bash scripts/validate-skills.sh
        |
        v
CI check: validate-marketplace.yml
  - plugin/marketplace consistency
  - changed SKILL.md size budget (<= 500 lines)
        |
        v
Merge-ready docs and plugin metadata
```

---

## Feature 1: Monty GitHub Posting Protocol via Reference File

What changed:
- Added `plugins/monty-code-review/skills/monty-code-review/references/github-posting-protocol.md`.
- Kept `SKILL.md` focused and converted protocol details into a referenced document.
- Updated command wrapper to point to the protocol reference.

Why this approach:
- Keeps `SKILL.md` concise for progressive disclosure and better model reliability.
- Centralizes posting behavior so duplicate-audit safeguards are clear and reusable.

Notable protocol details:
- Uses `--paginate --slurp` + flattening for dedupe audits.
- Audits both inline and issue comment endpoints.
- Requires strict empty-result pass condition for duplicate detectors.

---

## Feature 2: Process Code Review Posting Mode

What changed:
- Added "GitHub Review Comment Posting Mode" to `process-code-review` skill.
- Added command-level reminder to apply posting-mode rules when asked to post findings.

Why this approach:
- Makes posting behavior explicit for processed-review workflows.
- Reduces accidental comment duplication/noise by defining posting constraints.

---

## Feature 3: CI-Enforced SKILL.md Size Guardrail

What changed:
- Added executable script: `scripts/validate-skills.sh`.
- Added workflow step in `.github/workflows/validate-marketplace.yml`.
- Checkout depth set to full history for reliable branch-diff detection.

How it works:
- Default mode validates changed + untracked `SKILL.md` files.
- `--all` mode audits all skills in repo.
- CI mode supports PR (`GITHUB_BASE_REF`) and push (`GITHUB_BEFORE`) diff ranges.
- Emits clear remediation instructions when limits are exceeded.

---

## Feature 4: Docs + Version Metadata Sync

What changed:
- Added explicit guardrail guidance to `README.md` and `AGENTS.md`.
- Added Claude best-practice reference links alongside Agent Skills references.
- Synced plugin versions:
  - `monty-code-review`: `1.2.2` -> `1.2.3`
  - `process-code-review`: `0.1.2` -> `0.1.3`
  - mirrored in `.claude-plugin/marketplace.json`

---

## Files Changed

<details>
<summary>Marketplace / Workflow</summary>

- `.claude-plugin/marketplace.json` - synced plugin versions.
- `.github/workflows/validate-marketplace.yml` - added SKILL size validation step and full fetch depth.

</details>

<details>
<summary>Top-Level Docs</summary>

- `README.md` - added CI-enforced size guardrail guidance and commands.
- `AGENTS.md` - added skill-size/progressive-disclosure policy and updated references.

</details>

<details>
<summary>Monty Code Review Plugin</summary>

- `plugins/monty-code-review/.claude-plugin/plugin.json` - version bump.
- `plugins/monty-code-review/commands/code-review.md` - command references protocol doc.
- `plugins/monty-code-review/skills/monty-code-review/SKILL.md` - reduced protocol section to orchestrator-level guidance.
- `plugins/monty-code-review/skills/monty-code-review/references/github-posting-protocol.md` - full protocol spec.

</details>

<details>
<summary>Process Code Review Plugin</summary>

- `plugins/process-code-review/.claude-plugin/plugin.json` - version bump.
- `plugins/process-code-review/commands/process-review.md` - command reminder for posting mode.
- `plugins/process-code-review/skills/process-code-review/SKILL.md` - added posting-mode rules.

</details>

<details>
<summary>Scripts</summary>

- `scripts/validate-skills.sh` - changed/all-scope SKILL size validator with CI-aware branch detection.

</details>

## How to Test

```bash
# Validate changed/untracked skill files
bash scripts/validate-skills.sh

# Validate all skill files (expected to report existing legacy oversized skills)
bash scripts/validate-skills.sh --all

# Validate marketplace/plugin JSON format
jq empty .claude-plugin/marketplace.json
jq empty plugins/monty-code-review/.claude-plugin/plugin.json
jq empty plugins/process-code-review/.claude-plugin/plugin.json
```

### Manual Checks

1. Confirm `monty-code-review` references protocol file and the file contains slurped dedupe audits.
2. Confirm workflow includes `Validate SKILL.md size budgets` step.
3. Confirm plugin versions match `marketplace.json` for modified plugins.

## Notes

- No application/runtime behavior changes; this PR is configuration, documentation, and workflow policy.
- Existing oversized legacy skills remain visible via `--all` mode and can be remediated incrementally.
