### PR TITLE
Align marketplace skills with harness workflows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,8 +20,8 @@
     },
     {
       "name": "monty-code-review",
-      "description": "Hyper-pedantic Django4Lyfe backend code review Skill (Monty's taste).",
-      "version": "1.2.3",
+      "description": "Hyper-pedantic Django4Lyfe backend code review Skill with correctness-first, harness-aware findings (Monty's taste).",
+      "version": "1.2.4",
       "author": {
         "name": "Diversio Devs"
       },
@@ -31,8 +31,8 @@
     },
     {
       "name": "backend-pr-workflow",
-      "description": "Enforces Diversio backend ClickUp-linked PR workflow, branch naming, safe Django migrations, and downtime-safe schema changes.",
-      "version": "0.1.3",
+      "description": "Enforces Diversio backend ClickUp-linked PR workflow, branch naming, repo-local workflow docs, safe Django migrations, and downtime-safe schema changes.",
+      "version": "0.1.4",
       "author": {
         "name": "Diversio Devs"
       },
@@ -42,8 +42,8 @@
     },
     {
       "name": "backend-atomic-commit",
-      "description": "Pedantic backend pre-commit and atomic-commit Skill with an iterative convergence protocol (budgets + stuck detection), enforcing AGENTS.md, pre-commit hooks (including djlint), .security/* helpers, and Monty's backend taste without AI commit signatures.",
-      "version": "0.2.3",
+      "description": "Pedantic backend pre-commit and atomic-commit Skill with an iterative convergence protocol (budgets + stuck detection), enforcing AGENTS.md, repo-local docs, pre-commit hooks, .security/* helpers, and Monty's backend taste without AI commit signatures.",
+      "version": "0.2.4",
       "author": {
         "name": "Diversio Devs"
       },
@@ -64,8 +64,8 @@
     },
     {
       "name": "plan-directory",
-      "description": "Create and maintain structured plan directories with a master PLAN.md index and numbered task files (001-*.md) containing checklists, tests, and completion criteria. Includes backend-ralph-plan for RALPH loop execution.",
-      "version": "0.2.2",
+      "description": "Create and maintain structured plan directories with a master PLAN.md index, numbered task files, and required fresh-eyes validation. Includes backend-ralph-plan for RALPH loop execution.",
+      "version": "0.2.3",
       "author": {
         "name": "Diversio Devs"
       },
@@ -119,14 +119,14 @@
     },
     {
       "name": "repo-docs",
-      "description": "Generate and canonicalize repository documentation with quality-gate awareness. Create new docs or audit existing AGENTS.md/CLAUDE.md to enforce single-source-of-truth pattern.",
-      "version": "0.1.3",
+      "description": "Generate and canonicalize repository harness docs: short AGENTS.md maps, repo-local docs, quality-gate guidance, and minimal CLAUDE.md stubs.",
+      "version": "0.1.4",
       "author": {
         "name": "Diversio Devs"
       },
       "source": "./plugins/repo-docs",
       "category": "documentation",
-      "keywords": ["documentation", "agents-md", "readme", "claude-md", "architecture", "ascii-diagrams", "tech-stack", "canonicalize"]
+      "keywords": ["documentation", "agents-md", "readme", "claude-md", "architecture", "quality-gates", "runbooks", "canonicalize", "harness"]
     },
     {
       "name": "dependabot-remediation",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,10 @@ Claude Marketplace or other channels.
   so they can be reused across multiple repos without copy‑pasting.
 - Keep plugin manifests, marketplace definitions, and SKILL docs small, clear, and
   versioned.
+- For repository-documentation workflows, follow the harness mindset from
+  OpenAI's February 11, 2026 article "Harness engineering: leveraging Codex in
+  an agent-first world": short `AGENTS.md` maps, repo-local docs, and
+  mechanical guardrails over giant prose dumps.
 
 Key layout:
 
@@ -52,10 +56,11 @@ Key layout:
     - `skills/clickup-ticket/SKILL.md` – ClickUp ticket fetching, filtering, and creation Skill.
     - `commands/*.md` – Commands for reading, filtering, creating tickets, subtasks, multi-org.
   - `repo-docs/`
-    - `.claude-plugin/plugin.json` – plugin manifest for repository documentation generator.
-    - `skills/repo-docs-generator/SKILL.md` – comprehensive AGENTS.md/README.md/CLAUDE.md generator Skill.
-    - `commands/generate.md` – Generate new documentation from scratch.
-    - `commands/canonicalize.md` – Audit and fix existing docs (make AGENTS.md canonical, normalize CLAUDE.md).
+    - `.claude-plugin/plugin.json` – plugin manifest for repository harness docs generator.
+    - `skills/repo-docs-generator/SKILL.md` – repository harness docs generator Skill (short AGENTS.md map + repo-local docs).
+    - `skills/repo-docs-generator/references/*.md` – harness principles, templates, and generate/canonicalize playbooks.
+    - `commands/generate.md` – Generate new harness documentation from scratch.
+    - `commands/canonicalize.md` – Audit and fix existing docs (trim AGENTS.md, move deep detail into topic docs, normalize CLAUDE.md).
   - `backend-release/`
     - `.claude-plugin/plugin.json` – plugin manifest for Django4Lyfe release workflow.
     - `skills/release-manager/SKILL.md` – full release workflow management Skill.
@@ -121,6 +126,9 @@ When working in this repo, Claude Code should:
      wrapper that references the Skill by name). This ensures the plugin
      appears as a `/plugin-name:command` entry in Claude Code's slash command
      palette.
+   - After any substantive change to a Skill, command, or manifest, do a
+     fresh-eyes self-review of the changed files plus adjacent docs/metadata
+     and fix obvious issues before handing off.
    - **SKILL.md size and progressive disclosure guardrail (CI-enforced):**
      - Keep each changed `SKILL.md` at or below 500 lines.
      - Keep `SKILL.md` focused on activation workflow, priorities, and output shape.
@@ -396,12 +404,12 @@ marketplace), respond with instructions that avoid hardcoded paths:
     - `/clickup-ticket:create-subtask` – Add subtask to existing ticket
     - `/clickup-ticket:switch-org` – Switch between organizations
     - `/clickup-ticket:configure` – Set up defaults and cache
