### PR TITLE
Canonicalize repo docs harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,481 +1,98 @@
-# Claude Code Configuration for `agent-skills-marketplace`
-
-This repository is an **Agent Skills marketplace repo** for Diversio. It hosts
-reusable Skills packaged in the open Agent Skills standard and includes Claude
-Code plugin/marketplace metadata so the same skills can be distributed via
-Claude Marketplace or other channels.
-
-## Repository Purpose
-
-- Provide a **local / GitHub marketplace** of Diversio-maintained Agent Skills.
-- Encapsulate opinionated Skills (for example, the Monty backend code review Skill)
-  so they can be reused across multiple repos without copy‑pasting.
-- Keep plugin manifests, marketplace definitions, and SKILL docs small, clear, and
-  versioned.
-- For repository-documentation workflows, follow the harness mindset from
-  OpenAI's February 11, 2026 article "Harness engineering: leveraging Codex in
-  an agent-first world": short `AGENTS.md` maps, repo-local docs, and
-  mechanical guardrails over giant prose dumps.
-
-Key layout:
-
-- `.claude-plugin/`
-  - `marketplace.json` – Claude Code marketplace definition listing available plugins.
-- `plugins/`
-  - `monty-code-review/`
-    - `.claude-plugin/plugin.json` – plugin manifest for `monty-code-review`.
-    - `skills/monty-code-review/SKILL.md` – the Monty backend code review Skill.
-  - `backend-atomic-commit/`
-    - `.claude-plugin/plugin.json` – plugin manifest for backend pre-commit / atomic commit.
-    - `skills/backend-atomic-commit/SKILL.md` – backend atomic commit Skill.
-    - `commands/*.md` – Commands for pre-commit, atomic-commit, and commit (run→fix→commit).
-  - `backend-pr-workflow/`
-    - `.claude-plugin/plugin.json` – plugin manifest for backend PR workflow checks.
-    - `skills/backend-pr-workflow/SKILL.md` – backend PR workflow Skill.
-  - `bruno-api/`
-    - `.claude-plugin/plugin.json` – plugin manifest for Bruno API docs generator.
-    - `skills/bruno-api/SKILL.md` – Bruno API documentation Skill.
-  - `code-review-digest-writer/`
-    - `.claude-plugin/plugin.json` – plugin manifest for code review digests.
-    - `skills/code-review-digest-writer/SKILL.md` – code review digest writer Skill.
-  - `plan-directory/`
-    - `.claude-plugin/plugin.json` – plugin manifest for structured plan directories.
-    - `skills/plan-directory/SKILL.md` – plan directory creation and maintenance Skill.
-    - `skills/backend-ralph-plan/SKILL.md` – RALPH loop integration for backend Django.
-  - `pr-description-writer/`
-    - `.claude-plugin/plugin.json` – plugin manifest for PR descriptions.
-    - `skills/pr-description-writer/SKILL.md` – PR description generator Skill.
-  - `process-code-review/`
-    - `.claude-plugin/plugin.json` – plugin manifest for code review processor.
-    - `skills/process-code-review/SKILL.md` – process code review findings Skill.
-  - `mixpanel-analytics/`
-    - `.claude-plugin/plugin.json` – plugin manifest for MixPanel analytics.
-    - `skills/mixpanel-analytics/SKILL.md` – MixPanel tracking implementation and review Skill.
-  - `clickup-ticket/`
-    - `.claude-plugin/plugin.json` – plugin manifest for ClickUp ticket management.
-    - `skills/clickup-ticket/SKILL.md` – ClickUp ticket fetching, filtering, and creation Skill.
-    - `commands/*.md` – Commands for reading, filtering, creating tickets, subtasks, multi-org.
-  - `repo-docs/`
-    - `.claude-plugin/plugin.json` – plugin manifest for repository harness docs generator.
-    - `skills/repo-docs-generator/SKILL.md` – repository harness docs generator Skill (short AGENTS.md map + repo-local docs).
-    - `skills/repo-docs-generator/references/*.md` – harness principles, templates, and generate/canonicalize playbooks.
-    - `commands/generate.md` – Generate new harness documentation from scratch.
-    - `commands/canonicalize.md` – Audit and fix existing docs (trim AGENTS.md, move deep detail into topic docs, normalize CLAUDE.md).
-  - `visual-explainer/`
-    - `.claude-plugin/plugin.json` – plugin manifest for HTML visual explainers.
-    - `skills/visual-explainer/SKILL.md` – visual explainer Skill for stakeholder-ready HTML pages.
-    - `skills/visual-explainer/references/*.md` – layout, diagram, slide, and stakeholder explainer guidance.
-    - `skills/visual-explainer/templates/*.html` – reusable reference templates for architecture, Mermaid, tables, and slides.
-    - `commands/explain.md` – Interactive explainer entrypoint.
-  - `backend-release/`
-    - `.claude-plugin/plugin.json` – plugin manifest for Django4Lyfe release workflow.
-    - `skills/release-manager/SKILL.md` – full release workflow management Skill.
-    - `commands/*.md` – Commands for check, create, and publish releases.
-  - `dependabot-remediation/`
-    - `.claude-plugin/plugin.json` – plugin manifest for unified Dependabot remediation workflows.
-    - `skills/dependabot-remediation/SKILL.md` – backend/frontend Dependabot remediation Skill.
-    - `commands/*.md` – Commands for config-aware backend/frontend triage, execution, and release closeout.
-  - `terraform/`
-    - `.claude-plugin/plugin.json` – plugin manifest for Terraform/Terragrunt workflows.
-    - `skills/terraform-atomic-commit/SKILL.md` – Terraform atomic commit Skill.
-    - `skills/terraform-pr-workflow/SKILL.md` – Terraform PR workflow Skill.
-    - `commands/*.md` – Commands for pre-commit, atomic-commit, and PR workflow checks.
-  - `login-cta-attribution-skill/`
-    - `.claude-plugin/plugin.json` – plugin manifest for CTA login attribution.
-    - `skills/login-cta-attribution-skill/SKILL.md` – CTA attribution implementation Skill.
-    - `commands/implement.md` – Implement new CTA sources with attribution.
-
-## How Claude Code Should Behave Here
-
-When working in this repo, Claude Code should:
-
-1. **Treat this as configuration, not application code.**
-   - Do **not** scaffold apps, frameworks, or unrelated code here.
-   - Limit changes to:
-     - `AGENTS.md`, `CLAUDE.md`
-     - `.claude-plugin/*.json` (marketplace + repo metadata)
-     - `plugins/**/.claude-plugin/plugin.json` (per-plugin manifests)
-     - `plugins/**/skills/*/SKILL.md` (Skill docs)
-     - `plugins/**/commands/*.md` (plugin slash-command entrypoints that invoke Skills)
-     - `README.md` / documentation.
-
-2. **Keep JSON valid and minimal.**
-   - Always keep `marketplace.json` and each `plugin.json` valid JSON.
-   - Prefer small, targeted edits over whole‑file rewrites.
-   - If making non‑trivial changes, mentally (or programmatically) validate JSON.
-
-   - **Versioning:** When you add or change a plugin, always bump its version:
-     - Update `plugins/<plugin>/.claude-plugin/plugin.json` with a new version
-       (use simple SemVer-style increments, e.g. `0.1.0` → `0.1.1`).
-     - Ensure the corresponding entry in `.claude-plugin/marketplace.json` uses
-       the **same** version string.
-     - For new plugins, start at `0.1.0` (or similar) and add a matching entry
-       in `marketplace.json`.
-
-   - **CLAUDE.md best practice:** Follow Claude Code's guidance for web-based
-     repos (see
-     `https://docs.claude.com/en/docs/claude-code/claude-code-on-the-web#best-practices`):
-     - Keep requirements and commands defined in a single source of truth
-       (`AGENTS.md` in this repo).
-     - In `CLAUDE.md`, **source** this file using `@AGENTS.md` instead of
-       duplicating content, and only add minimal extra notes if truly needed.
-
-3. **Keep Skills self‑contained and documented.**
-   - Each Skill should live at `plugins/<plugin-name>/skills/<skill-name>/SKILL.md`.
-   - SKILL docs should explain:
-     - When to use the Skill.
-     - Core priorities / taste.
-     - Output shape and severity tags.
-   - Avoid including secrets or customer‑specific confidential details in SKILL docs.
-   - For every Skill, add at least one corresponding **plugin slash command**
-     under `plugins/<plugin>/commands/*.md` that invokes the Skill (thin
-     wrapper that references the Skill by name). This ensures the plugin
-     appears as a `/plugin-name:command` entry in Claude Code's slash command
-     palette.
-   - After any substantive change to a Skill, command, or manifest, do a
-     fresh-eyes self-review of the changed files plus adjacent docs/metadata
-     and fix obvious issues before handing off.
-   - **SKILL.md size and progressive disclosure guardrail (CI-enforced):**
-     - Keep each changed `SKILL.md` at or below 500 lines.
-     - Keep `SKILL.md` focused on activation workflow, priorities, and output shape.
-     - Move long procedures/examples into `references/*.md`.
-     - Move reusable command logic into `scripts/`.
-     - Keep references one level deep where possible.
-     - Run `bash scripts/validate-skills.sh` locally after Skill edits.
-
-   - **SKILL.md YAML frontmatter:** Always quote string values in the YAML
-     frontmatter that contain special characters (colons, brackets, commas,
-     quotes). Unquoted strings with colons can cause YAML parsing errors:
-     ```yaml
-     # CORRECT - strings with special chars are quoted
-     ---
-     name: my-skill
-     description: "Use this when preparing releases, bumping versions, etc."
-     allowed-tools: Bash Read Edit Grep Glob
-     argument-hint: "[action] (e.g., create, publish)"
-     ---
-
-     # WRONG - unquoted strings with colons cause parse errors
-     ---
-     name: my-skill
-     description: Use this when preparing releases, bumping versions, etc.
-     argument-hint: [action] (e.g., "create", "publish")
-     ---
-     ```
-
-4. **Treat Python typing as a strict quality gate in code-touching skills.**
-   - Skills that edit or review Python code must define type-gate detection and
-     enforcement explicitly.
-   - Detection precedence should be:
-     - `ty` first, then `pyright`, then `mypy` (unless target repo docs/CI say
-       otherwise).
-   - If `ty` is configured in the target repo (`[tool.ty]`, `ty.toml`,
-     `.bin/ty`, or CI/pre-commit usage), treat it as mandatory and blocking.
-   - Do not document or encourage "baseline acceptable" behavior for touched
-     files.
-   - Prefer narrow, justified suppressions only when no better typing solution
-     exists; do not default to blanket `# noqa` or broad type-ignore patterns.
-   - Canonical marketplace policy reference:
-     - `docs/python-typing-and-ty-best-practices.md`
-   - In target codebases, also read local policy docs when present (for example
-     `docs/python-typing-3.14-best-practices.md`, `TY_MIGRATION_GUIDE.md`,
-     `AGENTS.md`).
-
-5. **Follow existing naming and structure.**
-   - New plugins should mirror the structure of `monty-code-review`:
-     - `plugins/<plugin>/`
-       - `.claude-plugin/plugin.json`
-       - `skills/<skill-name>/SKILL.md`
-   - Use `kebab-case` for plugin folder names where possible.
-
-6. **Do not modify application behavior here.**
-   - This repo should not contain Django/React/Terraform or other app logic.
-   - If a plugin needs to describe behavior in another repo, document it here but
-     change the actual code in that other repo.
-
-## Requirements & Commands
-
-- Dependencies:
-  - Claude Code installed locally.
-  - This repo (`agent-skills-marketplace`) cloned on your machine.
-
-- Once this repo is hosted at `github.com/DiversioTeam/agent-skills-marketplace`, add the
-  marketplace to Claude Code from any project:
-
-  ```bash
-  /plugin marketplace add DiversioTeam/agent-skills-marketplace
-  ```
-
-- Install the Monty backend code review plugin:
-
-  ```bash
-  /plugin install monty-code-review@diversiotech
-  ```
-
-- Install the backend atomic commit plugin:
-
-  ```bash
-  /plugin install backend-atomic-commit@diversiotech
-  ```
-
-- Install the backend PR workflow plugin:
-
-  ```bash
-  /plugin install backend-pr-workflow@diversiotech
-  ```
-
-- Install the Bruno API docs plugin:
-
-  ```bash
-  /plugin install bruno-api@diversiotech
-  ```
-
-- Install the code review digest writer plugin:
-
-  ```bash
-  /plugin install code-review-digest-writer@diversiotech
-  ```
-
-- Install the plan directory plugin:
-
-  ```bash
-  /plugin install plan-directory@diversiotech
-  ```
-
-- Install the PR description writer plugin:
-
-  ```bash
-  /plugin install pr-description-writer@diversiotech
-  ```
-
-- Install the code review processor plugin:
-
-  ```bash
-  /plugin install process-code-review@diversiotech
-  ```
-
-- Install the MixPanel analytics plugin:
-
-  ```bash
-  /plugin install mixpanel-analytics@diversiotech
-  ```
-
-- Install the ClickUp ticket plugin:
-
-  ```bash
-  /plugin install clickup-ticket@diversiotech
-  ```
-
-- Install the repo docs plugin:
-
-  ```bash
-  /plugin install repo-docs@diversiotech
-  ```
-
-- Install the visual explainer plugin:
-
-  ```bash
-  /plugin install visual-explainer@diversiotech
-  ```
-
-  If you already installed the upstream plugin, uninstall it first so the
-  marketplace entry is unambiguous:
-
-  ```bash
-  /plugin uninstall visual-explainer@visual-explainer-marketplace
-  ```
-
-- Install the backend release plugin:
-
-  ```bash
-  /plugin install backend-release@diversiotech
-  ```
-
-- Install the Dependabot remediation plugin:
-
-  ```bash
-  /plugin install dependabot-remediation@diversiotech
-  ```
-
-- Install the Terraform workflows plugin:
-
-  ```bash
-  /plugin install terraform@diversiotech
-  ```
-
-- Install the login CTA attribution plugin:
-
-  ```bash
-  /plugin install login-cta-attribution-skill@diversiotech
-  ```
-
-- **Uninstall all Diversio plugins** (Claude Code) to reinstall fresh:
-
-  First check what's installed: `/plugin list` (note `Scope:` field).
-
-  ```bash
-  # User scope (default) - run each line
-  /plugin uninstall monty-code-review@diversiotech
-  /plugin uninstall backend-atomic-commit@diversiotech
-  /plugin uninstall backend-pr-workflow@diversiotech
-  /plugin uninstall bruno-api@diversiotech
-  /plugin uninstall code-review-digest-writer@diversiotech
-  /plugin uninstall plan-directory@diversiotech
-  /plugin uninstall pr-description-writer@diversiotech
-  /plugin uninstall process-code-review@diversiotech
-  /plugin uninstall mixpanel-analytics@diversiotech
-  /plugin uninstall clickup-ticket@diversiotech
-  /plugin uninstall repo-docs@diversiotech
-  /plugin uninstall visual-explainer@diversiotech
-  /plugin uninstall backend-release@diversiotech
-  /plugin uninstall dependabot-remediation@diversiotech
-  /plugin uninstall terraform@diversiotech
-  /plugin uninstall login-cta-attribution-skill@diversiotech
-  ```
-
-  For project-scoped plugins, add `--scope project`:
-
-  ```bash
-  /plugin uninstall <plugin>@diversiotech --scope project
-  ```
-
-  **Troubleshooting:** If a plugin shows in list but "not found" on uninstall,
-  try the other scope. For stuck/disabled plugins, enable first then uninstall.
-  For manual cleanup, delete `.claude/` in project root or check `~/.config/claude/`.
-
-## Codex Skill Installer Notes (For LLMs)
-
-When a user asks how to install these Skills into OpenAI Codex (not Claude's
-marketplace), respond with instructions that avoid hardcoded paths:
-
-- Use the Skill Installer script that ships with Codex:
-  - `$CODEX_HOME/skills/.system/skill-installer/scripts/install-skill-from-github.py`
-  - (with `CODEX_HOME` defaulting to `~/.codex`)
-- Prefer `--repo DiversioTeam/agent-skills-marketplace --path plugins/<plugin>/skills/<skill>`.
-- Mention `--ref <branch-or-tag>` for pinning and the need to restart Codex.
-- Avoid hardcoded absolute user paths like `/Users/<name>/...`.
-- If the user wants Codex-console commands, provide `$skill-installer` examples
-  that mirror the repo/path usage above.
-- If the user is replacing the upstream `visual-explainer` skill with this
-  repo's version, remind them to remove the existing
-  `$CODEX_HOME/skills/visual-explainer` directory first because the installer
-  does not overwrite existing skills.
-
-- **Uninstall all Diversio skills** (Codex) to reinstall fresh:
-
-  ```bash
-  # Uninstall all Diversio skills (safe: continues if skill doesn't exist)
-  CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
-  rm -rf "$CODEX_HOME/skills/monty-code-review" \
-         "$CODEX_HOME/skills/backend-atomic-commit" \
-         "$CODEX_HOME/skills/backend-pr-workflow" \
-         "$CODEX_HOME/skills/bruno-api" \
-         "$CODEX_HOME/skills/code-review-digest-writer" \
-         "$CODEX_HOME/skills/plan-directory" \
-         "$CODEX_HOME/skills/backend-ralph-plan" \
-         "$CODEX_HOME/skills/pr-description-writer" \
-         "$CODEX_HOME/skills/process-code-review" \
-         "$CODEX_HOME/skills/mixpanel-analytics" \
-         "$CODEX_HOME/skills/clickup-ticket" \
-         "$CODEX_HOME/skills/repo-docs-generator" \
-         "$CODEX_HOME/skills/visual-explainer" \
-         "$CODEX_HOME/skills/release-manager" \
-         "$CODEX_HOME/skills/dependabot-remediation" \
-         "$CODEX_HOME/skills/terraform-atomic-commit" \
-         "$CODEX_HOME/skills/terraform-pr-workflow" \
-         "$CODEX_HOME/skills/login-cta-attribution-skill"
-  ```
-
-  After removing, restart Codex and reinstall using the Skill Installer.
-
-## Usage Notes for Humans
-
-- After installation, you can use:
-  - `monty-code-review` for hyper‑pedantic Django4Lyfe backend reviews.
-  - `backend-atomic-commit` for backend pre-commit fixes and strict atomic
-     commits that obey local `AGENTS.md`, `.pre-commit-config.yaml`,
-     `.security/*` helpers, and Monty's backend taste (no AI commit
-     signatures). Includes `/backend-atomic-commit:commit` for full
-     run→fix→commit closure with convergence budgets and stuck detection.
-  - `backend-pr-workflow` for backend PR workflow checks (ClickUp-linked
-    branch/PR naming, migrations, downtime-safe schema changes).
-  - `bruno-api` to generate API endpoint documentation from Bruno (`.bru`)
-    files by tracing the corresponding Django4Lyfe implementation.
-  - `code-review-digest-writer` to generate weekly code review digests for a
-    repo based on PR review comments.
-  - `plan-directory` to create and maintain structured plan directories with
-    a master PLAN.md index and numbered task files (001-*.md) containing
-    checklists, tests, and completion criteria.
-  - `backend-ralph-plan` to create RALPH loop-integrated plans for backend
-    Django projects with iteration-aware prompts, quality gates, and
-    automated execution via `/plan-directory:run <slug>`.
-  - `pr-description-writer` to generate comprehensive, reviewer-friendly PR
-    descriptions with visual diagrams, summary tables, and structured sections.
-  - `process-code-review` to interactively process code review findings from
-    monty-code-review output - fix or skip issues with status tracking.
-  - `mixpanel-analytics` to implement new MixPanel tracking events and review
-    implementations for PII protection, schema design, and pattern compliance
-    in the Django4Lyfe optimo_analytics module.
-  - `clickup-ticket` to fetch, filter, and create ClickUp tickets directly from
-    Claude Code or Codex. Supports reading tickets by ID, powerful filtering
-    (status, assignee, tags, dates), viewing assigned tickets, multi-org
-    workspaces, subtasks, and intelligent caching of workspace data. Commands:
-    - `/clickup-ticket:get-ticket <id>` – Fetch full ticket details by ID or URL
-    - `/clickup-ticket:list-tickets` – List/filter tickets (status, assignee, tags, dates)
-    - `/clickup-ticket:my-tickets` – View your assigned tickets grouped by urgency
-    - `/clickup-ticket:create-ticket` – Full interactive ticket creation
-    - `/clickup-ticket:quick-ticket` – Fast ticket with defaults
-    - `/clickup-ticket:add-to-backlog` – Ultra-fast backlog addition
-    - `/clickup-ticket:create-subtask` – Add subtask to existing ticket
-    - `/clickup-ticket:switch-org` – Switch between organizations
-    - `/clickup-ticket:configure` – Set up defaults and cache
-  - `repo-docs` to generate and canonicalize repository harness documentation. Commands:
-    - `/repo-docs:generate [path]` – Generate repository harness docs: a short
-      AGENTS.md map, README.md, CLAUDE.md stub, and focused repo-local docs.
-    - `/repo-docs:canonicalize [path]` – Audit existing docs across a repo:
-      trim bloated AGENTS.md files, move deep detail into topic docs, and
-      normalize all CLAUDE.md files to minimal `@AGENTS.md` stubs.
-  - `visual-explainer` to generate presentation-ready HTML explainers for plans,
-    diffs, docs, architecture, audits, and stakeholder updates. It gathers
-    missing audience/goal/source context interactively, separates confirmed
-    facts from inference, and writes a shareable HTML page to
-    `~/.agent/diagrams/`. Command:
-    - `/visual-explainer:explain [topic]` – Create the default visual explainer
-      flow with optional technical mode, Markdown summary, reply draft, or
-      slides.
-  - `backend-release` to manage the full release workflow for Django4Lyfe backend
-    (Diversio monolith). Handles release PRs, date-based version bumping
-    (YYYY.MM.DD), uv lock updates, and GitHub release publishing. Commands:
-    - `/backend-release:check` – Check what commits are pending release
-    - `/backend-release:create` – Create release PR with merge method
-    - `/backend-release:publish [PR_NUMBER]` – Publish GitHub release after PR merge
-  - `dependabot-remediation` to plan and execute unified backend/frontend
-    Dependabot remediation workflows, including `.github/dependabot.yml`
-    review/scaffold, clear wave boundaries, and closure verification. Commands:
-    - `/dependabot-remediation:backend [triage|execute-wave <N>|release]` – Backend remediation lane (backend-scoped inventory)
-    - `/dependabot-remediation:frontend [triage|execute|release]` – Frontend remediation lane
-  - `terraform-atomic-commit` for Terraform/Terragrunt pre-commit fixes and strict
-    atomic commits (fmt/validate/docs drift; no apply; no AI commit signatures). Commands:
-    - `/terraform:pre-commit` – Fix and validate changed IaC files
-    - `/terraform:atomic-commit` – Enforce staged atomicity + propose commit message
-  - `terraform-pr-workflow` for Terraform/Terragrunt PR workflow checks (naming,
-    PR hygiene, read-only CI gates, versioning expectations). Command:
-    - `/terraform:check-pr` – Review PR workflow quality
-  - `login-cta-attribution-skill` to implement new CTA login attribution sources
-    for the Django4Lyfe backend. Guides adding new CTA sources (Slack, Teams,
-    Email) with proper enum registration, allowlist updates, button/tab
-    attribution, URL generation, and tests. Command:
-    - `/login-cta-attribution-skill:implement` – Add a new CTA source with full attribution
-
-## References
-
-- [Agent Skills Standard](https://agentskills.io/specification)
-- [Agent Skills Best Practices](https://agentskills.io/best-practices)
-- [Claude Agent Skills Best Practices](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/best-practices)
-- [OpenAI Codex Skills](https://developers.openai.com/codex/skills)
-- [OpenAI Codex Skills (Install new skills)](https://developers.openai.com/codex/skills#install-new-skills)
-- [Harness engineering: leveraging Codex in an agent-first world](https://openai.com/index/harness-engineering/)
-- [Claude Agent Skills Overview](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview)
-- [Claude Code Plugins](https://code.claude.com/docs/en/plugins)
-- [Plugin Marketplaces](https://code.claude.com/docs/en/plugin-marketplaces)
-- [Agent Skills](https://code.claude.com/docs/en/skills)
+# AGENTS.md
+
+## What This Repo Is
+
+This repo is Diversio's configuration-only marketplace for reusable Agent
+Skills and Claude Code plugins. The source of truth is the marketplace
+metadata, per-plugin manifests, skill docs, slash-command wrappers, and the
+repo-local docs that explain how they fit together.
+
+Do not add application behavior here. Keep changes scoped to docs, manifests,
+skills, commands, and supporting validation scripts.
+
+## How To Navigate This Repo
+
+- Start here for repo-wide rules, verified commands, and doc routing.
+- Read `docs/architecture/overview.md` for the marketplace layout, boundaries,
+  and change flow.
+- Read `docs/quality/gates.md` for CI checks, manifest-sync rules, and the
+  `SKILL.md` size guardrail.
+- Read `docs/runbooks/distribution.md` for Claude Code and Codex install,
+  uninstall, and reinstall workflows.
+- Read `docs/plugins/catalog.md` for the plugin inventory, skill paths, and
+  slash commands.
+- Read `docs/python-typing-and-ty-best-practices.md` when editing a
+  code-touching Python skill.
+- Read `CONTRIBUTING.md` when adding a plugin or reshaping a skill.
+
+## Commands
+
+```bash
+bash scripts/validate-skills.sh
+bash scripts/validate-skills.sh --all
+jq -e . .claude-plugin/marketplace.json >/dev/null
+jq -e . plugins/<plugin>/.claude-plugin/plugin.json >/dev/null
+git diff -- AGENTS.md CLAUDE.md README.md CONTRIBUTING.md docs .claude-plugin plugins
+```
+
+## Non-Negotiable Rules
+
+- Treat this as configuration, not application code.
+- Keep JSON valid and minimal. When a plugin changes, bump the version in both
+  `plugins/<plugin>/.claude-plugin/plugin.json` and the matching entry in
+  `.claude-plugin/marketplace.json`.
+- Every skill must live under `plugins/<plugin>/skills/<skill>/SKILL.md` and
+  have at least one thin wrapper in `plugins/<plugin>/commands/*.md`.
+- Keep each changed `SKILL.md` at or below 500 lines. Move deep guidance to
+  `references/` and reusable logic to `scripts/`.
+- Quote YAML frontmatter strings that contain special characters such as
+  colons, commas, brackets, or quotes.
+- `CLAUDE.md` is a minimal `@AGENTS.md` pointer only. Put durable rules here or
+  in repo-local docs, not in `CLAUDE.md`.
+- `README.md` is still a maintained engineer-facing document. When plugin
+  inventory, install flows, slash-command examples, or the top-level repo shape
+  change, update `README.md` as well as the focused docs.
+- For Python code-touching skills, document type-gate detection in this order:
+  `ty`, then `pyright`, then `mypy`. If `ty` is configured in the target repo,
+  treat it as mandatory and blocking.
+- When documenting Codex installation, use the `$CODEX_HOME`-based installer
+  pattern from `docs/runbooks/distribution.md`; avoid hardcoded user paths and
+  mention `--ref`, restart requirements, and the `visual-explainer`
+  replacement caveat.
+- After substantive skill, command, manifest, or doc changes, do a fresh-eyes
+  pass across adjacent docs and metadata before stopping.
+
+## Repo Shape
+
+- `.claude-plugin/marketplace.json` - top-level marketplace definition
+- `plugins/<plugin>/.claude-plugin/plugin.json` - per-plugin manifest
+- `plugins/<plugin>/skills/<skill>/SKILL.md` - skill definition
+- `plugins/<plugin>/commands/*.md` - slash-command wrappers
+- `scripts/validate-skills.sh` - local and CI `SKILL.md` size budget check
+- `.github/workflows/validate-marketplace.yml` - JSON, version, and structure CI
+- `.github/workflows/notify-plugin-updates.yml` - Slack notification on plugin
+  changes pushed to `main`
+
+## Docs Index
+
+- `README.md` - human-first quickstart and entrypoint
+- `docs/architecture/overview.md` - structure, ownership boundaries, and flows
+- `docs/quality/gates.md` - validation, CI coverage, and recurring failure modes
+- `docs/runbooks/distribution.md` - Claude Code and Codex install workflows
+- `docs/plugins/catalog.md` - plugin inventory, commands, and skill paths
+- `docs/python-typing-and-ty-best-practices.md` - policy for code-touching
+  Python skills
+- `CONTRIBUTING.md` - how to add or update plugins safely
+
+## Keep The Harness Fresh
+
+- If a failure repeats, encode it in docs, scripts, or CI instead of letting it
+  remain tribal knowledge.
+- If install or distribution behavior changes, update
+  `docs/runbooks/distribution.md` and any top-level pointers that reference it.
+- If the plugin inventory or command surface changes, update both
+  `docs/plugins/catalog.md` and `README.md`. Keep the catalog as the structured
+  inventory and keep `README.md` accurate for engineers who use it as the main
+  handbook.
+- Add focused docs under `docs/` instead of turning this file back into a
+  handbook.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,14 +5,4 @@
 ## Notes
 
 This `CLAUDE.md` intentionally sources `AGENTS.md` so that requirements,
-commands, and agent behavior live in a single source of truth for this repo.
-
-For Claude Code best practices on `CLAUDE.md` / `AGENTS.md` in web-based repos,
-see:
-- https://docs.claude.com/en/docs/claude-code/claude-code-on-the-web#best-practices
-
-Relevant guidance (summarized):
-- Document requirements: clearly specify dependencies and commands for the
-  project.
-- If you have an `AGENTS.md` file, you can source it in your `CLAUDE.md` using
-  `@AGENTS.md` to maintain a single source of truth.
+commands, and agent behavior have a single canonical entrypoint in this repo.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,183 +1,112 @@
 # Contributing to `agent-skills-marketplace`
 
-This repo is an **Agent Skills marketplace** for Diversio. It is mostly
-configuration, Skills, and commands – not application code. The goal is to make
-it easy to add and evolve Skills and plugin metadata using LLMs while keeping
-things consistent and safe.
+This repo is a configuration marketplace for Diversio-maintained Agent Skills
+and Claude Code plugins. Treat it as manifests, docs, commands, and validation
+scripts, not application code.
 
-If in doubt, treat `AGENTS.md` as the source of truth and follow it first.
+Start with `AGENTS.md` for repo-wide rules, then use the focused docs in
+`docs/` for deeper guidance:
+
+- `docs/architecture/overview.md`
+- `docs/quality/gates.md`
+- `docs/runbooks/distribution.md`
+- `docs/plugins/catalog.md`
 
 ## What You Can Change
 
-In this repo, contributions should generally be limited to:
+Contributions should generally be limited to:
 
-- `AGENTS.md`, `CLAUDE.md`
+- `AGENTS.md`, `CLAUDE.md`, `README.md`, `CONTRIBUTING.md`
 - `.claude-plugin/marketplace.json`
-- `plugins/**/.claude-plugin/plugin.json` (per-plugin manifests)
-- `plugins/**/skills/*/SKILL.md` (Skill definitions)
-- `plugins/**/commands/*.md` (slash command entrypoints)
-- `README.md` / `CONTRIBUTING.md` / other small docs
+- `plugins/**/.claude-plugin/plugin.json`
+- `plugins/**/skills/*/SKILL.md`
+- `plugins/**/commands/*.md`
+- `docs/**`
+- `scripts/**`
 
-Do **not** add application logic (Django, React, Terraform, etc.) here.
+Do not add application logic here.
 
-## Adding a New Plugin
+## Adding Or Updating A Plugin
 
-Follow the existing structure (e.g. `monty-code-review`, `backend-atomic-commit`):
-
-1. **Create the plugin folder**
+1. Create or update the plugin shape
 
    ```text
    plugins/<plugin-name>/
      .claude-plugin/plugin.json
      skills/<skill-name>/SKILL.md
-     commands/<command-name>.md (one or more)
+     commands/<command-name>.md
    ```
 
-   - Use `kebab-case` for `<plugin-name>` where possible.
-   - `<skill-name>` is usually the same as the plugin name, but doesn’t have to be.
+2. Keep manifests minimal and synchronized
 
-2. **Plugin manifest**
+   - `plugins/<plugin-name>/.claude-plugin/plugin.json` must stay valid JSON.
+   - `.claude-plugin/marketplace.json` must contain a matching entry with the
+     same `name`, `version`, and `source`.
+   - Any plugin change requires a version bump in both files.
 
-   `plugins/<plugin-name>/.claude-plugin/plugin.json`:
+3. Keep skills small and portable
 
-   - Keep it minimal and valid JSON.
-   - Fields:
-     - `name` – plugin name (kebab-case).
-     - `version` – SemVer-like string.
-     - `description` – short, human-readable.
-     - `author` – e.g. `{ "name": "Diversio Devs" }`.
+   - `SKILL.md` should focus on activation workflow, priorities, and output
+     shape.
+   - Keep each changed `SKILL.md` at or below 500 lines.
+   - Move long procedures into `references/` and reusable logic into `scripts/`.
+   - Quote YAML frontmatter strings when they contain special characters.
 
-   **Versioning rules:**
+4. Keep slash commands thin
 
-   - New plugins start at `0.1.0` (or similar).
-   - On any behavior or docs change to the plugin, bump the version:
-     - e.g. `0.1.0` → `0.1.1`.
+   - Every skill needs at least one command under `plugins/<plugin>/commands/`.
+   - Command files should invoke the skill and add only command-specific
+     context; they should not duplicate the full skill body.
 
-3. **Marketplace entry**
+5. Preserve repo-local policy docs
 
-   Add an entry to `.claude-plugin/marketplace.json`:
+   - Update `docs/plugins/catalog.md` when plugin inventory or slash commands
+     change.
+   - Update `README.md` when plugin inventory, install commands, slash command
+     examples, or the repository structure summary change.
+   - Keep the engineer-facing README sections current:
+     - repository tree diagram
+     - available plugins table
+     - install examples
+     - slash command examples
+   - Update `docs/runbooks/distribution.md` when install, uninstall, or Codex
+     distribution guidance changes.
+   - Update `AGENTS.md` when repo-wide navigation, commands, or agent-facing
+     rules change.
+   - If the plugin touches code-oriented Python workflows, reflect the typing
+     policy in `docs/python-typing-and-ty-best-practices.md`.
 
-   - `name` – must match plugin manifest.
-   - `version` – must match plugin manifest version.
-   - `source` – `./plugins/<plugin-name>`.
-   - `category`, `keywords` – keep them short and accurate.
+## Validation
 
-4. **Skill definition**
+Run the guardrails that match your change:
 
-   `plugins/<plugin-name>/skills/<skill-name>/SKILL.md` should:
+```bash
+bash scripts/validate-skills.sh
+bash scripts/validate-skills.sh --all
+jq -e . .claude-plugin/marketplace.json >/dev/null
+jq -e . plugins/<plugin>/.claude-plugin/plugin.json >/dev/null
+```
 
-   - Start with YAML frontmatter:
+The `Validate Marketplace` GitHub workflow also checks:
 
-     ```yaml
-     ---
-     name: <skill-name>
-     description: "Short, single-line summary of what this Skill does."
-     allowed-tools: Bash Read Edit Glob Grep
-     ---
-     ```
+- JSON parses cleanly
+- marketplace plugin names are unique
+- every marketplace entry has a matching `plugins/<name>` directory
+- every plugin manifest name and version matches the marketplace entry
+- each plugin has at least one `SKILL.md`
 
-   - For portability across both Codex + Claude Code:
-     - Keep `description` single-line and reasonably short (Codex validates this at startup).
-     - Avoid `anthropic`/`claude` in Skill names and don’t include XML tags in `name`/`description` (Claude).
+## Review Checklist
 
-   - Include sections such as:
-     - `When to Use This Skill`
-     - `Example Prompts`
-     - Core priorities / taste (what the Skill optimizes for)
-     - Any severity tags and required output structure
-     - High-level workflow / checklist
+Before opening a PR or pushing directly:
 
-   - Keep it self-contained and repo-agnostic where possible:
-     - If it depends on a particular repo’s `AGENTS.md`, say so explicitly.
-     - Avoid hard-coding customer-specific or secret information.
-
-5. **Commands**
-
-   Add one or more command files under:
-
-   ```text
-   plugins/<plugin-name>/commands/<command-name>.md
-   ```
-
-   Each should:
-
-   - Have a short frontmatter block:
-
-     ```yaml
-     ---
-     description: Short description of what this command does.
-     ---
-     ```
-
-   - Instruct Claude to “use your `<skill-name>` Skill” with:
-     - Clear mode (e.g. “pre-commit mode”, “atomic-commit mode”, “PR review mode”).
-     - High-level focus areas.
-     - Any special flags/arguments to interpret.
-
-   Commands should be **thin wrappers** over the Skill – avoid duplicating full
-   Skill logic in the command file.
-
-6. **Docs & references**
-
-   - Update `README.md`:
-     - Add the plugin to the tree diagram.
-     - Add a row to the “Available Plugins” table.
-     - Add an install example and slash command examples.
-   - Update `AGENTS.md`:
-     - Add an install command for the new plugin.
-     - Add a short bullet under “Usage Notes for Humans”.
-
-## Using LLMs to Create Skills & Commands
-
-We expect most Skills and commands here to be written with LLM help. That’s OK
-and encouraged – a few guidelines:
-
-- It’s fine to **reuse prompt patterns** across Skills:
-  - Example: Monty’s backend taste, severity tags, output shapes.
-  - Example: “When to Use This Skill” + “Example Prompts” sections.
-- Anchor new Skills in existing ones:
-  - If you’re adding a backend tool, read:
-    - `plugins/monty-code-review/skills/monty-code-review/SKILL.md`
-    - `plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md`
-    - `plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md`
-  - Reuse structure and wording where it saves review time, then customize the
-    behavior and context.
-- Keep prompts **explicit and pedantic**:
-  - Spell out checklists and severity tags.
-  - Define the expected output shape (sections, tags, summaries).
-  - When behavior involves repositories with `AGENTS.md`, tell the Skill to
-    treat those as the source of truth.
-- Always review LLM output before committing:
-  - Remove or rephrase anything that sounds generic or misaligned with Diversio.
-  - Make sure no secrets, tokens, or internal-only URLs are included.
-
-## JSON & Validation
-
-- Always keep JSON valid:
-  - You can use `python -m json.tool` or any editor tooling locally to validate
-    `.claude-plugin/marketplace.json` and `plugin.json` files.
-- Optionally validate Skills against the Agent Skills spec using `skills-ref validate <path>` (if you have `skills-ref` installed).
-- Prefer small, focused edits over wholesale rewrites:
-  - This makes diffs easier to review.
-
-## Review Checklist for PRs
-
-Before opening a PR (or pushing directly, if that’s your workflow), quickly
-check:
-
-- [ ] New plugin has:
-  - [ ] `plugins/<plugin-name>/.claude-plugin/plugin.json`
-  - [ ] `plugins/<plugin-name>/skills/<skill-name>/SKILL.md`
-  - [ ] `plugins/<plugin-name>/commands/*.md`
-- [ ] Plugin `version` matches in `plugin.json` and `marketplace.json`.
-- [ ] `marketplace.json` JSON parses cleanly.
-- [ ] `README.md` and `AGENTS.md` mention the new plugin where appropriate.
-- [ ] SKILL docs:
-  - [ ] Explain when to use the Skill.
-  - [ ] Include example prompts.
-  - [ ] Define severity tags / output shape if the Skill reports findings.
-- [ ] No application code or secrets added to this repo.
-
-Following these guidelines should keep new plugins easy to add, easy to review,
-and consistent with the rest of the marketplace. Feel free to evolve this
-document as we learn what patterns work best.
+- [ ] Plugin manifest and marketplace entry are in sync.
+- [ ] Every changed skill still has at least one command wrapper.
+- [ ] Changed `SKILL.md` files stay within the 500-line budget.
+- [ ] `docs/plugins/catalog.md` reflects any added, removed, or renamed plugins
+      and commands.
+- [ ] `README.md` reflects any changed plugin inventory, install flows,
+      repository structure summaries, or slash command examples.
+- [ ] `docs/runbooks/distribution.md` still matches the supported Claude Code
+      and Codex installation flows.
+- [ ] `README.md` and `AGENTS.md` still point to the right docs.
+- [ ] No application code or secrets were added.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,61 @@
+# Architecture Overview
+
+## Main Components
+
+- `.claude-plugin/marketplace.json`
+  - The top-level Claude Code marketplace definition.
+  - Owns the published plugin list, versions, descriptions, categories, and
+    source paths.
+- `plugins/<plugin>/`
+  - Each plugin directory owns one plugin manifest, one or more skills, and
+    one or more slash-command wrappers.
+- `plugins/<plugin>/skills/<skill>/SKILL.md`
+  - The canonical instructions for a skill.
+  - Deep procedures should live one level deeper in `references/` or `scripts/`.
+- `plugins/<plugin>/commands/*.md`
+  - Thin wrappers that surface skills as `/plugin:command` entries in Claude
+    Code.
+- `scripts/validate-skills.sh`
+  - Local and CI guardrail for the `SKILL.md` line-count budget.
+- `.github/workflows/validate-marketplace.yml`
+  - Structure and consistency checks for marketplace metadata and changed
+    skills.
+- `.github/workflows/notify-plugin-updates.yml`
+  - Post-merge notification flow for plugin changes pushed to `main`.
+
+## Boundaries
+
+- This repo stores configuration and documentation for skills. It should not
+  contain application behavior from the target repos those skills operate on.
+- The marketplace manifest and per-plugin manifests must agree on plugin name,
+  version, and source path.
+- Slash-command files should stay thin. The real behavior belongs in
+  `SKILL.md`, `references/`, and helper scripts.
+- `README.md` stays human-first, `AGENTS.md` stays as the agent routing map,
+  and detailed guidance lives under `docs/`.
+
+## Main Flows
+
+1. Add or change a plugin
+   - Update the skill, command wrapper, and plugin manifest under
+     `plugins/<plugin>/`.
+   - Sync the matching `.claude-plugin/marketplace.json` entry.
+   - Update the catalog or distribution docs if the user-facing inventory
+     changed.
+2. Validate locally
+   - Run `bash scripts/validate-skills.sh` for changed skills.
+   - Validate edited JSON with `jq -e .`.
+3. CI verification
+   - `Validate Marketplace` checks JSON validity, unique plugin names,
+     directory/manifest consistency, version sync, presence of skills, and the
+     `SKILL.md` size budget.
+4. Post-merge notification
+   - Pushes to `main` that touch `plugins/**` trigger Slack update messages with
+     plugin names, versions, and changelog snippets.
+
+## Useful References
+
+- `AGENTS.md` - repo-wide rules and navigation
+- `docs/quality/gates.md` - validation details and recurring failure modes
+- `docs/runbooks/distribution.md` - install, uninstall, and reinstall commands
+- `docs/plugins/catalog.md` - plugin inventory and slash commands

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -1,0 +1,122 @@
+# Plugin Catalog
+
+This is the canonical inventory for marketplace plugins, their skill paths, and
+their slash commands. Update it when a plugin is added, removed, renamed, or
+when command files change.
+
+## Review And Workflow
+
+- `monty-code-review`
+  - Purpose: hyper-pedantic Django4Lyfe backend code review.
+  - Claude install: `claude plugin install monty-code-review@diversiotech`
+  - Skill path: `plugins/monty-code-review/skills/monty-code-review`
+  - Slash commands: `/monty-code-review:code-review`
+- `backend-atomic-commit`
+  - Purpose: backend pre-commit fixes and strict atomic commits.
+  - Claude install: `claude plugin install backend-atomic-commit@diversiotech`
+  - Skill path: `plugins/backend-atomic-commit/skills/backend-atomic-commit`
+  - Slash commands: `/backend-atomic-commit:pre-commit`,
+    `/backend-atomic-commit:atomic-commit`, `/backend-atomic-commit:commit`
+- `backend-pr-workflow`
+  - Purpose: backend PR workflow, naming, and migration safety checks.
+  - Claude install: `claude plugin install backend-pr-workflow@diversiotech`
+  - Skill path: `plugins/backend-pr-workflow/skills/backend-pr-workflow`
+  - Slash commands: `/backend-pr-workflow:check-pr`
+- `process-code-review`
+  - Purpose: process findings from `monty-code-review`.
+  - Claude install: `claude plugin install process-code-review@diversiotech`
+  - Skill path: `plugins/process-code-review/skills/process-code-review`
+  - Slash commands: `/process-code-review:process-review`
+- `backend-release`
+  - Purpose: Django4Lyfe backend release management.
+  - Claude install: `claude plugin install backend-release@diversiotech`
+  - Skill path: `plugins/backend-release/skills/release-manager`
+  - Slash commands: `/backend-release:check`, `/backend-release:create`,
+    `/backend-release:publish`
+- `dependabot-remediation`
+  - Purpose: backend and frontend Dependabot triage, execution, and release
+    closure.
+  - Claude install:
+    `claude plugin install dependabot-remediation@diversiotech`
+  - Skill path:
+    `plugins/dependabot-remediation/skills/dependabot-remediation`
+  - Slash commands: `/dependabot-remediation:backend`,
+    `/dependabot-remediation:frontend`
+- `terraform`
+  - Purpose: Terraform/Terragrunt atomic-commit and PR workflow checks.
+  - Claude install: `claude plugin install terraform@diversiotech`
+  - Skill paths: `plugins/terraform/skills/terraform-atomic-commit`,
+    `plugins/terraform/skills/terraform-pr-workflow`
+  - Slash commands: `/terraform:pre-commit`, `/terraform:atomic-commit`,
+    `/terraform:check-pr`
+
+## Documentation And Planning
+
+- `bruno-api`
+  - Purpose: generate API docs from Bruno collections by tracing Django
+    implementations.
+  - Claude install: `claude plugin install bruno-api@diversiotech`
+  - Skill path: `plugins/bruno-api/skills/bruno-api`
+  - Slash commands: `/bruno-api:docs`
+- `code-review-digest-writer`
+  - Purpose: generate weekly code-review digest docs from PR comments.
+  - Claude install:
+    `claude plugin install code-review-digest-writer@diversiotech`
+  - Skill path:
+    `plugins/code-review-digest-writer/skills/code-review-digest-writer`
+  - Slash commands: `/code-review-digest-writer:review-digest`
+- `plan-directory`
+  - Purpose: create structured plan directories and backend RALPH execution
+    plans.
+  - Claude install: `claude plugin install plan-directory@diversiotech`
+  - Skill paths: `plugins/plan-directory/skills/plan-directory`,
+    `plugins/plan-directory/skills/backend-ralph-plan`
+  - Slash commands: `/plan-directory:plan`,
+    `/plan-directory:backend-ralph-plan`, `/plan-directory:run`
+- `pr-description-writer`
+  - Purpose: reviewer-friendly pull request descriptions with diagrams and
+    tables.
+  - Claude install:
+    `claude plugin install pr-description-writer@diversiotech`
+  - Skill path:
+    `plugins/pr-description-writer/skills/pr-description-writer`
+  - Slash commands: `/pr-description-writer:write-pr`
+- `repo-docs`
+  - Purpose: generate and canonicalize repository harness docs.
+  - Claude install: `claude plugin install repo-docs@diversiotech`
+  - Skill path: `plugins/repo-docs/skills/repo-docs-generator`
+  - Slash commands: `/repo-docs:generate`, `/repo-docs:canonicalize`
+- `visual-explainer`
+  - Purpose: presentation-ready HTML explainers for plans, diffs, diagrams,
+    and stakeholder updates.
+  - Claude install: `claude plugin install visual-explainer@diversiotech`
+  - Skill path: `plugins/visual-explainer/skills/visual-explainer`
+  - Slash commands: `/visual-explainer:explain`
+
+## Operations And Implementation
+
+- `clickup-ticket`
+  - Purpose: read, filter, and create ClickUp tickets with multi-org support.
+  - Claude install: `claude plugin install clickup-ticket@diversiotech`
+  - Skill path: `plugins/clickup-ticket/skills/clickup-ticket`
+  - Slash commands: `/clickup-ticket:get-ticket`,
+    `/clickup-ticket:list-tickets`, `/clickup-ticket:my-tickets`,
+    `/clickup-ticket:create-ticket`, `/clickup-ticket:quick-ticket`,
+    `/clickup-ticket:create-subtask`, `/clickup-ticket:add-to-backlog`,
+    `/clickup-ticket:configure`, `/clickup-ticket:switch-org`,
+    `/clickup-ticket:add-org`, `/clickup-ticket:list-spaces`,
+    `/clickup-ticket:refresh-cache`
+- `mixpanel-analytics`
+  - Purpose: implement and review MixPanel tracking for the Django
+    `optimo_analytics` module.
+  - Claude install: `claude plugin install mixpanel-analytics@diversiotech`
+  - Skill path: `plugins/mixpanel-analytics/skills/mixpanel-analytics`
+  - Slash commands: `/mixpanel-analytics:implement`,
+    `/mixpanel-analytics:review`
+- `login-cta-attribution-skill`
+  - Purpose: add CTA login attribution sources and related tests.
+  - Claude install:
+    `claude plugin install login-cta-attribution-skill@diversiotech`
+  - Skill path:
+    `plugins/login-cta-attribution-skill/skills/login-cta-attribution-skill`
+  - Slash commands: `/login-cta-attribution-skill:implement`

--- a/docs/quality/gates.md
+++ b/docs/quality/gates.md
@@ -1,0 +1,66 @@
+# Quality Gates
+
+## Required Commands
+
+Run the checks that match the files you touched:
+
+```bash
+bash scripts/validate-skills.sh
+bash scripts/validate-skills.sh --all
+jq -e . .claude-plugin/marketplace.json >/dev/null
+jq -e . plugins/<plugin>/.claude-plugin/plugin.json >/dev/null
+```
+
+`bash scripts/validate-skills.sh` checks changed and untracked `SKILL.md`
+files. Use `--all` when auditing the full repo.
+
+## Active Type Gate
+
+This repo does not ship Python application code, so there is no local runtime
+type-check job to run here.
+
+The typing policy in this marketplace applies to the repos that code-touching
+skills target:
+
+- Read `docs/python-typing-and-ty-best-practices.md`.
+- Detect type gates in this order unless the target repo says otherwise:
+  `ty`, then `pyright`, then `mypy`.
+- If `ty` is configured in the target repo, treat it as mandatory and blocking.
+
+## Common Failures
+
+- Plugin version changed in `plugins/<plugin>/.claude-plugin/plugin.json` but
+  not in `.claude-plugin/marketplace.json`.
+- Marketplace `source` does not match `./plugins/<plugin>`.
+- A skill was added or renamed without a matching command wrapper.
+- A changed `SKILL.md` grew beyond 500 lines instead of moving detail into
+  `references/` or `scripts/`.
+- YAML frontmatter uses unquoted strings with special characters, which breaks
+  parsing.
+- `CLAUDE.md` accumulates unique behavior instead of remaining a pointer to
+  `AGENTS.md`.
+- Docs mention install or maintenance behavior that no longer matches the repo.
+
+## CI Notes
+
+- `Validate Marketplace`
+  - Triggered by changes under `.claude-plugin/**`, `plugins/**`, `scripts/**`,
+    or the workflow file itself.
+  - Validates JSON, unique plugin names, plugin directory coverage, manifest
+    name and version sync, skill presence, and changed-skill size budgets.
+- `Notify Plugin Updates`
+  - Triggered by pushes to `main` that touch `plugins/**`.
+  - Diffs the previous commit, extracts changed plugin versions and top
+    changelog snippets, and posts a Slack message.
+
+Docs-only changes do not currently trigger the marketplace validation workflow,
+so run the local checks manually when you touch shared instructions.
+
+## Review Discipline
+
+- After substantive edits, review the changed files plus the adjacent docs or
+  metadata they rely on.
+- If a workflow changed, update the focused doc that owns it instead of
+  expanding `AGENTS.md` or `CLAUDE.md`.
+- If the same failure repeats across reviews, add a harness improvement: a doc,
+  script, CI check, or clearer wrapper.

--- a/docs/runbooks/distribution.md
+++ b/docs/runbooks/distribution.md
@@ -1,0 +1,208 @@
+# Distribution Runbook
+
+Use this file for installation, uninstallation, and reinstall workflows across
+Claude Code and Codex.
+
+## Claude Code Marketplace
+
+### Add the marketplace
+
+Terminal:
+
+```bash
+claude plugin marketplace add DiversioTeam/agent-skills-marketplace
+```
+
+Inside Claude Code:
+
+```text
+/plugin marketplace add DiversioTeam/agent-skills-marketplace
+```
+
+### Install a plugin
+
+```bash
+claude plugin install repo-docs@diversiotech
+```
+
+Project scope is supported, but user scope is the safest default when you work
+across multiple git worktrees:
+
+```bash
+claude plugin install repo-docs@diversiotech --scope project
+```
+
+If you are replacing the upstream `visual-explainer` plugin, uninstall that
+version first:
+
+```bash
+claude plugin uninstall visual-explainer@visual-explainer-marketplace
+```
+
+### Install all marketplace plugins
+
+```bash
+PLUGINS=(
+  monty-code-review
+  backend-atomic-commit
+  backend-pr-workflow
+  bruno-api
+  code-review-digest-writer
+  plan-directory
+  pr-description-writer
+  process-code-review
+  mixpanel-analytics
+  clickup-ticket
+  repo-docs
+  visual-explainer
+  backend-release
+  dependabot-remediation
+  terraform
+  login-cta-attribution-skill
+)
+
+for plugin in "${PLUGINS[@]}"; do
+  claude plugin install "${plugin}@diversiotech"
+done
+```
+
+Use `--scope project` inside the loop if you intentionally want project-scoped
+installs.
+
+### Uninstall all Diversio plugins
+
+Check what is installed first:
+
+```bash
+claude plugin list
+```
+
+Then uninstall the user-scoped copies:
+
+```bash
+PLUGINS=(
+  monty-code-review
+  backend-atomic-commit
+  backend-pr-workflow
+  bruno-api
+  code-review-digest-writer
+  plan-directory
+  pr-description-writer
+  process-code-review
+  mixpanel-analytics
+  clickup-ticket
+  repo-docs
+  visual-explainer
+  backend-release
+  dependabot-remediation
+  terraform
+  login-cta-attribution-skill
+)
+
+for plugin in "${PLUGINS[@]}"; do
+  claude plugin uninstall "${plugin}@diversiotech"
+done
+```
+
+If you also installed project-scoped copies:
+
+```bash
+for plugin in "${PLUGINS[@]}"; do
+  claude plugin uninstall "${plugin}@diversiotech" --scope project
+done
+```
+
+Troubleshooting:
+
+- If uninstall says the plugin is not found, try the other scope.
+- If a plugin is disabled, re-enable it before uninstalling.
+- If cleanup is still required, inspect the repo-local `.claude/` directory and
+  your user-level Claude Code config location before deleting anything.
+
+## Codex Skill Installation
+
+### Install a single skill
+
+```bash
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+
+python3 "$CODEX_HOME/skills/.system/skill-installer/scripts/install-skill-from-github.py" \
+  --repo DiversioTeam/agent-skills-marketplace \
+  --path plugins/repo-docs/skills/repo-docs-generator
+```
+
+Preferred pattern:
+
+- Use `$CODEX_HOME` instead of hardcoded absolute paths.
+- Prefer `--repo DiversioTeam/agent-skills-marketplace`.
+- Prefer `--path plugins/<plugin>/skills/<skill>`.
+- Add `--ref <branch-or-tag>` when you want to pin a branch, tag, or commit.
+- Restart Codex after installation.
+
+### Install multiple skills
+
+Repeat `--path` once per skill:
+
+```bash
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+
+python3 "$CODEX_HOME/skills/.system/skill-installer/scripts/install-skill-from-github.py" \
+  --repo DiversioTeam/agent-skills-marketplace \
+  --ref main \
+  --path plugins/repo-docs/skills/repo-docs-generator \
+  --path plugins/visual-explainer/skills/visual-explainer
+```
+
+Codex console example:
+
+```text
+$skill-installer install from github repo=DiversioTeam/agent-skills-marketplace path=plugins/repo-docs/skills/repo-docs-generator
+```
+
+See `docs/plugins/catalog.md` for the full set of skill paths.
+
+### Replace an existing skill
+
+The installer does not overwrite an existing skill directory. Remove the old
+directory first, then reinstall.
+
+If you are replacing the upstream `visual-explainer` skill with this repo's
+version, remove the existing directory first:
+
+```bash
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+rm -rf "$CODEX_HOME/skills/visual-explainer"
+```
+
+### Uninstall all Diversio Codex skills
+
+```bash
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+
+SKILLS=(
+  monty-code-review
+  backend-atomic-commit
+  backend-pr-workflow
+  bruno-api
+  code-review-digest-writer
+  plan-directory
+  backend-ralph-plan
+  pr-description-writer
+  process-code-review
+  mixpanel-analytics
+  clickup-ticket
+  repo-docs-generator
+  visual-explainer
+  release-manager
+  dependabot-remediation
+  terraform-atomic-commit
+  terraform-pr-workflow
+  login-cta-attribution-skill
+)
+
+for skill in "${SKILLS[@]}"; do
+  rm -rf "$CODEX_HOME/skills/$skill"
+done
+```
+
+Restart Codex after uninstalling and reinstalling skills.


### PR DESCRIPTION
## Summary

This PR canonicalizes the repository documentation harness by shrinking the agent entrypoints, moving durable detail into focused docs, and making the README maintenance rules explicit while keeping `README.md` itself unchanged.

### Key Features

| Feature | Description |
|---------|-------------|
| **Shorter agent entrypoints** | Turns `AGENTS.md` into a routing map and `CLAUDE.md` into a minimal pointer. |
| **Focused repo-local docs** | Adds dedicated docs for architecture, quality gates, distribution workflows, and the plugin catalog. |
| **Explicit README maintenance** | Restores contributor guidance that the engineer-facing README must stay current when plugin inventory, install flows, or command examples change. |

## Documentation Flow

```text
README.md (engineer-facing handbook)
        │
        ├── AGENTS.md (agent routing map + hard rules)
        │       │
        │       ├── docs/architecture/overview.md
        │       ├── docs/quality/gates.md
        │       ├── docs/runbooks/distribution.md
        │       └── docs/plugins/catalog.md
        │
        └── CLAUDE.md (@AGENTS.md pointer only)
```

---

## Entry Point Cleanup

This change trims the top-level agent-facing docs so repo rules and navigation are easier to scan.

Key implementation details:
- `AGENTS.md` now focuses on verified commands, hard rules, repo shape, and doc routing.
- `CLAUDE.md` is reduced to the minimal `@AGENTS.md` stub.
- `README.md` is intentionally left unchanged because engineers actively use it as the fuller handbook.

---

## Focused Repo-Local Docs

This change moves durable operational detail into focused docs instead of keeping it in the entrypoints.

Key implementation details:
- Adds `docs/architecture/overview.md` for structure, boundaries, and change flow.
- Adds `docs/quality/gates.md` for validation commands, CI coverage, and recurring failure modes.
- Adds `docs/runbooks/distribution.md` for Claude Code and Codex install, uninstall, and reinstall workflows.
- Adds `docs/plugins/catalog.md` as the structured source for plugin inventory, skill paths, and slash commands.

---

## Contribution Guidance

This change keeps the repository documentation contract explicit for future updates.

Key implementation details:
- `CONTRIBUTING.md` now points contributors at the new focused docs.
- README maintenance expectations are explicit again.
- Contributor checklists now call out keeping README inventory, install flows, repository structure summaries, and slash-command examples current.

## Files Changed

<details>
<summary>Top-level harness docs</summary>

- `AGENTS.md` - trims the agent entrypoint into a routing map with hard rules and doc links.
- `CLAUDE.md` - normalizes the file to a minimal `@AGENTS.md` stub.
- `CONTRIBUTING.md` - updates contributor guidance to reflect the layered docs harness and README maintenance requirements.

</details>

<details>
<summary>Focused docs</summary>

- `docs/architecture/overview.md` - documents repository components, boundaries, and change flow.
- `docs/quality/gates.md` - documents validation commands, CI checks, and common failure modes.
- `docs/runbooks/distribution.md` - documents Claude Code and Codex distribution workflows.
- `docs/plugins/catalog.md` - documents plugin inventory, skill paths, and slash commands.

</details>

## How to Test

```bash
bash scripts/validate-skills.sh
git diff --check
```

### Manual Testing

1. Open `AGENTS.md` and verify it reads as a routing map rather than a handbook.
2. Open `CLAUDE.md` and verify it is only an `@AGENTS.md` stub.
3. Open `CONTRIBUTING.md` and verify README maintenance expectations are explicit.
4. Open the new docs under `docs/` and verify each topic has a clear single purpose.
5. Confirm `README.md` is unchanged.

## Notes

- Docs-only change; no marketplace JSON or plugin manifest behavior changed.
- No breaking changes expected.