-  - `repo-docs` to generate and canonicalize repository documentation. Commands:
-    - `/repo-docs:generate [path]` – Generate new AGENTS.md, README.md, CLAUDE.md
-      from scratch with ASCII architecture diagrams and tech stack analysis.
-    - `/repo-docs:canonicalize [path]` – Audit existing docs across a repo: update
-      AGENTS.md to match current tooling (uv, .bin/*), merge CLAUDE.md content
-      into AGENTS.md, normalize all CLAUDE.md to minimal `@AGENTS.md` stubs.
+  - `repo-docs` to generate and canonicalize repository harness documentation. Commands:
+    - `/repo-docs:generate [path]` – Generate repository harness docs: a short
+      AGENTS.md map, README.md, CLAUDE.md stub, and focused repo-local docs.
+    - `/repo-docs:canonicalize [path]` – Audit existing docs across a repo:
+      trim bloated AGENTS.md files, move deep detail into topic docs, and
+      normalize all CLAUDE.md files to minimal `@AGENTS.md` stubs.
   - `backend-release` to manage the full release workflow for Django4Lyfe backend
     (Diversio monolith). Handles release PRs, date-based version bumping
     (YYYY.MM.DD), uv lock updates, and GitHub release publishing. Commands:
@@ -433,6 +441,7 @@ marketplace), respond with instructions that avoid hardcoded paths:
 - [Claude Agent Skills Best Practices](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices)
 - [OpenAI Codex Skills](https://developers.openai.com/codex/skills)
 - [OpenAI Codex Skills (Install new skills)](https://developers.openai.com/codex/skills#install-new-skills)
+- [Harness engineering: leveraging Codex in an agent-first world](https://openai.com/index/harness-engineering/)
 - [Claude Agent Skills Overview](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview)
 - [Claude Code Plugins](https://code.claude.com/docs/en/plugins)
 - [Plugin Marketplaces](https://code.claude.com/docs/en/plugin-marketplaces)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Use `bash scripts/validate-skills.sh --all` for a full-repo audit.
 - Ensure the skill directory name matches `name` and stays in kebab-case.
 - Add or update a corresponding `plugins/<plugin>/commands/*.md` entrypoint.
 - Keep `SKILL.md` focused; put deep docs in `references/` and helpers in `scripts/`.
+- After substantive edits, do a fresh-eyes self-review of the changed skill,
+  adjacent commands/docs, and version metadata, then fix obvious issues before
+  stopping.
 - If you change a plugin, bump its version in `plugins/<plugin>/.claude-plugin/plugin.json`
   and keep `.claude-plugin/marketplace.json` in sync.
 
@@ -62,6 +65,17 @@ Use `bash scripts/validate-skills.sh --all` for a full-repo audit.
 This repository hosts Diversio-maintained Agent Skills and plugin manifests so
 the same skills can be distributed via the Claude Code marketplace or other
 channels.
+
+## Documentation Philosophy
+
+The `repo-docs` plugin is now explicitly informed by OpenAI's February 11,
+2026 article [Harness engineering: leveraging Codex in an agent-first
+world](https://openai.com/index/harness-engineering/).
+
+The practical takeaway for this repo is:
+- Keep `AGENTS.md` as a short routing map, not a giant handbook.
+- Put durable detail in focused repo-local docs.
+- Treat repeated failures as harness gaps to encode in docs, wrappers, or CI.
 
 ## Repository Structure
 
@@ -140,9 +154,11 @@ agent-skills-marketplace/
 │   │       ├── switch-org.md
 │   │       ├── add-org.md
 │   │       └── refresh-cache.md
-│   ├── repo-docs/                     # Repository documentation generator
+│   ├── repo-docs/                     # Repository harness docs generator
 │   │   ├── .claude-plugin/plugin.json
-│   │   ├── skills/repo-docs-generator/SKILL.md
+│   │   ├── skills/repo-docs-generator/
+│   │   │   ├── SKILL.md
+│   │   │   └── references/           # Harness principles, templates, playbooks
 │   │   └── commands/
 │   │       ├── generate.md
 │   │       └── canonicalize.md
@@ -197,7 +213,7 @@ agent-skills-marketplace/
 | `process-code-review` | Process code review findings - interactively fix or skip issues from monty-code-review output with status tracking |
 | `mixpanel-analytics` | MixPanel tracking implementation and review Skill for Django4Lyfe optimo_analytics module with PII protection and pattern enforcement |
 | `clickup-ticket` | Create and manage ClickUp tickets directly from Claude Code or Codex with multi-org support, interactive ticket creation, subtasks, and backlog management |
-| `repo-docs` | Generate and canonicalize repository documentation (AGENTS.md, README.md, CLAUDE.md) with ASCII architecture diagrams and single-source-of-truth pattern |
+| `repo-docs` | Generate and canonicalize repository harness docs: short AGENTS.md maps, README.md, CLAUDE.md stubs, and focused repo-local docs for architecture, gates, and runbooks |
 | `backend-release` | Django4Lyfe backend release workflow - create release PRs, date-based version bumping (YYYY.MM.DD), and GitHub release publishing |
 | `dependabot-remediation` | Unified backend/frontend Dependabot remediation workflow: `.github/dependabot.yml` review/scaffold, backend waves, frontend triage/execute/release, and post-merge closure verification |
 | `terraform` | Terraform/Terragrunt workflows: atomic-commit quality gates and PR workflow checks |
@@ -307,8 +323,8 @@ Once plugins are installed:
    /clickup-ticket:switch-org                # Switch between organizations
    /clickup-ticket:add-org                   # Add a new organization
    /clickup-ticket:refresh-cache             # Force refresh cached data
-   /repo-docs:generate                       # Generate new AGENTS.md, README.md, CLAUDE.md
-   /repo-docs:canonicalize                   # Audit and fix existing docs (make AGENTS.md canonical)
+   /repo-docs:generate                       # Generate harness docs (AGENTS map + README + CLAUDE + focused docs)
+   /repo-docs:canonicalize                   # Audit and fix existing docs (trim AGENTS, normalize CLAUDE, add topic docs)
    /backend-release:check                    # Check what commits are pending release
    /backend-release:create                   # Create release PR with merge method
    /backend-release:publish                  # Publish GitHub release after PR merge

--- a/plugins/backend-atomic-commit/.claude-plugin/plugin.json
+++ b/plugins/backend-atomic-commit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "backend-atomic-commit",
-  "version": "0.2.3",
-  "description": "Pedantic backend pre-commit and atomic-commit Skill for Django/Optimo-style repos, enforcing local AGENTS.md, pre-commit hooks (including djlint), and Monty’s backend taste with an explicit fix-retry convergence protocol.",
+  "version": "0.2.4",
+  "description": "Pedantic backend pre-commit and atomic-commit Skill for Django/Optimo-style repos, enforcing local AGENTS.md, repo-local docs, pre-commit hooks, and Monty’s backend taste with an explicit fix-retry convergence protocol.",
   "author": {
     "name": "Diversio Devs"
   }

--- a/plugins/backend-atomic-commit/commands/atomic-commit.md
+++ b/plugins/backend-atomic-commit/commands/atomic-commit.md
@@ -32,8 +32,9 @@ Do everything the `/backend-atomic-commit:pre-commit` command would do, plus:
 - Use `CHECK_CACHE_BUST=1` only when explicitly requested or debugging.
 - Do **not** use TodoWrite to track gate results — report directly in output.
 - Propose a commit message that:
-  - Extracts the ticket ID from the branch name using local `AGENTS.md`
-    conventions (e.g. `clickup_<ticket_id>_...` → `<ticket_id>: Description`).
+  - Extracts the ticket ID from the branch name using the local repo harness
+    (`AGENTS.md` and linked workflow docs) conventions
+    (e.g. `clickup_<ticket_id>_...` → `<ticket_id>: Description`).
   - Contains **no** Claude/AI/plugin signature or footer.
 
 Your output should clearly state whether the commit is ready:

--- a/plugins/backend-atomic-commit/commands/commit.md
+++ b/plugins/backend-atomic-commit/commands/commit.md
@@ -30,8 +30,8 @@ Workflow:
      it as `[BLOCKING]` with the exact error + what was tried.
    - Do **not** use TodoWrite to track gate results — report directly in output.
 3. Verify atomicity of the staged diff (one coherent change).
-4. Propose a ticket-prefixed commit message (derived from the branch name per local
-   `AGENTS.md` rules) with **no AI signature**.
+4. Propose a ticket-prefixed commit message (derived from the branch name per
+   the local repo harness rules) with **no AI signature**.
 5. Create the commit:
    - `git commit -m "<message>"`
    - If commit-msg hooks fail, fix the cause and retry (do not silently bypass).

--- a/plugins/backend-atomic-commit/commands/pre-commit.md
+++ b/plugins/backend-atomic-commit/commands/pre-commit.md
@@ -7,7 +7,8 @@ Run your `backend-atomic-commit` Skill in **pre-commit** mode.
 Focus on:
 
 - Actively fixing the files in `git status` so they match backend `AGENTS.md`,
-  `.pre-commit-config.yaml`, `.security/*` helpers, and Monty's backend taste.
+  linked repo-local docs, `.pre-commit-config.yaml`, `.security/*` helpers,
+  and Monty's backend taste.
 - Eliminating local imports, debug statements, PII-in-logs issues, and obvious
   type-hint problems.
 - Running the following checks in order:

--- a/plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md
+++ b/plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backend-atomic-commit
-description: "Pedantic backend pre-commit + atomic-commit skill for Django/Optimo repos that enforces local repo rules, pre-commit hooks, and security helpers (no AI signatures in commit messages)."
+description: "Pedantic backend pre-commit + atomic-commit skill for Django/Optimo repos that enforces local AGENTS.md, repo-local docs, pre-commit hooks, and security helpers (no AI signatures in commit messages)."
 allowed-tools: Bash Read Edit Glob Grep
 ---
 
@@ -13,7 +13,7 @@ backend) when you want:
 
 - `/backend-atomic-commit:pre-commit` – to **actively fix** the current code
   (formatting, imports, type hints, logging, etc.) so that it matches:
-  - Local `AGENTS.md` / `CLAUDE.md` rules.
+  - Local `AGENTS.md`, linked repo-local docs, and quality gates.
   - `.pre-commit-config.yaml` expectations.
   - `.security/` diff helpers (ruff and local imports).
   - Monty’s backend taste.
@@ -25,38 +25,11 @@ backend) when you want:
 - `/backend-atomic-commit:commit` – to run `atomic-commit`, then **create the
   commit** once all gates are green (no bypassing commit-msg hooks).
 
-## Example Prompts
-
-- “Run `/backend-atomic-commit:pre-commit` on this repo and actively fix all
-  files in `git status` so they obey backend `AGENTS.md`, `.pre-commit-config.yaml`,
-  `.security/*` helpers, and Monty’s taste (no local imports, strong typing,
-  structured logging). Then summarize what you changed and what’s still
-  `[BLOCKING]`.”
-- “Use `/backend-atomic-commit:atomic-commit` to prepare an atomic commit for
-  the staged changes in `backend/`. Enforce all pre-commit hooks and
-  `.security` scripts, run Ruff, active type gate checks, Django checks, and relevant pytest
-  subsets, then propose a ticket-prefixed commit message with **no AI
-  signature** and clearly mark any `[BLOCKING]` issues.”
-- “Treat my current backend changes as one logical bugfix and run
-  `/backend-atomic-commit:pre-commit` in a strict mode: eliminate local
-  imports, fix type hints (no `Any`, no string-based annotations), clean up
-  debug statements, and ensure Ruff, `.security/local_imports_pr_diff.sh`,
-  active type gate checks, and Django checks are happy."
-- “Before I commit these `optimo_*` changes, run
-  `/backend-atomic-commit:atomic-commit --auto` to:
-  - enforce structured logging with `TypedDict` payloads,
-  - ensure no PII in logs,
-  - verify tests and `.security/*` scripts,
-  and then tell me whether the commit is ready and what the commit message
-  should be.”
-- “Use `/backend-atomic-commit:commit` to run all gates on my staged changes,
-  then create the commit once everything is green. If something fails, keep
-  fixing and re-running until it commits or you have a clear `[BLOCKING]`
-  reason it can’t.”
+Representative prompt shapes live in `references/usage-examples.md`.
 
 If you’re not in a backend repo (no `manage.py`, no backend-style `AGENTS.md`,
-no `.pre-commit-config.yaml`), this Skill should say so explicitly and fall
-back to a lighter “generic Python pre-commit” behavior.
+no `.pre-commit-config.yaml`, no backend quality docs), this Skill should say
+so explicitly and fall back to a lighter “generic Python pre-commit” behavior.
 
 ## Modes
 
@@ -95,8 +68,9 @@ Emulate Monty’s backend engineering and review taste, tuned for pre-commit:
    try/except blocks, hidden PII, or untyped payloads.
 3. **Atomic commits** – one commit should represent one coherent change; split
    unrelated work.
-4. **Local repo rules first** – treat `AGENTS.md` and `CLAUDE.md` as the source
-   of truth when present; this Skill is a default baseline.
+4. **Local harness first** – treat `AGENTS.md` as the canonical entrypoint,
+   follow linked repo-local docs and directory-scoped `AGENTS.md` files for
+   per-topic truth, and do not treat `CLAUDE.md` as a unique rule source.
 5. **Tooling alignment** – use uv wrappers, `.security/*` helpers, and
    `.pre-commit-config.yaml` hooks as documented, not ad-hoc commands.
 6. **Type and structure** – prefer precise type hints, `TypedDict`/dataclasses,
@@ -118,10 +92,15 @@ When this Skill runs, you should first gather context using `Bash`, `Read`,
   - `git diff --cached --name-only`
   - `git log --oneline -10`
 - Repo configuration:
-  - Read `AGENTS.md` and `CLAUDE.md` (if present) for repo-specific rules.
-  - If they’re missing or obviously stale, recommend generating/canonicalizing
-    them so linting/workflow rules are persistent (AGENTS.md canonical, CLAUDE.md
-    as a minimal stub that sources it).
+  - Read `AGENTS.md` first for repo-specific rules and doc routing.
+  - Load any linked repo-local docs relevant to the changed files, especially
+    quality gates, runbooks, architecture docs, and directory-scoped
+    `AGENTS.md` files.
+  - If `CLAUDE.md` exists, treat it as a pointer to `AGENTS.md`, not as a
+    source of unique behavioral rules.
+  - If the harness is missing or obviously stale, recommend generating or
+    canonicalizing docs via the `repo-docs` plugin so rules stop living in
+    tribal knowledge.
   - Detect `.pre-commit-config.yaml`.
   - Detect `.security/` scripts, especially:
     - `./.security/gate_cache.sh`
@@ -327,190 +306,19 @@ In **both** `pre-commit` and `atomic-commit` modes, follow this pipeline:
    results directly in the final output using the existing severity-tagged
    sections (`Checks run`, `Needs changes`, etc.).
 
-## Monty Backend Taste – Auto-Fix Rules
+## Backend Fix Rules
 
-When running in `pre-commit` mode, you are allowed and expected to **actively
-edit code** to align with Monty’s backend taste where it is clearly safe. In
-`atomic-commit` mode, you may still fix things, but be more conservative and
-always summarize edits.
+When you need concrete auto-fix heuristics, load:
 
-### Imports & local imports
+- `references/backend-taste-and-fix-rules.md`
 
-- Enforce **no local imports at any cost**:
-  - Avoid `from myapp.models import MyModel` inside functions or methods just
-    to dodge cyclic imports.
-  - Use `.security/local_imports_pr_diff.sh` as the first line of defense.
-  - Prefer:
-    - Module-level imports.
-    - Refactoring helpers to avoid cycles.
-    - Type-only imports (e.g. `from __future__ import annotations`) when needed.
-  - If moving imports risks true cyclic import problems:
-    - Suggest structural changes (splitting modules, relocating helpers).
-    - Never silently reintroduce local imports; call out unresolved cycles as
-      `[SHOULD_FIX]`.
+Use that reference when actively editing backend code, templates, logging,
+types, tests, migrations, or other recurring lint targets. It contains the
+safe-fix guidance that used to live inline here.
 
-### Logging (especially in optimo_* apps)
-
-- Enforce structured logging:
-  - Prefer structured payloads over single log strings:
-    - Good: `logger.info("optimo_event", extra={"company_uuid": str(company.uuid)})`.
-    - Avoid: `logger.info("Company %s did %s", company.name, something)`.
-  - In `optimo_*` apps, treat unstructured logging as at least `[SHOULD_FIX]`.
-- PII in logs:
-  - Never log PII such as `assignment.employee.email`; this is enforced by
-    pre-commit hooks already, but you should also conceptually check.
-  - Prefer logging UUIDs/IDs instead of emails or names.
-- Log levels:
-  - Avoid `logger.exception` for expected error paths; use `error` or `warning`
-    with explicit messages.
-
-### Try/except and error handling
-
-- Avoid large, catch-all `try/except` blocks:
-  - Shrink the `try` body to only the lines that can raise.
-  - Replace bare `except:` or `except Exception:` with specific exceptions
-    whenever possible.
-- Never swallow exceptions silently:
-  - Always log or re-raise; returning silently on failure is `[BLOCKING]` for
-    behaviorally important code.
-- Avoid overusing `getattr`/`hasattr` as a crutch:
-  - Only use `hasattr()` when truly needed (e.g. cross-version adapters) and
-    document why.
-
-### Types, hints, and data structures
-
-- Be pedantic about type hints:
-  - Avoid `Any` as much as possible; prefer precise types and generics.
-  - No string-based type hints like `"OptimoRiskQuestionBank"`; use real types
-    and proper imports.
-  - Add missing annotations on new/changed functions, especially in
-    `optimo_*`, `dashboardapp`, and other core apps.
-- Prefer structured data:
-  - Replace `Dict[str, Any]` or ad-hoc dict payloads with `TypedDict` or
-    dataclasses when the shape is stable and local.
-  - Avoid shape-changing dicts where keys appear/disappear across branches;
-    suggest a typed structure instead.
-
-### Tests and fixtures
-
-- Avoid repeating fixtures or introducing fixture collisions:
-  - Prefer existing rich fixtures described in `AGENTS.md` (e.g. `responses`
-    in survey tests, company/survey fixtures that respect multi-tenant
-    relationships).
-  - Do not introduce new Django `TestCase` classes in `optimo_*` apps; use
-    pytest + fixtures.
-  - Watch for multi-tenant fixture mismatches (e.g. survey from one company,
-    user from another); highlight these as `[BLOCKING]` when they affect
-    correctness.
-- When touching tests:
-  - Prefer pytest fixtures and helper factories.
-  - Avoid local imports inside tests; use module-level imports.
-
-### ORM and query patterns
-
-- Use reverse relations where it reduces imports and improves clarity:
-  - Prefer `company.surveys.all()` to `Survey.objects.filter(company=company)`
-    when it avoids extra imports and is idiomatic.
-- Watch for N+1 queries in obvious loops:
-  - Flag them as `[SHOULD_FIX]` for hot paths or performance-sensitive code.
-
-### Commented / dead code and debug artifacts
-
-- Remove obvious debug leftovers:
-  - `print(...)`, `pdb.set_trace()`, `ipdb.set_trace()`, `breakpoint()` in
-    non-test code.
-- Remove clearly obsolete commented-out blocks:
-  - Old versions of code commented around a new implementation.
-- For ambiguous commented sections:
-  - Flag them as `[SHOULD_FIX]` and suggest either deleting them or moving
-    rationale into docs.
-- `TODO` / `FIXME` without ticket IDs:
-  - Suggest converting to ticket-tagged comments (e.g. `TODO(GH-123): ...` or
-    `TODO(27pfu0): ...`) or moving the note into ClickUp.
-
-### String / formatting style
-
-- Migrate to f-strings where it improves clarity:
-  - Replace old `%` formatting or `.format()` with f-strings when not blocked
-    by translation/i18n constraints.
-- Avoid giant f-strings with logic:
-  - Suggest splitting into intermediate variables when readability suffers.
-
-### Django templates and djlint
-
-- Treat template lint failures (djlint + template pre-commit hooks) as
-  first-class problems, not “formatting nits”. In `atomic-commit` mode, they
-  are usually `[BLOCKING]`.
-- Common djlint blockers (fix patterns):
-  - **Inline styles** (`style="..."`):
-    - Prefer CSS classes / existing utility frameworks.
-    - If new styling is required, add it via the repo’s normal CSS pipeline
-      (not ad-hoc inline styles).
-  - **Unnamed endblocks**:
-    - If templates use named blocks, always close them with the name:
-      - `{% block content %} ... {% endblock content %}`
-    - Do not leave bare `{% endblock %}` when the repo’s linting expects names.
-- Workflow:
-  - After any template edit, run the relevant template hooks (or `djlint --lint
-    --check <file>` when that’s what the repo uses), fix, and re-run until
-    clean.
-  - If hooks auto-reformat templates, accept the changes and restage the file.
-- Optional acceleration (Claude Code):
-  - Recommend an `afterEdit` hook for `*.html` in `.claude/settings.json` to run
-    djlint on the edited file, using the repo's wrapper (`.bin/djlint`, `uv run
-    djlint`, etc.) when available.
-- Configuration discovery:
-  - Look for `[tool.djlint]` in `pyproject.toml` or a standalone `.djlintrc`
-    file for project-specific settings (profile, indent, max_line_length,
-    custom rules, ignored rules). Respect these when they exist.
-  - If no djlint config is found but djlint hooks are in
-    `.pre-commit-config.yaml`, note this as `[SHOULD_FIX]` — the project
-    should have explicit djlint configuration to avoid ambiguity.
-- Reformat-first protocol:
-  - Always run `djlint --reformat` (or the repo's reformat hook) **before**
-    running `djlint --lint --check`. Reformatting resolves most lint issues
-    automatically.
-  - After reformatting, re-stage the modified templates (`git add <file>`)
-    before running the lint check.
-  - If the lint check still fails after a fresh reformat, the remaining errors
-    are structural (missing attributes, banned patterns) and must be fixed by
-    hand.
-
-### Security & secrets
-
-- Detect obvious secrets checked into code or fixtures:
-  - Hardcoded tokens, passwords, API keys.
-  - Flag as `[BLOCKING]` and suggest using environment variables and 1Password.
-- Avoid staging obvious secret-heavy files:
-  - `.env`, `google_creds.json`, `google_drive_creds.json`, etc.
-  - Recommend un-staging and `.gitignore` updates where appropriate.
-
-### Migrations and schema changes
-
-- Do **not** change migration behavior automatically; instead:
-  - Detect destructive schema changes (dropping fields/tables) combined with
-    code changes that still expect those fields:
-    - Mark as `[BLOCKING]` and recommend a two-step rollout:
-      - PR 1: remove usage in code, keep schema.
-      - PR 2: drop the field/table once code is clean.
-  - Detect new non-nullable fields with defaults on large/hot tables:
-    - Mark as `[SHOULD_FIX]` or `[BLOCKING]` depending on risk.
-    - Suggest the safer pattern:
-      - Add nullable field with no default.
-      - Backfill in batches.
-      - Then add default for new rows only.
-  - Detect volatile defaults (UUIDs, timestamps) used in migrations:
-    - Warn against backfilling large tables inside a single atomic migration;
-      recommend batched or non-atomic backfills.
-
-### Critical backend patterns from AGENTS.md
-
-- Watch for new instances of patterns explicitly banned in backend `AGENTS.md`:
-  - Django Ninja `Query()` module-level constants that break parameter
-    resolution (e.g. `Q_INCLUDE_INACTIVE = Query(False, ...)`).
-  - Legacy survey models like `OptimoEmployeeSurvey` or `employee_survey`.
-  - Any other CRITICAL warnings spelled out in that file.
-- Treat any new usage of these patterns as `[BLOCKING]`.
+If you discover a recurring failure that is hard to infer from the repo
+harness, emit a `[SHOULD_FIX]` follow-up recommending a docs, wrapper, or CI
+improvement instead of letting the rule stay tribal.
 
 ## Atomic-Commit Mode – Extra Strictness
 
@@ -627,6 +435,7 @@ Output shape for both modes:
   - `What’s aligned`
   - `Needs changes`
   - `Checks run`
+  - `Harness follow-ups` (only when docs/tooling should be improved)
   - `Proposed commit` (only in atomic-commit mode)
 
 Be direct, specific, and actionable in each bullet, pointing to file/area and
@@ -635,9 +444,5 @@ phrases when you can be precise.
 
 ## Compatibility Notes
 
-This Skill is designed to work with both Claude Code and OpenAI Codex.
-
-- Claude Code: install the corresponding plugin and use its slash commands (see `plugins/backend-atomic-commit/commands/`).
-- Codex: install the Skill directory and invoke `name: backend-atomic-commit`.
-
-For installation, see this repo's `README.md`.
+Works in both Claude Code and OpenAI Codex. For installation, see this repo's
+`README.md`.

--- a/plugins/backend-atomic-commit/skills/backend-atomic-commit/references/backend-taste-and-fix-rules.md
+++ b/plugins/backend-atomic-commit/skills/backend-atomic-commit/references/backend-taste-and-fix-rules.md
@@ -1,0 +1,86 @@
+# Backend Taste And Fix Rules
+
+Load this file when you are actively fixing backend code and need concrete
+heuristics beyond the main workflow in `SKILL.md`.
+
+## Imports And Local Imports
+
+- Enforce **no local imports at any cost**:
+  - Avoid `from myapp.models import MyModel` inside functions or methods just
+    to dodge cyclic imports.
+  - Use `./.security/local_imports_pr_diff.sh` as the first line of defense.
+  - Prefer module-level imports, refactoring helpers to avoid cycles, and
+    type-only imports where needed.
+  - If moving imports risks a real cycle, suggest structural changes and do not
+    silently reintroduce local imports.
+
+## Logging
+
+- Prefer structured payloads over single log strings.
+- In `optimo_*` apps, treat unstructured logging as at least `[SHOULD_FIX]`.
+- Never log PII such as employee emails; prefer UUIDs/IDs instead.
+- Avoid `logger.exception` for expected error paths; use explicit `warning` or
+  `error` messages.
+
+## Try/Except And Error Handling
+
+- Shrink large catch-all `try/except` blocks to the smallest raisable region.
+- Replace bare `except:` / `except Exception:` with specific exceptions when
+  possible.
+- Never swallow exceptions silently in behaviorally important code.
+- Avoid `getattr`/`hasattr` as a “just in case” crutch.
+
+## Types And Data Structures
+
+- Avoid `Any` when a precise type is available.
+- Avoid string-based type hints; arrange imports so real types can be used.
+- Add missing annotations on new/changed functions in core apps.
+- Replace stable-shape dict payloads with `TypedDict` or dataclasses when
+  reasonable.
+
+## Tests, Fixtures, And ORM Patterns
+
+- Prefer existing rich fixtures documented in `AGENTS.md` or linked test docs.
+- Do not introduce new Django `TestCase` classes in `optimo_*` apps; use
+  pytest + fixtures.
+- Treat multi-tenant fixture mismatches as correctness bugs.
+- Watch for N+1 loops and use reverse relations when they improve clarity.
+
+## Debug Artifacts And Commented Code
+
+- Remove `print(...)`, `pdb.set_trace()`, `ipdb.set_trace()`, and
+  `breakpoint()` from non-test code.
+- Remove clearly obsolete commented-out blocks.
+- Flag ambiguous commented sections or ticket-less `TODO` / `FIXME` notes as
+  `[SHOULD_FIX]`.
+
+## Templates And djlint
+
+- Treat template lint failures as first-class issues. In `atomic-commit` mode
+  they are usually `[BLOCKING]`.
+- Reformat before lint/check.
+- Restage modified templates after reformatting.
+- Look for `[tool.djlint]` or `.djlintrc`; if hooks exist without config, note
+  that as `[SHOULD_FIX]`.
+- Common blockers:
+  - Inline styles should usually become CSS classes.
+  - Named blocks should close with named endblocks.
+
+## Security And Secrets
+
+- Flag hardcoded tokens, passwords, or API keys as `[BLOCKING]`.
+- Avoid staging obvious secret-heavy files such as `.env` or local creds JSON.
+
+## Migrations And Schema Changes
+
+- Do **not** change migration strategy automatically; instead detect and report:
+  - destructive drops combined with live code expectations,
+  - new non-nullable fields with defaults on large/hot tables,
+  - volatile defaults that imply heavy atomic backfills.
+- Recommend the safer nullable -> backfill -> default pattern when applicable.
+
+## Critical Patterns From Repo Docs
+
+- Watch for patterns explicitly banned in backend `AGENTS.md` or linked docs,
+  such as Django Ninja `Query()` module constants or legacy survey models.
+- Treat new usage of those patterns as `[BLOCKING]`.

--- a/plugins/backend-atomic-commit/skills/backend-atomic-commit/references/usage-examples.md
+++ b/plugins/backend-atomic-commit/skills/backend-atomic-commit/references/usage-examples.md
@@ -1,0 +1,22 @@
+# Usage Examples
+
+Representative user prompts for this skill:
+
+- “Run `/backend-atomic-commit:pre-commit` on this repo and actively fix all
+  files in `git status` so they obey backend `AGENTS.md`,
+  `.pre-commit-config.yaml`, `.security/*` helpers, and Monty’s taste.”
+- “Use `/backend-atomic-commit:atomic-commit` to prepare an atomic commit for
+  the staged changes in `backend/`. Enforce all hooks and checks, then propose
+  a ticket-prefixed commit message with no AI signature.”
+- “Treat my current backend changes as one logical bugfix and run
+  `/backend-atomic-commit:pre-commit` in a strict mode: eliminate local
+  imports, fix type hints, clean up debug statements, and ensure the active
+  gates are happy.”
+- “Before I commit these `optimo_*` changes, run
+  `/backend-atomic-commit:atomic-commit --auto` to enforce structured logging,
+  ensure no PII in logs, verify tests and `.security/*` scripts, and tell me
+  whether the commit is ready.”
+- “Use `/backend-atomic-commit:commit` to run all gates on my staged changes,
+  then create the commit once everything is green. If something fails, keep
+  fixing and re-running until it commits or you have a clear `[BLOCKING]`
+  reason it can’t.”

--- a/plugins/backend-pr-workflow/.claude-plugin/plugin.json
+++ b/plugins/backend-pr-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "backend-pr-workflow",
-  "version": "0.1.3",
-  "description": "Enforces Diversio backend ClickUp-linked PR workflow, branch naming, safe Django migrations, and downtime-safe schema changes.",
+  "version": "0.1.4",
+  "description": "Enforces Diversio backend ClickUp-linked PR workflow, branch naming, repo-local workflow docs, safe Django migrations, and downtime-safe schema changes.",
   "author": {
     "name": "Diversio Devs"
   }

--- a/plugins/backend-pr-workflow/commands/check-pr.md
+++ b/plugins/backend-pr-workflow/commands/check-pr.md
@@ -10,8 +10,8 @@ workflow aspects:
 - Correct base branch for normal vs hotfix releases.
 - PR description quality and self-review checklist completion.
 - Django migrations cleanup and downtime-safe schema changes.
+- Repo-local workflow docs / harness clarity when rules are non-obvious.
 
 Report findings with `[BLOCKING]`, `[SHOULD_FIX]`, and `[NIT]` tags as defined
 in the Skill, and give a succinct summary verdict for whether the PR is
 workflow-ready to merge.
-

--- a/plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md
+++ b/plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backend-pr-workflow
-description: "Pedantic backend PR workflow skill enforcing ClickUp-linked branch/PR naming, PR hygiene, safe Django migrations, and downtime-safe schema changes."
+description: "Pedantic backend PR workflow skill enforcing ClickUp-linked branch/PR naming, repo-local workflow docs, safe Django migrations, and downtime-safe schema changes."
 allowed-tools: Read Bash Glob Grep
 ---
 
@@ -17,9 +17,11 @@ Use this Skill whenever you are:
 - Planning a release or hotfix and want to ensure the workflow (branches, tags,
   and migrations) is correct and downtime-safe.
 
-If local `AGENTS.md` / `CLAUDE.md` in the target repo conflict with anything
-here, **treat those files as the source of truth** and use this Skill as the
-default baseline.
+If the target repo has its own harness docs, treat `AGENTS.md` as the
+canonical entrypoint and follow any linked workflow/release/migration docs or
+directory-scoped `AGENTS.md` files for per-topic truth. `CLAUDE.md` should be
+treated as a pointer, not as a unique rule source. This Skill is the default
+baseline when repo-local docs are absent or thin.
 
 ## Example Prompts
 
@@ -66,6 +68,14 @@ Before giving a full review, this Skill should gather:
 
 If any of these are missing or unclear, ask the user to provide them before
 doing a full workflow review.
+
+Before applying the checklist, inspect the repo harness:
+
+- Read `AGENTS.md` first.
+- Load linked workflow/release/runbook docs or relevant directory-scoped
+  `AGENTS.md` files when they exist.
+- If workflow rules are tribal knowledge or only implied by stale docs, emit a
+  `[SHOULD_FIX]` harness finding recommending a `repo-docs` update.
 
 ## Checklist 1 – ClickUp & Branch / PR Naming
 
@@ -176,8 +186,8 @@ If a PR targets the wrong base branch:
 - Emit `[BLOCKING]` and recommend the correct base, explaining whether the
   change belongs in `release` or should be a `master` hotfix.
 
-If the repo’s docs specify a different default (e.g. custom long-lived branches
-documented in `CLAUDE.md`), follow that instead.
+If the repo’s harness docs specify a different default (e.g. custom long-lived
+branches in `AGENTS.md` or a linked workflow doc), follow that instead.
 
 ## Checklist 3 – PR Description & Self-Review
 
@@ -305,7 +315,8 @@ If the PR clearly contains many iterative migrations for one feature, emit:
 When suggesting commands, align with the repo’s tooling:
 
 - For Django4Lyfe / Optimo, prefer:
-  - `uv run` / `.bin/django` wrappers as documented in `AGENTS.md` / `CLAUDE.md`.
+  - `uv run` / `.bin/django` wrappers as documented in `AGENTS.md` or linked
+    repo-local docs.
 
 This Skill should conceptually describe the migration cleanup steps, not hard
 code commands that may become outdated.
@@ -414,6 +425,8 @@ When invoked, this Skill should:
      requirements, not nice-to-haves.
    - Always provide specific, actionable corrections rather than vague
      guidance.
+   - When rules are missing from the repo harness, call that out explicitly as
+     a documentation/tooling problem, not just a one-off nit.
 
 ## Compatibility Notes
 

--- a/plugins/monty-code-review/.claude-plugin/plugin.json
+++ b/plugins/monty-code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "monty-code-review",
-  "version": "1.2.3",
-  "description": "Hyper-pedantic Django4Lyfe backend code review Skill (Monty's taste).",
+  "version": "1.2.4",
+  "description": "Hyper-pedantic Django4Lyfe backend code review Skill with correctness-first, harness-aware findings (Monty's taste).",
   "author": {
     "name": "Diversio Devs"
   }

--- a/plugins/monty-code-review/commands/code-review.md
+++ b/plugins/monty-code-review/commands/code-review.md
@@ -11,7 +11,7 @@ Focus order:
 2. API and contract changes (including migrations / schema changes).
 3. Performance in realistic hot paths.
 4. Tests and regression coverage.
-5. Maintainability and smaller nits.
+5. Harness gaps, maintainability, and smaller nits.
 
 If asked to post review comments to GitHub, apply the Skill's `GitHub Posting Protocol`
 (`MUST_*`, `SHOULD_*`, and `STEP_*` rules) from

--- a/plugins/monty-code-review/skills/monty-code-review/SKILL.md
+++ b/plugins/monty-code-review/skills/monty-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: monty-code-review
-description: "Hyper-pedantic Django code review skill emulating Monty's correctness-first, multi-tenant-safe review style."
+description: "Hyper-pedantic Django code review skill emulating Monty's correctness-first, multi-tenant-safe, harness-aware review style."
 allowed-tools: Bash Read Edit Glob Grep
 ---
 
@@ -39,6 +39,8 @@ Emulate Monty's backend engineering and review taste as practiced in this reposi
   if tests pass.
 - Testing as contracts: tests should capture business promises, realistic data,
   edge cases, and regressions.
+- Agent legibility matters: when a non-obvious invariant or workflow only lives
+  in tribal knowledge, weak docs and weak guardrails are part of the defect.
 
 Always prioritize issues in this order:
 
@@ -59,6 +61,8 @@ When this skill is active and you are asked to review a change or diff, follow t
 1. Understand intent and context
    - Read the PR description, ticket, design doc, or docstrings that explain what
      the code is supposed to do.
+   - Read `AGENTS.md` and any linked repo-local docs/specs/runbooks that define
+     architecture, invariants, or quality gates for the changed area.
    - Scan nearby modules/functions to understand existing patterns and helpers that
      this code should align with.
    - Note key constraints: input/output expectations (types, ranges, nullability),
@@ -182,8 +186,12 @@ Use these tags consistently:
     per-row queries).
   - Missing tests for critical branches or regression scenarios.
   - Confusing control flow or naming that obscures invariants or intent.
-- Type-check debt that is not currently breaking merge gates but should be
-  reduced before follow-up work.
+  - Missing or stale repo-local docs for non-obvious invariants, workflows, or
+    architecture boundaries that reviewers/agents need to infer correctly.
+  - Repeated review issues that should become docs, wrappers, lint rules, or
+    CI guardrails.
+  - Type-check debt that is not currently breaking merge gates but should be
+    reduced before follow-up work.
 - `[NIT]`
   - Docstring tone/punctuation, minor style deviations, f-string usage, import order.
   - Non-critical duplication that could be refactored later.
@@ -245,7 +253,14 @@ When scanning a file or function, run through these lenses:
    - **Exception:** Django migration files (`*/migrations/*.py`) do not require tests;
      focus test coverage on the models and business logic they represent instead.
 
-9. Migrations & schema changes
+9. Harness & legibility
+   - Are important repo rules discoverable from `AGENTS.md` and linked docs?
+   - If this code depends on subtle invariants, is there an obvious in-repo
+     place where that knowledge is documented?
+   - Do repeated failure patterns suggest a missing wrapper, lint, CI check, or
+     repo-docs update?
+
+10. Migrations & schema changes
    - Does the PR include Django model or migration changes? If so:
      - Avoid destructive changes (dropping fields/tables) in the same deploy where
        running code still expects those fields; prefer a two-step rollout:
@@ -417,35 +432,9 @@ when calling out violations.
 
 ## Examples
 
-### Example 1 – Full pedantic review
+For concrete prompt variants and output sketches, load:
 
-- **Preferred user prompt (explicit skill)**:  
-  “Use your `monty-code-review` skill to review this Django PR like Monty would, and be fully pedantic with your usual severity tags.”
-- **Also treat as this skill (shorthand prompt)**:  
-  “Review this Django PR like Monty would! ultrathink”
-- When you see either of these (or similar wording clearly asking for a Monty-style backend review), assume the user wants this skill and follow the instructions in this file.
-- **Expected output shape** (sketch):  
-  - Short intro paragraph summarizing the change and what you focused on.  
-  - `What’s great` with 3–7 bullets, e.g.:  
-    - `survey/models.py – nice use of transaction.atomic around export generation.`  
-  - `What could be improved` with bullets like:  
-    - `[BLOCKING] dashboardapp/views/v2/report.py:L120–L145 – queryset is missing organization scoping; this risks cross-tenant leakage. Add an explicit filter on organization and a test covering mixed-tenant data.`  
-    - `[SHOULD_FIX] pulse_iq/tasks.py:L60–L80 – potential N+1 when iterating over responses. Consider prefetching related objects or batching queries.`  
-    - `[NIT] utils/date_helpers.py:L30 – docstring could clarify how “current quarter” is defined; also missing newline at EOF.`  
-  - `Tests` section calling out what’s covered and what’s missing.  
-  - `Verdict` section, e.g. “Request changes due to blocking multi-tenant and test coverage issues.”
-
-### Example 2 – Quick / non-pedantic pass
-
-- **Preferred user prompt (explicit skill)**:  
-  “Use your `monty-code-review` skill to skim this PR and only flag blocking or should-fix issues; skip most nits.”
-- **Also acceptable shorthand**:  
-  “Review this Django PR like Monty would, but only call out blocking or should-fix issues; skip the tiny nits.”
-- **Expected behavior**:
-  - Follow the same workflow and priorities, but:
-    - Only emit `[BLOCKING]` and `[SHOULD_FIX]` items unless a nit is truly important to mention.
-    - In the intro or verdict, state that you intentionally suppressed most `[NIT]` items due to the requested lighter review.
-  - The structure (`What's great`, `What could be improved`, `Tests`, `Verdict`) stays the same; the difference is primarily in strictness and number of nits.
+- `references/review-examples.md`
 
 ## Compatibility Notes
 

--- a/plugins/monty-code-review/skills/monty-code-review/references/review-examples.md
+++ b/plugins/monty-code-review/skills/monty-code-review/references/review-examples.md
@@ -1,0 +1,29 @@
+# Review Examples
+
+## Full Pedantic Review
+
+- Preferred prompt:
+  - “Use your `monty-code-review` skill to review this Django PR like Monty
+    would, and be fully pedantic with your usual severity tags.”
+- Also treat as this skill:
+  - “Review this Django PR like Monty would! ultrathink”
+- Expected output sketch:
+  - Short intro paragraph summarizing the change and focus areas.
+  - `What’s great` with specific positive bullets.
+  - `What could be improved` with `[BLOCKING]`, `[SHOULD_FIX]`, and `[NIT]`
+    findings.
+  - `Tests` section calling out what’s covered and what’s missing.
+  - `Verdict` section stating approve/request-changes posture.
+
+## Quick / Non-Pedantic Pass
+
+- Preferred prompt:
+  - “Use your `monty-code-review` skill to skim this PR and only flag blocking
+    or should-fix issues; skip most nits.”
+- Also acceptable shorthand:
+  - “Review this Django PR like Monty would, but only call out blocking or
+    should-fix issues; skip the tiny nits.”
+- Expected behavior:
+  - Follow the same workflow and priorities.
+  - Suppress most `[NIT]` items unless they are unusually important.
+  - Keep the same output structure with a lighter strictness level.

--- a/plugins/plan-directory/.claude-plugin/plugin.json
+++ b/plugins/plan-directory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "plan-directory",
-  "version": "0.2.2",
-  "description": "Create and maintain structured plan directories with a master PLAN.md index and numbered task files (001-*.md) containing checklists, tests, and completion criteria. Includes backend-ralph-plan for RALPH loop execution.",
+  "version": "0.2.3",
+  "description": "Create and maintain structured plan directories with a master PLAN.md index, numbered task files, and required fresh-eyes validation. Includes backend-ralph-plan for RALPH loop execution.",
   "author": {
     "name": "Diversio Devs"
   }

--- a/plugins/plan-directory/commands/backend-ralph-plan.md
+++ b/plugins/plan-directory/commands/backend-ralph-plan.md
@@ -4,6 +4,10 @@ description: Create a structured plan with Ralph Wiggum Loop integration for bac
 
 Use your `backend-ralph-plan` Skill to create a plan directory with Ralph integration.
 
+This includes a required fresh-eyes audit before delivery: re-read the plan and
+RALPH prompt, then fix obvious dependency, blocker, quality-gate, or prompt
+clarity issues before handing it back.
+
 ## What This Creates
 
 1. **PLAN.md** - Task index with quality tracking tables

--- a/plugins/plan-directory/commands/plan.md
+++ b/plugins/plan-directory/commands/plan.md
@@ -4,6 +4,10 @@ description: Create or update a structured plan directory with master index and 
 
 Use your `plan-directory` Skill to create or maintain a structured project plan.
 
+Every create/update run must end with a fresh-eyes self-review of the plan so
+obvious gaps, ordering mistakes, hidden blockers, and weak tests are fixed
+before delivery.
+
 ## Modes
 
 - **Create:** Scaffold a new plan directory with `PLAN.md` and numbered task files.

--- a/plugins/plan-directory/skills/backend-ralph-plan/SKILL.md
+++ b/plugins/plan-directory/skills/backend-ralph-plan/SKILL.md
@@ -242,6 +242,8 @@ Before delivering:
 - [ ] RALPH-PROMPT.md has NO remaining `{{placeholders}}`
 - [ ] Execution order matches actual dependencies
 - [ ] Completion promise includes task count and slug
+- [ ] Fresh-eyes pass completed: task order, blockers, test gates, and prompt
+      instructions were re-read and obvious problems were fixed
 
 ## Example
 

--- a/plugins/plan-directory/skills/plan-directory/SKILL.md
+++ b/plugins/plan-directory/skills/plan-directory/SKILL.md
@@ -114,7 +114,20 @@ Each task file must include:
 - **Notes (optional):** Constraints, references, warnings.
 - **Blockers (optional):** Added when work is blocked; removed when unblocked.
 
-### 6. Maintain Progress
+### 6. Fresh-Eyes Review (Required)
+
+Before delivering a new or updated plan, read it again as if you did not write
+it and fix obvious issues immediately. Look for:
+
+- Missing or incorrect dependencies / execution order
+- Checklist items that are vague, oversized, or not verifiable
+- Tests that are missing, generic, or inconsistent with the task scope
+- Hidden blockers, assumptions, or locked decisions that were left implicit
+- Scope leaks where a task bundles unrelated work
+
+Do not wait for the user to ask for this pass. It is part of the skill.
+
+### 7. Maintain Progress
 
 As work completes:
 1. Check items in the task file's Checklist and Tests sections.

--- a/plugins/plan-directory/skills/plan-directory/references/advanced.md
+++ b/plugins/plan-directory/skills/plan-directory/references/advanced.md
@@ -19,6 +19,8 @@ Before delivering a plan, verify:
 - [ ] No task exceeds ~10 checklist items (split if needed).
 - [ ] Dependency graph has no cycles (task A can't depend on B if B depends on A).
 - [ ] Parallel-executable tasks are identified where applicable.
+- [ ] A fresh-eyes pass was completed: obvious ordering bugs, vague tasks,
+      hidden blockers, and missing tests were fixed before delivery.
 
 ## Parallel Task Execution
 
@@ -253,4 +255,3 @@ spawn a nested sub-plan:
 
 This keeps individual task files focused while allowing complex work to be
 properly structured.
-

--- a/plugins/repo-docs/.claude-plugin/plugin.json
+++ b/plugins/repo-docs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repo-docs",
-  "version": "0.1.3",
-  "description": "Generate and canonicalize repository documentation. Create new AGENTS.md/README.md/CLAUDE.md from scratch, or audit existing docs to make AGENTS.md canonical and normalize CLAUDE.md to minimal stubs.",
+  "version": "0.1.4",
+  "description": "Generate and canonicalize repository harness docs: short AGENTS.md maps, repo-local docs, preserved README.md content, and minimal CLAUDE.md stubs.",
   "author": {
     "name": "Diversio Devs"
   }

--- a/plugins/repo-docs/commands/canonicalize.md
+++ b/plugins/repo-docs/commands/canonicalize.md
@@ -1,18 +1,28 @@
 ---
-description: Audit and fix existing AGENTS.md/CLAUDE.md files - make AGENTS.md canonical, normalize CLAUDE.md to minimal stubs.
+description: "Audit and fix existing repo docs: trim AGENTS.md into a routing map, move deep detail into repo-local docs, and normalize CLAUDE.md to a stub."
 ---
 
 Use your `repo-docs-generator` Skill in **canonicalize** mode.
+
+This mode follows the harness model described in OpenAI's February 11, 2026
+article:
+- https://openai.com/index/harness-engineering/
+
+Default to `--dry-run` or a human confirmation checkpoint before broad,
+ambiguous, or repo-wide reshaping. Recursive canonicalization is high-impact
+steer-mode work, not blind queue-mode work.
 
 Recursively processes every directory with AGENTS.md and/or CLAUDE.md to:
 
 1. **Analyze** actual code/tooling behavior (uv, .bin/*, CI jobs)
 2. **Compare** existing docs against reality
-3. **Merge** valuable CLAUDE.md content into AGENTS.md
-4. **Rewrite** AGENTS.md with current commands and patterns
-5. **Encode** quality gates and common failure modes (pre-commit/djlint
-   “gotchas”, required commit message patterns) to reduce repetitive lint loops
-6. **Normalize** CLAUDE.md to minimal stub (`@AGENTS.md` + best-practices note)
+3. **Shrink** oversized AGENTS.md files into short routing maps
+4. **Move** durable detail into focused repo-local docs (`docs/quality/`,
+   `docs/architecture/`, `docs/runbooks/`, etc.)
+5. **Merge** valuable CLAUDE.md content into AGENTS.md or the right topic doc
+6. **Encode** quality gates and common failure modes so agents stop
+   rediscovering them
+7. **Normalize** CLAUDE.md to minimal stub (`@AGENTS.md`)
 
 **Arguments:**
 - `[path]` - Path to repository (defaults to `.` for current directory)
@@ -28,9 +38,11 @@ Recursively processes every directory with AGENTS.md and/or CLAUDE.md to:
 | `poetry install` / `poetry run` | `uv sync` / `uv run` |
 | `python manage.py` | `.bin/django` or `uv run python manage.py` |
 | `pytest` | `.bin/pytest` or `uv run pytest` |
+| giant AGENTS.md handbook | short AGENTS.md map + focused topic docs |
 
 **End state:**
-- All AGENTS.md files are canonical, current, and accurate
+- All AGENTS.md files are short, current, and act as canonical entrypoints
+- Deep detail lives in focused repo-local docs instead of bloated AGENTS files
 - All CLAUDE.md files are identical minimal stubs:
   ```markdown
   @AGENTS.md
@@ -49,4 +61,4 @@ Recursively processes every directory with AGENTS.md and/or CLAUDE.md to:
 /repo-docs:canonicalize --dry-run    # Preview only
 ```
 
-See the SKILL.md "Canonicalize Mode" section for detailed workflow.
+See the SKILL.md and references for the full canonicalization workflow.

--- a/plugins/repo-docs/commands/generate.md
+++ b/plugins/repo-docs/commands/generate.md
@@ -1,17 +1,20 @@
 ---
-description: Generate comprehensive AGENTS.md, README.md, and CLAUDE.md documentation for a repository.
+description: "Generate repository harness docs: short AGENTS.md map, README.md, CLAUDE.md stub, and repo-local docs that make the codebase legible to agents."
 ---
 
 Use your `repo-docs-generator` Skill in **generate** mode.
 
+This mode follows the harness model described in OpenAI's February 11, 2026
+article:
+- https://openai.com/index/harness-engineering/
+
 Analyzes the target repository to:
-- Identify tech stack (Python, JS/TS, Java, Go, Rust, Terraform, etc.)
-- Understand architecture patterns
-- Detect quality gates (pre-commit, linters/formatters, template tooling) and
-  document them so agents don’t rediscover failures at commit time
-- Create ASCII architecture diagrams (standard ASCII only, no Unicode)
-- Preserve existing documentation content
-- Generate three standardized files: AGENTS.md, README.md, CLAUDE.md
+- Identify actual commands, wrappers, CI, and quality gates
+- Build `AGENTS.md` as a short routing map instead of a giant manual
+- Preserve and refresh `README.md` for human readers
+- Normalize or create `CLAUDE.md` as a minimal `@AGENTS.md` stub
+- Add focused repo-local docs under `docs/` when complexity warrants it
+- Capture recurring failure modes as docs or explicit follow-up harness work
 
 **Arguments:**
 - `[path]` - Path to repository (defaults to `.` for current directory)
@@ -24,8 +27,10 @@ Analyzes the target repository to:
 ```
 
 **Output:**
-- AGENTS.md: Comprehensive architecture docs with ASCII diagrams
-- README.md: Enhanced with architecture overview (preserves existing)
+- AGENTS.md: Concise agent entrypoint and doc index
+- README.md: Human quickstart plus pointers to deeper docs
 - CLAUDE.md: Minimal file that sources AGENTS.md
+- docs/*: Architecture, quality, runbook, spec, or plan docs as needed
 
-See the SKILL.md for detailed workflow and ASCII diagram standards.
+See the SKILL.md and references for the harness workflow, doc layering rules,
+and optional ASCII diagram guidance.

--- a/plugins/repo-docs/skills/repo-docs-generator/SKILL.md
+++ b/plugins/repo-docs/skills/repo-docs-generator/SKILL.md
@@ -1,810 +1,205 @@
 ---
 name: repo-docs-generator
-description: "Generate comprehensive AGENTS.md, README.md, and CLAUDE.md documentation for any repository. Deep-dives into codebase structure, identifies technologies, creates ASCII architecture diagrams, and respects existing documentation content."
-allowed-tools: Bash Read Edit Write Grep Glob Task
+description: "Generate repository harness docs: a short AGENTS.md map, README.md, CLAUDE.md stub, and repo-local docs that make the codebase legible to agents."
+allowed-tools: Bash Read Edit Write Grep Glob
 argument-hint: "[path] (e.g., /path/to/repo or . for current directory)"
 ---
 
 # Repository Documentation Generator Skill
 
-Generates comprehensive, agent-friendly documentation (AGENTS.md, README.md, CLAUDE.md) for any software repository by analyzing its structure, technologies, and patterns.
+Build repository docs as an engineering harness, not a prose dump.
+
+This skill is aligned with OpenAI's February 11, 2026 harness-engineering
+article:
+- `AGENTS.md` should be a short routing map, not a giant manual.
+- Detailed knowledge should live in versioned, repo-local docs.
+- Repeated failures should become harness improvements: docs, wrappers, CI,
+  lints, or clearer error messages.
+- The goal is agent legibility and higher-quality autonomous work.
 
 ## When to Use This Skill
 
-- Setting up documentation for a new repository
-- Enhancing existing documentation with architecture diagrams
-- Creating standardized AGENTS.md files across an organization
-- Onboarding AI agents to understand a codebase
-- Documenting legacy codebases that lack proper documentation
-
-## Philosophy
-
-**Respect existing content.** Never blindly replace documentation that humans have written. Always:
-1. Read existing AGENTS.md, README.md, and CLAUDE.md files first
-2. Identify valuable content that must be preserved
-3. Enhance rather than replace when possible
-4. Ask for confirmation before making destructive changes
-
-## Core Workflow
-
-### Phase 1: Discovery
-
-Thoroughly explore the repository before writing anything:
-
-```bash
-# 1. Understand the repo structure
-find . -maxdepth 3 -type f -name "*.md" 2>/dev/null | head -20
-ls -la
-cat README.md 2>/dev/null || echo "No README.md"
-cat AGENTS.md 2>/dev/null || echo "No AGENTS.md"
-cat CLAUDE.md 2>/dev/null || echo "No CLAUDE.md"
-
-# 2. Identify the tech stack
-ls package.json pyproject.toml requirements.txt Cargo.toml go.mod build.gradle pom.xml Gemfile 2>/dev/null
-cat package.json 2>/dev/null | head -50
-cat pyproject.toml 2>/dev/null | head -50
-
-# 3. Find main entry points
-find . -maxdepth 2 -name "main.*" -o -name "index.*" -o -name "app.*" 2>/dev/null
-ls src/ app/ lib/ 2>/dev/null
-
-# 4. Identify the build/deploy system
-ls Dockerfile docker-compose.yml .github/workflows .circleci serverless.yml 2>/dev/null
-
-# 5. Check for existing documentation
-find . -maxdepth 2 -name "*.md" -type f 2>/dev/null
-
-# 6. Identify quality gates (pre-commit, linters, formatters)
-ls .pre-commit-config.yaml .pre-commit-config.yml 2>/dev/null
-rg -n "djlint|ruff|mypy|pyright|ty|eslint|prettier|black|isort" .pre-commit-config.yaml .pre-commit-config.yml pyproject.toml package.json 2>/dev/null | head -50
-```
-
-### Phase 2: Analysis
-
-Based on discovery, identify:
-
-1. **Repository Type**: Web app, API, CLI tool, library, infrastructure, scripts collection, etc.
-2. **Primary Language(s)**: Python, JavaScript, Java, Go, Rust, etc.
-3. **Framework(s)**: Django, React, Express, Spring, etc.
-4. **Architecture Pattern**: Monolith, microservices, serverless, etc.
-5. **Key Components**: What are the main modules/packages/services?
-6. **Data Storage**: PostgreSQL, MongoDB, Redis, S3, etc.
-7. **CI/CD**: GitHub Actions, CircleCI, Jenkins, etc.
-8. **Deployment**: Docker, Kubernetes, Lambda, Heroku, etc.
-
-### Phase 2.5: Quality Gates (High ROI)
-
-If the repo uses pre-commit and/or strict linters, treat them as the highest
-ROI documentation target. In AGENTS.md, explicitly document:
-
-- How to run the gates (preferred wrappers, scoped vs all-files behavior)
-- What the gates enforce (template rules, type checks, commit-msg conventions)
-- Type-gate detection and precedence for Python repos:
-  - `ty` first when configured, then `pyright`, then `mypy`
-  - `ty` is mandatory if configured
-  - no "baseline acceptable" language for touched files
-- “Gotchas” that repeatedly waste time (e.g., djlint inline styles, named
-  endblocks, date/time math that must be verified with code/tests)
-- Local typing policy docs if present (for example:
-  `docs/python-typing-3.14-best-practices.md`, `TY_MIGRATION_GUIDE.md`)
-
-### Phase 3: Documentation Generation
-
-#### AGENTS.md Structure (Required)
-
-```markdown
-# AGENTS.md — The [Project Name] Story
-
-*A guide for AI agents and humans alike. [One-sentence description of what this guide explains.]*
-
----
-
-## What This Repo Is
-
-**[Project Name]** is [brief description of what it does and why it exists].
-
-[Metaphor or analogy that captures its essence.]
-
-```
-[HIGH-LEVEL ASCII ARCHITECTURE DIAGRAM]
-```
-
----
-
-## Architecture Diagrams
-
-### [Subsystem 1] Architecture
-
-```
-[DETAILED ASCII DIAGRAM]
-```
-
-### [Subsystem 2] Architecture
-
-```
-[DETAILED ASCII DIAGRAM]
-```
-
----
-
-## Folder Structure
-
-```
-project/
-|
-+-- dir1/            # Description
-|       +-- file.ext   # Description
-+-- dir2/            # Description
-```
-
----
-
-## Technologies
-
-| Category | Technology | Purpose |
-|----------|------------|---------|
-| **Language** | ... | ... |
-| **Framework** | ... | ... |
-| **Database** | ... | ... |
-
----
-
-## Do
-
-- [Best practice 1]
-- [Best practice 2]
-- [Best practice 3]
-
-## Don't
-
-- Don't [anti-pattern 1]
-- Don't [anti-pattern 2]
-- Don't [anti-pattern 3]
-
----
-
-## Common Commands
-
-```bash
-# Development
-command1    # Description
-
-# Testing
-command2    # Description
-
-# Deployment
-command3    # Description
-```
-
----
-
-## The Hard Lessons
-
-### Lesson 1: [Title]
-
-[What happened]
-
-**The cause:** [Root cause]
-
-**The fix:** [Solution]
-
----
-
-## Quick Reference
-
-**[Category 1]:**
-```bash
-command
-```
-
-**[Category 2]:**
-```
-key info
-```
-
-**When in doubt:** [Most important advice]
-```
-
-#### ASCII Diagram Rules (Critical)
-
-**DO use these characters:**
-- Box corners: `+`
-- Horizontal lines: `-`, `=`
-- Vertical lines: `|`
-- Arrows: `>`, `<`, `v`, `^`, `---->`, `|`
-- Bullet points: `*`, `-`
-- Section dividers: `===`, `---`
-
-**DO NOT use:**
-- Unicode box-drawing characters (U+2500-U+257F): `─`, `│`, `┌`, `┐`, `└`, `┘`, `├`, `┤`, `┬`, `┴`, `┼`
-- Emojis in diagrams
-- Fancy Unicode arrows: `→`, `←`, `↓`, `↑`
-
-**Correct example:**
-```
-+------------------------------------------------------------------+
-|                         PROJECT NAME                              |
-+------------------------------------------------------------------+
-|                                                                   |
-|  +------------------+  +------------------+  +------------------+ |
-|  | COMPONENT A      |  | COMPONENT B      |  | COMPONENT C      | |
-|  | Description      |  | Description      |  | Description      | |
-|  +------------------+  +------------------+  +------------------+ |
-|                                                                   |
-+------------------------------------------------------------------+
-```
-
-**Flow diagram example:**
-```
-+----------------+     +----------------+     +----------------+
-| Input          |---->| Process        |---->| Output         |
-| (source)       |     | (transform)    |     | (result)       |
-+----------------+     +----------------+     +----------------+
-        |
-        | Annotated flow description
-        v
-+----------------+
-| Next Step      |
-+----------------+
-```
-
-#### README.md Strategy
-
-**If README.md exists:**
-1. Read it entirely
-2. Identify human-written content that must be preserved
-3. Add architecture overview at the TOP (after title)
-4. Add reference to AGENTS.md for detailed documentation
-5. Keep all existing sections intact
-6. Only add, don't remove
-
-**If README.md doesn't exist:**
-- Create a concise version with:
-  - Project name and description
-  - Architecture overview diagram
-  - Quick start instructions
-  - Reference to AGENTS.md for details
-
-#### CLAUDE.md Structure (Required)
-
-CLAUDE.md should be minimal and source AGENTS.md:
-
-```markdown
-@AGENTS.md
-
----
-
-## Notes
-
-This `CLAUDE.md` intentionally sources `AGENTS.md` so that requirements,
-commands, and agent behavior live in a single source of truth for this repo.
-
-For Claude Code best practices on `CLAUDE.md` / `AGENTS.md` in web-based repos,
-see:
-- https://docs.claude.com/en/docs/claude-code/claude-code-on-the-web#best-practices
-
-Relevant guidance (summarized):
-- Document requirements: clearly specify dependencies and commands for the
-  project.
-- If you have an `AGENTS.md` file, you can source it in your `CLAUDE.md` using
-  `@AGENTS.md` to maintain a single source of truth.
-```
-
-### Phase 4: Validation
-
-Before finalizing:
-
-1. **Verify ASCII diagrams render correctly** - No Unicode box characters
-2. **Check all paths exist** - Referenced files should exist
-3. **Validate commands** - Commands should be runnable
-4. **Confirm tech stack** - All mentioned technologies are actually used
-5. **Review against existing docs** - No valuable content was lost
-
-## Technology-Specific Patterns
-
-### Python Projects
-
-Look for:
-- `pyproject.toml`, `setup.py`, `requirements.txt`
-- `uv.lock`, `poetry.lock`, `Pipfile.lock`
-- Django: `manage.py`, `settings.py`, apps with `models.py`
-- Flask: `app.py`, `wsgi.py`
-- FastAPI: `main.py` with `FastAPI()` instance
-
-Common commands:
-```bash
-# uv-based
-uv run python ...
-uv sync
-
-# pip-based
-pip install -r requirements.txt
-python manage.py runserver
-
-# poetry-based
-poetry install
-poetry run python ...
-```
-
-### JavaScript/TypeScript Projects
-
-Look for:
-- `package.json`, `yarn.lock`, `package-lock.json`
-- `tsconfig.json` for TypeScript
-- React: `src/App.tsx`, `src/index.tsx`
-- Node.js: `server.js`, `index.js`
-- Vite: `vite.config.ts`
-- Next.js: `next.config.js`, `pages/` or `app/`
-
-Common commands:
-```bash
-npm install / yarn
-npm run dev / yarn dev
-npm run build / yarn build
-npm test / yarn test
-```
-
-### Java Projects
-
-Look for:
-- `pom.xml` (Maven), `build.gradle` (Gradle)
-- `src/main/java/`, `src/test/java/`
-- Spring Boot: `Application.java`, `application.properties`
-
-Common commands:
-```bash
-# Maven
-mvn clean install
-mvn spring-boot:run
-
-# Gradle
-./gradlew build
-./gradlew bootRun
-
-# Ant (legacy)
-ant build
-ant clean
-```
-
-### Infrastructure/Terraform
-
-Look for:
-- `*.tf` files
-- `modules/`, `environments/`
-- `terraform.tfvars`, `backend.tf`
-
-Common commands:
-```bash
-terraform init
-terraform plan
-terraform apply
-terraform fmt
-```
-
-### Serverless
-
-Look for:
-- `serverless.yml` (Serverless Framework)
-- `zappa_settings.json` (Zappa)
-- `sam.yaml` (AWS SAM)
-- `functions/` directory
-
-Common commands:
-```bash
-serverless deploy --stage dev
-serverless offline
-zappa deploy staging
-```
-
-## Output Shape
-
-When documentation is generated, report:
-
-```
-## Documentation Generated
-
-**Repository:** /path/to/repo
-**Type:** [Web App / API / Library / Infrastructure / Scripts]
-**Tech Stack:** [Primary technologies]
-
-### Files Created/Updated:
-
-| File | Action | Notes |
-|------|--------|-------|
-| AGENTS.md | Created/Updated | [summary] |
-| README.md | Enhanced/Created | [summary] |
-| CLAUDE.md | Created/Updated | Sources AGENTS.md |
-
-### Architecture Diagrams Included:
-
-1. [Diagram name 1]
-2. [Diagram name 2]
-3. [Diagram name 3]
-
-### Preserved Content:
-
-- [Existing section 1 from README.md]
-- [Existing section 2 from README.md]
-
-### Recommendations:
-
-- [Any follow-up suggestions]
-```
-
-## Important Rules
-
-1. **Always read existing docs first** - Never overwrite without understanding what exists
-2. **Use standard ASCII only** - No Unicode box characters in diagrams
-3. **Be specific about technologies** - Don't guess; verify by reading config files
-4. **Include "The Hard Lessons"** - If you can identify common pitfalls, document them
-5. **Test commands before documenting** - Don't document commands that don't work
-6. **Reference files that exist** - Don't mention files that aren't in the repo
-7. **Keep README.md concise** - Detailed docs go in AGENTS.md
-8. **CLAUDE.md sources AGENTS.md** - Single source of truth pattern
-
-## Error Recovery
-
-### Existing AGENTS.md has critical content
-
-If the existing AGENTS.md has valuable content that shouldn't be lost:
-
-1. Extract and preserve critical sections
-2. Merge with new structure
-3. Show diff to user before writing
-4. Ask for confirmation
-
-### Unable to determine tech stack
-
-If you can't identify the technology:
-
-1. List what you found (or didn't find)
-2. Ask user for clarification
-3. Generate placeholder sections that can be filled in
-
-### Repository is monorepo
-
-If the repo contains multiple distinct projects:
-
-1. Identify each sub-project
-2. Consider generating per-project AGENTS.md in subdirectories
-3. Create top-level AGENTS.md that explains the monorepo structure
-4. Link to sub-project documentation
-
-## Examples
-
-### Example 1: Python Django Project
-
-After analyzing a Django project, the AGENTS.md might include:
-
-```
-## Architecture Diagrams
-
-### Request Flow
-
-```
-+------------------------------------------------------------------+
-|                    DJANGO REQUEST LIFECYCLE                       |
-+------------------------------------------------------------------+
-
-+----------------+     +----------------+     +----------------+
-| Browser        |---->| nginx          |---->| gunicorn       |
-| (HTTP request) |     | (reverse proxy)|     | (WSGI server)  |
-+----------------+     +----------------+     +----------------+
-                                                      |
-                                                      v
-                              +----------------+     +----------------+
-                              | Django         |---->| PostgreSQL     |
-                              | (views/models) |     | (database)     |
-                              +----------------+     +----------------+
-```
-```
-
-### Example 2: React Frontend
-
-After analyzing a React project:
-
-```
-## Architecture Diagrams
-
-### Component Hierarchy
-
-```
-+------------------------------------------------------------------+
-|                    REACT APPLICATION                              |
-+------------------------------------------------------------------+
-
-                    +------------------------+
-                    | App.tsx                |
-                    | (Router, Providers)    |
-                    +------------------------+
-                               |
-         +---------------------+---------------------+
-         |                     |                     |
-         v                     v                     v
-+----------------+   +----------------+   +----------------+
-| AuthLayout     |   | DashboardLayout|   | PublicLayout   |
-| (login/signup) |   | (main app)     |   | (landing)      |
-+----------------+   +----------------+   +----------------+
-```
-```
-
-### Example 3: Preserving Existing README
-
-If README.md exists with:
-```markdown
-# My Project
-
-Some important info written by humans.
-
-## Installation
-
-Custom installation instructions.
-```
-
-The enhanced README.md becomes:
-```markdown
-# My Project
-
-Some important info written by humans.
-
-> **Architecture Note**: For detailed architecture documentation, agent guidelines, and development patterns, see [AGENTS.md](./AGENTS.md).
-
-## Architecture Overview
-
-```
-[ASCII DIAGRAM]
-```
-
----
-
-## Installation
-
-Custom installation instructions.
-```
-
-## Quick Reference
-
-**Discover repo:**
-```bash
-ls -la && cat README.md 2>/dev/null && cat AGENTS.md 2>/dev/null
-```
-
-**Find tech stack:**
-```bash
-ls package.json pyproject.toml *.tf serverless.yml 2>/dev/null
-```
-
-**Check existing docs:**
-```bash
-find . -maxdepth 2 -name "*.md" -type f
-```
-
-**When in doubt:** Read everything first, enhance carefully, preserve human content, use standard ASCII only for diagrams.
-
----
+- A repo has weak, stale, or missing agent-facing documentation.
+- `AGENTS.md` has become a long dumping ground instead of a navigation layer.
+- Engineers or agents keep rediscovering the same commands, constraints, or
+  failure modes.
+- You want to canonicalize `CLAUDE.md` into a minimal `@AGENTS.md` stub.
+- You want repo docs that improve execution speed, not just onboarding prose.
+
+## Core Model
+
+Treat documentation as a layered harness:
+
+1. `README.md` is human-first quickstart and orientation.
+2. `AGENTS.md` is the canonical agent entrypoint and routing map.
+3. Topic-specific docs under `docs/` (or an equivalent repo-local location)
+   hold the durable details.
+4. `CLAUDE.md` is a minimal pointer that sources `AGENTS.md`.
+5. Tooling and CI enforce the highest-value constraints mechanically.
+
+Important nuance:
+- `AGENTS.md` is the canonical entrypoint.
+- The source of truth for a topic can live in a linked doc such as
+  `docs/quality/gates.md` or `docs/architecture/overview.md`.
+- `CLAUDE.md` must not carry unique behavioral rules.
+
+## Required Outcomes
+
+Every run should leave the repo with a clear harness shape:
+
+- `AGENTS.md`
+  - Short, scannable, and command-heavy.
+  - Explains what the repo is, where important docs live, how to run key
+    commands, and which constraints are non-negotiable.
+  - Usually targets roughly 80-180 lines unless the repo is genuinely tiny.
+- `README.md`
+  - Preserves human-authored content.
+  - Points readers to `AGENTS.md` and any major docs directories.
+- `CLAUDE.md`
+  - Minimal `@AGENTS.md` stub only.
+- `docs/` (or existing equivalent)
+  - Add or normalize topic-specific docs when the repo complexity warrants it.
+  - Prefer a few focused docs over one giant file.
+
+## Generate Mode
+
+Use `/repo-docs:generate` when creating or rebuilding the harness from scratch.
+
+### Generate Workflow
+
+1. Discover actual behavior
+   - Read existing `README.md`, `AGENTS.md`, `CLAUDE.md`, and any existing
+     `docs/` indexes first.
+   - Inspect manifests, wrappers, CI, pre-commit, scripts, Makefiles, and test
+     commands.
+   - Identify recurring failure modes, architectural boundaries, and the active
+     type gate (`ty`, then `pyright`, then `mypy`, unless repo docs/CI differ).
+
+2. Choose the smallest useful harness footprint
+   - Tiny repo: `README.md`, `AGENTS.md`, `CLAUDE.md` may be enough.
+   - Normal product repo: add focused docs for architecture, quality gates, and
+     runbooks.
+   - Complex monorepo: add per-domain docs and keep each `AGENTS.md` scoped to
+     its directory.
+
+3. Write docs in the right layer
+   - Put stable commands, navigation, and "where truth lives" in `AGENTS.md`.
+   - Put deep architecture, policies, plans, and runbooks in topic docs.
+   - Keep diagrams optional; include them only when they clarify boundaries or
+     flows better than prose and code references.
+
+4. Encode the harness gap
+   - If the repo repeatedly fails on the same issue, document the fix path and
+     recommend or add mechanical enforcement when reasonable.
+   - Prefer wrapper commands, lint messages, CI checks, and dedicated docs over
+     repeating the same free-form instructions.
 
 ## Canonicalize Mode
 
-Use `/repo-docs:canonicalize` to audit and fix existing documentation across a repository, making AGENTS.md the canonical source of truth and normalizing all CLAUDE.md files to minimal stubs.
+Use `/repo-docs:canonicalize` when docs already exist but are stale or badly
+structured.
 
-### When to Use Canonicalize
+### Canonicalize Goals
 
-- Repository has scattered/divergent AGENTS.md and CLAUDE.md files
-- Documentation contains stale content (old package managers, outdated commands)
-- CLAUDE.md files have unique content that should live in AGENTS.md
-- Want to enforce the "single source of truth" pattern across a codebase
-
-### Canonicalize Workflow
-
-#### Phase 1: Discovery
-
-Find all directories with AGENTS.md and/or CLAUDE.md:
-
-```bash
-# Find all AGENTS.md and CLAUDE.md files recursively
-find . -name "AGENTS.md" -o -name "CLAUDE.md" | sort
-
-# Group by directory
-find . -name "AGENTS.md" -o -name "CLAUDE.md" | xargs -I{} dirname {} | sort -u
-```
-
-#### Phase 2: Per-Directory Analysis
-
-For each directory with docs, analyze the **actual** current behavior:
-
-**Tooling Analysis:**
-```bash
-# Check for uv (modern Python)
-ls uv.lock pyproject.toml 2>/dev/null
-
-# Check for .bin/* wrappers
-ls .bin/ 2>/dev/null
-
-# Check CI configuration
-ls .github/workflows/*.yml 2>/dev/null
-cat .github/workflows/*.yml 2>/dev/null | grep -E "run:|command:" | head -20
-
-# Check for Makefile/scripts
-ls Makefile *.sh scripts/ 2>/dev/null
-
-# Check pre-commit + linting configuration (often the real “source of truth”)
-ls .pre-commit-config.yaml .pre-commit-config.yml 2>/dev/null
-rg -n "djlint|ruff|mypy|pyright|ty|eslint|prettier|black|isort" .pre-commit-config.yaml .pre-commit-config.yml pyproject.toml package.json 2>/dev/null | head -50
-```
-
-**Identify Stale Patterns (remove these):**
-- `pip install -r requirements.txt` → should be `uv sync`
-- `poetry install` / `poetry run` → should be `uv sync` / `uv run`
-- `python manage.py` → should be `.bin/django` or `uv run python manage.py`
-- `pytest` → should be `.bin/pytest` or `uv run pytest`
-- References to old Django versions, old CI patterns, removed features
-
-**Identify Current Patterns (use these):**
-- `uv sync`, `uv run ...`
-- `.bin/django`, `.bin/pytest`, `.bin/ruff`, plus active type gate wrapper
-  (`.bin/ty`, `.bin/pyright`, or `.bin/mypy`)
-- `pre-commit run ...` (and any repo wrappers like `make precommit`)
-- Current CI job names and commands
-- Actual architecture from code inspection
-
-#### Phase 3: Comparison & Merge
-
-For each directory:
-
-1. **Read both files:**
-   ```bash
-   cat AGENTS.md 2>/dev/null
-   cat CLAUDE.md 2>/dev/null
-   ```
-
-2. **Identify content categories:**
-   - **Keep**: Still true and important
-   - **Remove**: Stale, outdated, or incorrect
-   - **Merge**: In CLAUDE.md but not AGENTS.md (move to AGENTS.md)
-
-3. **Merge strategy:**
-   - If CLAUDE.md has better/more current detail → move to AGENTS.md
-   - If both have same info → keep AGENTS.md version
-   - If conflict → prefer what matches actual code behavior
-
-#### Phase 4: Rewrite AGENTS.md
-
-Update AGENTS.md to be canonical for its directory scope:
-
-**Command updates:**
-````markdown
-## Common Commands
-
-```bash
-# Environment setup
-uv sync                              # Install dependencies
-
-# Running the server
-.bin/django runserver                # Or: uv run python manage.py runserver
-
-# Testing
-.bin/pytest                          # Or: uv run pytest
-.bin/pytest -x -vvs path/to/test.py  # Single test with output
-
-# Linting
-.bin/ruff check .                    # Check for issues
-.bin/ruff format .                   # Auto-format
-
-# Pre-commit (if present, this is usually the authoritative lint gate)
-pre-commit run --all-files           # Or: pre-commit run --files <changed files>
-
-# Type checking
-# Prefer ty when configured, then pyright, then mypy
-.bin/ty check .                      # Run ty (if configured)
-.bin/pyright .                       # Or pyright
-.bin/mypy .                          # Or mypy
-```
-````
-
-**Behavior descriptions must match actual code:**
-- Check what CI actually runs, not what old docs say
-- Verify management commands exist before documenting them
-- Confirm architecture matches current codebase structure
-- If `.pre-commit-config.*` exists, summarize key hooks and “gotchas” in
-  AGENTS.md (e.g. djlint template rules, required commit message prefixes) so
-  agents write compliant code on the first pass instead of discovering failures
-  at commit time.
-
-#### Phase 5: Normalize CLAUDE.md
-
-Replace every CLAUDE.md with this minimal stub:
-
-```markdown
-@AGENTS.md
-
----
-
-## Notes
-
-This `CLAUDE.md` intentionally sources `AGENTS.md` so that requirements,
-commands, and agent behavior live in a single source of truth for this repo.
-
-For Claude Code best practices on `CLAUDE.md` / `AGENTS.md` in web-based repos,
-see:
-- https://docs.claude.com/en/docs/claude-code/claude-code-on-the-web#best-practices
-
-Relevant guidance (summarized):
-- Document requirements: clearly specify dependencies and commands for the
-  project.
-- If you have an `AGENTS.md` file, you can source it in your `CLAUDE.md` using
-  `@AGENTS.md` to maintain a single source of truth.
-```
-
-**Important:** No additional rules, requirements, or divergent specs in CLAUDE.md. All behavioral guidance must live in AGENTS.md.
-
-### Canonicalize Output Shape
-
-```
-## Documentation Canonicalized
-
-**Repository:** /path/to/repo
-**Directories processed:** N
-
-### Summary by Directory:
-
-| Directory | AGENTS.md | CLAUDE.md | Changes |
-|-----------|-----------|-----------|---------|
-| `/` | Updated | Normalized | Merged 3 sections, removed stale pip commands |
-| `/backend` | Updated | Normalized | Updated to .bin/* wrappers |
-| `/infra` | Created | Normalized | Was CLAUDE.md only, now has AGENTS.md |
-
-### Stale Content Removed:
-
-- `pip install -r requirements.txt` → `uv sync`
-- `poetry run pytest` → `.bin/pytest`
-- References to Django 3.x (now 4.x)
-- Old CI workflow names
-
-### Content Merged from CLAUDE.md → AGENTS.md:
-
-- `/backend/CLAUDE.md`: Database migration safety rules
-- `/infra/CLAUDE.md`: Terraform state locking guidance
-
-### All CLAUDE.md files now source @AGENTS.md
-```
+- Shrink oversized `AGENTS.md` files into routing maps.
+- Move durable detail into focused repo-local docs.
+- Remove stale commands and replace them with current wrappers and gates.
+- Merge any valuable `CLAUDE.md` content into `AGENTS.md` or topic docs.
+- Normalize every `CLAUDE.md` to a minimal stub.
 
 ### Canonicalize Rules
 
-1. **Analyze before changing** - Always understand actual behavior first
-2. **AGENTS.md is the source of truth** - All rules live there
-3. **CLAUDE.md is just a pointer** - Minimal stub, no unique content
-4. **Commands must be current** - `uv`, `.bin/*` wrappers, actual CI commands
-5. **Remove stale content aggressively** - Old package managers, old patterns
-6. **Merge, don't lose** - Move valuable CLAUDE.md content to AGENTS.md first
-7. **Recursive** - Process every directory with docs, not just root
-8. **Confirm before destructive changes** - Show diff, ask user if uncertain
-9. **Encode recurring failure modes** - If linters (pre-commit/djlint) or
-   reasoning pitfalls (date/time math) repeatedly trip agents, write explicit
-   “gotchas” and verification commands into AGENTS.md so they’re avoided up
-   front.
+1. Analyze the actual repo before changing docs.
+2. Use `--dry-run` first or pause for human confirmation before broad,
+   ambiguous, or repo-wide reshaping.
+3. Preserve valuable human-written content, but relocate it if it lives in the
+   wrong layer.
+4. Prefer `docs/quality/`, `docs/architecture/`, `docs/runbooks/`,
+   `docs/plans/`, or existing equivalents over bloating `AGENTS.md`.
+5. If `.pre-commit-config.*`, CI jobs, or wrappers define the real workflow,
+   those must be reflected in the docs.
+6. For Python repos, document the active type gate and treat `ty` as mandatory
+   when configured.
+7. Record recurring failure modes as explicit "golden rules" or gate docs.
 
-### Handling Edge Cases
+## Recommended Artifact Shapes
 
-#### Directory has CLAUDE.md but no AGENTS.md
+Use the smallest structure that matches the repo:
 
-1. Create AGENTS.md from CLAUDE.md content
-2. Update to current patterns
-3. Replace CLAUDE.md with minimal stub
+- Small repo
+  - `README.md`
+  - `AGENTS.md`
+  - `CLAUDE.md`
+- Medium repo
+  - `README.md`
+  - `AGENTS.md`
+  - `CLAUDE.md`
+  - `docs/architecture/overview.md`
+  - `docs/quality/gates.md`
+  - `docs/runbooks/development.md`
+- Complex repo or monorepo
+  - Top-level `README.md`, `AGENTS.md`, `CLAUDE.md`
+  - Per-domain docs such as `docs/architecture/`, `docs/quality/`,
+    `docs/runbooks/`, `docs/specs/`, `docs/plans/`
+  - Subdirectory `AGENTS.md` files only where scope genuinely diverges
 
-#### Directory has both but CLAUDE.md has unique rules
+## What Good Output Looks Like
 
-1. Merge unique rules into AGENTS.md
-2. Verify rules match actual code behavior
-3. Replace CLAUDE.md with minimal stub
+The skill should optimize for:
 
-#### AGENTS.md references files/commands that don't exist
+- Fast "first 5 minutes" comprehension by an agent.
+- Commands that actually work.
+- Clear doc routing instead of duplicated prose.
+- Explicit architectural boundaries and quality gates.
+- A place for plans, specs, and recurring lessons to accumulate in-repo.
+- Fewer rediscovered failures during later autonomous work.
 
-1. Remove or update the reference
-2. Document what actually exists
-3. Note the removal in output report
+## Important Rules
 
-#### Subdirectory AGENTS.md contradicts parent
+1. Read existing docs before writing anything.
+2. Do not treat a giant `AGENTS.md` as success.
+3. Preserve README content; enhance rather than replace.
+4. Keep `CLAUDE.md` as a pointer only.
+5. Prefer ASCII if you add diagrams.
+6. Never guess commands or tech stack details; verify them.
+7. If the repo already has a good docs hierarchy, improve it instead of
+   replacing it with your preferred layout.
+8. If you find repeated review or lint failures, turn them into docs or
+   enforceable checks.
 
-1. Subdirectory AGENTS.md is authoritative for its scope
-2. Parent should not repeat subdirectory rules
-3. Each AGENTS.md documents its directory scope only
+## Output Shape
+
+Report work in this structure:
+
+```text
+## Documentation Updated
+
+Repository: /path/to/repo
+Harness shape: [small | medium | complex]
+
+Files updated:
+- AGENTS.md - [created/updated/trimmed]
+- README.md - [created/updated/preserved]
+- CLAUDE.md - [normalized]
+- docs/... - [created/updated as needed]
+
+Harness upgrades:
+- [commands documented]
+- [quality gates documented]
+- [architecture/runbook docs added]
+- [stale patterns removed]
+
+Open follow-ups:
+- [optional mechanical enforcement or missing docs]
+```
+
+## References
+
+Load only what you need:
+
+- `references/harness-principles.md`
+  - Core policy, migration heuristics, and harness design rules.
+- `references/generate-and-canonicalize-playbook.md`
+  - Discovery commands, canonicalization steps, and stale-pattern checks.
+- `references/templates.md`
+  - Templates for `AGENTS.md`, `CLAUDE.md`, `README.md`, and topic docs.

--- a/plugins/repo-docs/skills/repo-docs-generator/references/generate-and-canonicalize-playbook.md
+++ b/plugins/repo-docs/skills/repo-docs-generator/references/generate-and-canonicalize-playbook.md
@@ -1,0 +1,166 @@
+# Generate And Canonicalize Playbook
+
+Use this file for command-heavy workflow details.
+
+## Discovery Commands
+
+Prefer targeted, fast inspection over broad dumps:
+
+```bash
+pwd
+rg --files -g 'README.md' -g 'AGENTS.md' -g 'CLAUDE.md' -g 'docs/**' | sort
+rg --files -g 'package.json' -g 'pyproject.toml' -g 'go.mod' -g 'Cargo.toml' -g '*.tf' | sort
+rg --files -g '.pre-commit-config.*' -g '.github/workflows/**' -g 'Makefile' -g '.bin/**' -g 'scripts/**' | sort
+rg -n "ty|pyright|mypy|ruff|eslint|prettier|djlint|pytest|vitest|jest|terraform|uv run|poetry run|pip install" \
+  pyproject.toml package.json .pre-commit-config.yaml .pre-commit-config.yml .github/workflows Makefile scripts docs 2>/dev/null
+```
+
+Read the docs that already exist before deciding to add more.
+
+## Generate Workflow Details
+
+### 1. Inspect existing documentation
+
+Read:
+
+- `README.md`
+- `AGENTS.md`
+- `CLAUDE.md`
+- Existing doc indexes such as `docs/README.md`, `docs/architecture/`,
+  `runbooks/`, or `design/`
+
+Preserve valuable human-authored content. Re-home it when the layer is wrong.
+
+### 2. Inspect actual execution paths
+
+Verify:
+
+- Package manager and runtime commands
+- Wrapper scripts (`.bin/*`, `make`, `just`, `scripts/*`)
+- Test commands
+- Pre-commit hooks
+- CI jobs and job names
+- Deployment or release commands
+
+For Python repos, detect the active type gate in this order unless repo docs/CI
+explicitly differ:
+
+1. `ty`
+2. `pyright`
+3. `mypy`
+
+If `ty` is configured via `pyproject.toml`, `ty.toml`, `.bin/ty`, CI, or
+pre-commit, treat it as mandatory.
+
+### 3. Decide the harness footprint
+
+Use this rule of thumb:
+
+- Tiny repo
+  - Keep everything in `README.md` + short `AGENTS.md`
+- Service or app repo
+  - Add focused docs for architecture, quality gates, and development runbooks
+- Large or fast-changing repo
+  - Add docs for specs and plans as first-class artifacts
+
+### 4. Write the right documents
+
+Recommended content by file:
+
+- `README.md`
+  - Project purpose
+  - Quickstart
+  - Pointer to `AGENTS.md`
+- `AGENTS.md`
+  - Navigation map
+  - Commands
+  - Non-negotiable rules
+  - Links to deeper docs
+- `docs/architecture/overview.md`
+  - Components, boundaries, request/data flows, ownership seams
+- `docs/quality/gates.md`
+  - Pre-commit, CI, type gates, wrappers, recurring gotchas
+- `docs/runbooks/development.md`
+  - Local setup, common workflows, debugging
+- `docs/specs/`
+  - Behavior-defining specs
+- `docs/plans/`
+  - Execution plans, staged rollouts, migrations
+
+### 5. Validate before finishing
+
+Check:
+
+- All documented commands exist and are current.
+- The docs hierarchy is easy to navigate.
+- `AGENTS.md` is concise and mostly links outward.
+- `CLAUDE.md` contains no unique rules.
+- The docs mention repeated failure modes that would otherwise be rediscovered.
+
+## Canonicalize Workflow Details
+
+### 1. Find every doc entrypoint
+
+```bash
+rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g 'README.md' -g 'docs/**' | sort
+```
+
+In monorepos, group by directory and scope.
+
+### 2. Identify stale patterns
+
+Common stale patterns to remove:
+
+- `pip install -r requirements.txt` when the repo uses `uv`
+- `poetry run ...` when the repo uses `uv run ...`
+- `python manage.py ...` when the repo standard is `.bin/django ...`
+- `pytest` when the repo standard is `.bin/pytest`
+- Outdated CI job names
+- Old branch or release workflows
+
+### 3. Split giant AGENTS.md files
+
+When `AGENTS.md` is too long:
+
+- Keep commands, navigation, and hard constraints in `AGENTS.md`
+- Move architecture detail to `docs/architecture/...`
+- Move quality rules to `docs/quality/...`
+- Move long runbooks to `docs/runbooks/...`
+- Move plans to `docs/plans/...`
+
+### 4. Normalize CLAUDE.md
+
+Use this exact pattern:
+
+```markdown
+@AGENTS.md
+
+---
+
+## Notes
+
+This `CLAUDE.md` intentionally sources `AGENTS.md` so that requirements,
+commands, and agent behavior have a single canonical entrypoint in this repo.
+```
+
+Do not leave extra behavioral rules in `CLAUDE.md`.
+
+### 5. Capture missing harness upgrades
+
+If the repo needs more than docs, report follow-ups such as:
+
+- Add a wrapper for a fragile multi-step command
+- Add clearer lint output for recurring failures
+- Add CI checks for layer or boundary violations
+- Add a `docs/plans/` index or `docs/specs/` directory
+
+## Optional Diagram Guidance
+
+Diagrams are optional. Use them only when they reduce ambiguity.
+
+If you add diagrams:
+
+- Use ASCII only
+- Keep them compact
+- Prefer boundaries and flow over decorative boxes
+- Put deep diagrams in `docs/architecture/`, not `AGENTS.md`

--- a/plugins/repo-docs/skills/repo-docs-generator/references/harness-principles.md
+++ b/plugins/repo-docs/skills/repo-docs-generator/references/harness-principles.md
@@ -1,0 +1,116 @@
+# Harness Principles
+
+This file extends `SKILL.md` with the design rules behind the repo-docs skill.
+
+Primary inspiration:
+- OpenAI, February 11, 2026: https://openai.com/index/harness-engineering/
+
+## Source Model
+
+The repo-docs skill should optimize for execution, not literary completeness.
+
+Use this layered model:
+
+1. `README.md`
+   - Human-first orientation, install, quickstart, and project purpose.
+   - Should point to `AGENTS.md` for agent navigation and deeper repo docs.
+2. `AGENTS.md`
+   - Canonical entrypoint for agents.
+   - Short routing map with key commands, boundaries, and links to deeper docs.
+3. Topic docs
+   - Versioned repo-local files for architecture, gates, runbooks, specs, and
+     plans.
+4. Tooling
+   - Linters, wrappers, CI, and tests that enforce the most important rules.
+
+## Repository Legibility Rules
+
+A repo is "legible to agents" when:
+
+- An agent can discover the correct commands without guessing.
+- Architectural boundaries are explicit and local.
+- Repeated failure modes are written down close to the code.
+- Plans and specs are committed, not trapped in chat history.
+- The docs layout makes it obvious where to add new durable knowledge.
+
+## AGENTS.md Rules
+
+`AGENTS.md` should not be the whole handbook.
+
+Prefer these sections:
+
+- What this repo is
+- How to navigate the docs
+- Commands that actually work
+- Non-negotiable invariants and gates
+- Directory-scoped guidance or links
+- How to update the harness when you learn something
+
+Avoid these anti-patterns:
+
+- Huge architecture essays better suited for `docs/architecture/`
+- Long runbooks better suited for `docs/runbooks/`
+- Plan details that belong in `docs/plans/`
+- Duplicated content already covered by topic docs
+
+## Topic Doc Heuristics
+
+Create focused docs when there is enough stable detail to justify them.
+
+Recommended categories:
+
+- `docs/architecture/`
+  - System boundaries, request/data flows, ownership seams, integration maps.
+- `docs/quality/`
+  - Pre-commit, CI, type gates, test strategy, recurring lint failures,
+    required wrappers, golden rules.
+- `docs/runbooks/`
+  - Development setup, release/deploy checklists, debugging, incident response.
+- `docs/specs/`
+  - Product or technical specs that define intended behavior.
+- `docs/plans/`
+  - Execution plans, migration plans, staged rollouts, follow-up work.
+
+Use existing repo conventions when present; do not force `docs/` if the repo
+already has a clear equivalent such as `design/`, `adr/`, or `runbooks/`.
+
+## Mechanical Enforcement Rule
+
+If a rule matters enough to repeat, it likely matters enough to encode.
+
+Prioritize:
+
+1. Tooling or CI enforcement.
+2. Wrapper commands with clear error messages.
+3. A focused doc page linked from `AGENTS.md`.
+4. Free-form prose only when the above are not practical yet.
+
+Examples:
+
+- Repeated lint failures -> document in `docs/quality/gates.md`, then add or
+  improve wrapper commands.
+- Repeated architecture violations -> document boundaries in
+  `docs/architecture/overview.md`, then add CI or lint checks if possible.
+- Repeated migration mistakes -> add a migration runbook and link it from
+  `AGENTS.md`.
+
+## Canonicalization Heuristics
+
+When docs are messy:
+
+- Keep `AGENTS.md` as the canonical entrypoint.
+- Move deep detail into focused docs.
+- Normalize `CLAUDE.md` to `@AGENTS.md`.
+- Remove stale package-manager or wrapper examples.
+- Prefer current CI and wrapper behavior over old prose.
+- Add missing docs only where they reduce future rediscovery cost.
+
+## Review Questions
+
+Before finishing, ask:
+
+- Can a new agent find the right command path in under 30 seconds?
+- Are the highest-cost failures documented or enforced?
+- Does `AGENTS.md` point to the right places instead of duplicating them?
+- Do the docs make future plans/specs discoverable inside the repo?
+- Did we reduce future guesswork, or just generate more text?

--- a/plugins/repo-docs/skills/repo-docs-generator/references/templates.md
+++ b/plugins/repo-docs/skills/repo-docs-generator/references/templates.md
@@ -1,0 +1,125 @@
+# Templates
+
+Use these as starting points, then tailor to the actual repo.
+
+## AGENTS.md Template
+
+````markdown
+# AGENTS.md
+
+## What This Repo Is
+
+<One short paragraph on purpose and shape.>
+
+## How To Navigate This Repo
+
+- Start here for commands and repo-wide rules.
+- Read `<linked doc>` for architecture boundaries.
+- Read `<linked doc>` for quality gates and wrappers.
+- Read `<linked doc>` for plans/specs/runbooks when relevant.
+
+## Commands
+
+```bash
+<verified command>
+<verified command>
+<verified command>
+```
+
+## Non-Negotiable Rules
+
+- <hard invariant>
+- <hard invariant>
+- <hard invariant>
+
+## Docs Index
+
+- `docs/architecture/overview.md` - <what it explains>
+- `docs/quality/gates.md` - <what it explains>
+- `docs/runbooks/development.md` - <what it explains>
+- `docs/plans/` - <where execution plans live>
+
+## Keep The Harness Fresh
+
+- If a failure repeats, update docs or tooling.
+- If a command changes, update this file and the linked source doc.
+- If a new durable workflow appears, add a focused doc instead of expanding
+  this file indefinitely.
+````
+
+## CLAUDE.md Template
+
+```markdown
+@AGENTS.md
+
+---
+
+## Notes
+
+This `CLAUDE.md` intentionally sources `AGENTS.md` so that requirements,
+commands, and agent behavior have a single canonical entrypoint in this repo.
+```
+
+## README.md Addition
+
+Add a short note near the top:
+
+```markdown
+> For agent-oriented commands, repo rules, and deeper project docs, see
+> [AGENTS.md](./AGENTS.md).
+```
+
+## docs/quality/gates.md Template
+
+````markdown
+# Quality Gates
+
+## Required Commands
+
+```bash
+<pre-commit command>
+<test command>
+<type-check command>
+```
+
+## Active Type Gate
+
+- <ty | pyright | mypy>
+- Why it is the active gate in this repo
+
+## Common Failures
+
+- <failure mode> -> <how to avoid it>
+- <failure mode> -> <how to avoid it>
+
+## CI Notes
+
+- <job name> verifies <scope>
+- <job name> verifies <scope>
+````
+
+## docs/architecture/overview.md Template
+
+```markdown
+# Architecture Overview
+
+## Main Components
+
+- `<component>` - <responsibility>
+- `<component>` - <responsibility>
+
+## Boundaries
+
+- `<boundary>` must not depend on `<boundary>`
+- `<boundary>` owns `<data or behavior>`
+
+## Main Flows
+
+1. <request or job flow>
+2. <request or job flow>
+
+## Useful Code References
+
+- `<path>` - <why it matters>
+- `<path>` - <why it matters>
+```


### PR DESCRIPTION
## Summary

This PR refreshes several marketplace skills around a harness-oriented documentation model. It makes `repo-docs` a thin orchestrator with repo-local references, aligns backend/review skills to treat `AGENTS.md` plus linked docs as the canonical harness, and adds required fresh-eyes self-review steps to planning workflows. It also syncs the touched plugin versions and marketplace metadata so the documentation changes ship cleanly.

### Key Features

| Feature | Description |
|---|---|
| `repo-docs` harness refactor | Rewrites the skill around short `AGENTS.md` maps, focused topic docs, minimal `CLAUDE.md` stubs, and explicit dry-run / human checkpoints for broad canonicalization. |
| Backend skill alignment | Updates `backend-atomic-commit`, `backend-pr-workflow`, and `monty-code-review` to load repo-local harness docs instead of treating `CLAUDE.md` as a co-equal source of truth. |
| Required fresh-eyes review | Adds mandatory self-review steps to `plan-directory`, `backend-ralph-plan`, `README.md`, and `AGENTS.md` so the user does not need to repeat that instruction. |
| Packaging / release hygiene | Bumps touched plugin versions and syncs marketplace descriptions and keywords with the new behavior. |

## Harness Flow

```text
User / reviewer prompt
        |
        v
AGENTS.md (short routing map)
        |
        v
SKILL.md (orchestrator, <=500 lines)
        |
        +--> references/*.md (durable detail, examples, playbooks)
        |
        +--> commands/*.md (thin entrypoints)
        |
        +--> marketplace/plugin manifests (versioned distribution contract)
        |
        v
Wrappers / CI / quality gates
```

---

## Repo Docs: Harness-First Documentation

This section shifts `repo-docs` from a large all-in-one generator into a harness-oriented doc skill inspired by OpenAI's February 11, 2026 article: https://openai.com/index/harness-engineering/

What changed:
- `plugins/repo-docs/skills/repo-docs-generator/SKILL.md` is now a much smaller orchestrator.
- Durable guidance moved into:
  - `references/harness-principles.md`
  - `references/generate-and-canonicalize-playbook.md`
  - `references/templates.md`
- `/repo-docs:generate` and `/repo-docs:canonicalize` now describe the harness model directly.
- Canonicalization now explicitly defaults to `--dry-run` or a human checkpoint for broad, ambiguous, or repo-wide reshaping.
- `README.md` and `AGENTS.md` now explicitly reference the harness-engineering article and describe the short-AGENTS / focused-docs approach.

---

## Backend / Review Skill Alignment

This PR updates the most obvious harness mismatches in the existing skills:
- `backend-atomic-commit`
  - Treats `AGENTS.md` as the canonical entrypoint.
  - Loads linked repo-local docs instead of relying on `CLAUDE.md` as a rule source.
  - Moves long fix heuristics and prompt examples into `references/`.
  - Adds harness follow-up output when recurring failures suggest missing docs or guardrails.
- `backend-pr-workflow`
  - Shifts to the same `AGENTS.md` + linked-docs model.
  - Updates command/manifests to describe repo-local workflow docs explicitly.
- `monty-code-review`
  - Adds a harness/legibility review lens.
  - Treats missing agent-legible docs / guardrails as reviewable issues.
  - Moves prompt/output examples into `references/review-examples.md`.

---

## Planning Workflow: Fresh-Eyes Review

The plan skills and repo docs now encode the repeated instruction to do a fresh-eyes pass before stopping:
- `plugins/plan-directory/skills/plan-directory/SKILL.md`
- `plugins/plan-directory/skills/backend-ralph-plan/SKILL.md`
- `plugins/plan-directory/skills/plan-directory/references/advanced.md`
- `plugins/plan-directory/commands/plan.md`
- `plugins/plan-directory/commands/backend-ralph-plan.md`
- `README.md`
- `AGENTS.md`

This makes the self-audit part of the harness rather than something the user has to restate every session.

---

## Packaging / Versioning

Touched plugin versions in this PR:
- `backend-atomic-commit`: `0.2.3` -> `0.2.4`
- `backend-pr-workflow`: `0.1.3` -> `0.1.4`
- `monty-code-review`: `1.2.3` -> `1.2.4`
- `plan-directory`: `0.2.2` -> `0.2.3`
- `repo-docs`: `0.1.3` -> `0.1.4`

`mixpanel-analytics` remains at `0.1.4`, and the stray `process-code-review` marketplace-only bump was corrected back to `0.1.3` to preserve parity with its manifest.

## Plugins / Skills Touched

- Plugin(s):
  - [x] Existing plugin(s) updated
- Skills:
  - `plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md`
  - `plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md`
  - `plugins/monty-code-review/skills/monty-code-review/SKILL.md`
  - `plugins/plan-directory/skills/plan-directory/SKILL.md`
  - `plugins/plan-directory/skills/backend-ralph-plan/SKILL.md`
  - `plugins/repo-docs/skills/repo-docs-generator/SKILL.md`
- Commands:
  - `plugins/backend-atomic-commit/commands/{pre-commit,atomic-commit,commit}.md`
  - `plugins/backend-pr-workflow/commands/check-pr.md`
  - `plugins/monty-code-review/commands/code-review.md`
  - `plugins/plan-directory/commands/{plan,backend-ralph-plan}.md`
  - `plugins/repo-docs/commands/{generate,canonicalize}.md`
- Manifests / marketplace:
  - `.claude-plugin/marketplace.json`
  - touched plugin manifests for the five version-bumped plugins above

## Files Changed

<details>
<summary>Repo-level docs and marketplace</summary>

- `.claude-plugin/marketplace.json` - synced versions and refreshed marketplace descriptions/keywords.
- `README.md` - added harness philosophy, fresh-eyes guidance, and updated repo-docs/plugin descriptions.
- `AGENTS.md` - encoded harness-first repo-docs guidance and required fresh-eyes self-review.

</details>

<details>
<summary>Backend workflow and review skills</summary>

- `plugins/backend-atomic-commit/...` - harness-first behavior, slimmer SKILL, new references.
- `plugins/backend-pr-workflow/...` - repo-local workflow docs as the source of detailed truth.
- `plugins/monty-code-review/...` - harness-aware findings and examples moved to references.

</details>

<details>
<summary>Planning skills</summary>

- `plugins/plan-directory/...` - required fresh-eyes review step in planning workflows and command entrypoints.

</details>

<details>
<summary>Repo docs skill</summary>

- `plugins/repo-docs/...` - harness-oriented generate/canonicalize behavior plus new references/playbooks/templates.

</details>

## Checklist (from CONTRIBUTING.md)

- [x] Limited changes to configuration / docs only.
- [x] Did not add application logic.
- [x] For each touched plugin, `plugin.json` exists and is valid JSON.
- [x] For each touched plugin, the version bump is reflected in both `plugin.json` and `.claude-plugin/marketplace.json`.
- [x] Updated command wrappers to point at the correct skills and modes.
- [x] Updated `README.md` / `AGENTS.md` where plugin behavior and repo guidance changed.
- [x] Reviewed generated content for tone and repo fit.

## Testing / Validation

Passed:
- `CI=true GITHUB_BASE_REF=main bash scripts/validate-skills.sh`
- marketplace consistency audit mirroring `.github/workflows/validate-marketplace.yml`:
  - JSON parsing
  - unique plugin names
  - plugin-directory coverage
  - source/name/version parity between marketplace and plugin manifests
  - `SKILL.md` presence per plugin
- `git diff origin/main...HEAD --check`

Known unrelated issue:
- `bash scripts/validate-skills.sh --all` still fails because the pre-existing `plugins/clickup-ticket/skills/clickup-ticket/SKILL.md` is 654 lines, which exceeds the repo-wide 500-line budget. This PR does not touch that plugin, but I am calling it out since I ran the full-repo audit before opening the PR.
