### PR TITLE
Add backend-skills plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -182,6 +182,17 @@
       "source": "./plugins/login-cta-attribution-skill",
       "category": "code-analysis",
       "keywords": ["django", "cta", "attribution", "login", "tracking", "slack", "teams", "email", "optimo", "diversio"]
+    },
+    {
+      "name": "backend-skills",
+      "description": "Backend workflow skills for Django4Lyfe: interactive PR review fix, commit-and-reply with SHA links, and codebase reuse finder with product boundary awareness.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Diversio Devs"
+      },
+      "source": "./plugins/backend-skills",
+      "category": "process",
+      "keywords": ["django", "backend", "pr-review", "commit", "reuse", "constants", "optimo", "diversio"]
     }
   ]
 }

--- a/plugins/backend-skills/.claude-plugin/plugin.json
+++ b/plugins/backend-skills/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "backend-skills",
+  "version": "0.1.0",
+  "description": "Backend workflow skills for Django4Lyfe: PR review fix, commit-and-reply, and codebase reuse finder.",
+  "author": {
+    "name": "Diversio Devs"
+  }
+}

--- a/plugins/backend-skills/commands/codebase-reuse-finder.md
+++ b/plugins/backend-skills/commands/codebase-reuse-finder.md
@@ -1,0 +1,21 @@
+---
+description: Scan code for hardcoded values and find existing constants/utilities
+---
+
+Use your `codebase-reuse-finder` Skill to scan current changes or a specified
+file/directory for hardcoded values, magic numbers, and reimplemented patterns,
+following the workflow and product boundary rules defined in its SKILL.md.
+
+**Arguments:** `$ARGUMENTS`
+
+Focus order:
+
+1. Determine scope (argument, staged changes, or unstaged changes).
+2. Auto-detect product boundary (Optimo vs Diversio vs Shared).
+3. Extract candidates (string literals, magic numbers, reimplemented patterns).
+4. Search for existing replacements (constants, utilities, model choices, DRF built-ins).
+5. Tag findings by severity (BLOCKING, SHOULD_FIX, NIT).
+6. Present findings grouped by file with import paths.
+
+If `--apply` is provided, implement BLOCKING and SHOULD_FIX replacements,
+run ruff and ty, and stage modified files.

--- a/plugins/backend-skills/commands/commit-and-reply.md
+++ b/plugins/backend-skills/commands/commit-and-reply.md
@@ -1,0 +1,23 @@
+---
+description: Commit, push, and reply to addressed PR reviewer comments with SHA
+---
+
+Use your `commit-and-reply` Skill to invoke `/backend-atomic-commit:commit` for
+quality gates and commit creation, then push to remote, then reply to each
+addressed PR reviewer comment on GitHub with the commit SHA link, following
+the workflow defined in its SKILL.md.
+
+**Arguments:** `$ARGUMENTS`
+
+Focus order:
+
+1. Verify staged changes exist and detect the PR.
+2. Invoke `/backend-atomic-commit:commit` for quality gates and commit.
+3. Push to remote.
+4. Determine which comments to reply to (from context or `--all`).
+5. Pre-audit for duplicate replies.
+6. Post replies with commit SHA link.
+7. Post-audit for duplicates.
+
+If `--all` is provided, reply to all unresolved reviewer comments.
+No AI signatures in commits or GitHub comments.

--- a/plugins/backend-skills/commands/pr-review-fix.md
+++ b/plugins/backend-skills/commands/pr-review-fix.md
@@ -1,0 +1,21 @@
+---
+description: Fetch and address PR reviewer comments interactively
+---
+
+Use your `pr-review-fix` Skill to fetch reviewer comments from the current PR,
+present each with code context, and implement fixes following the workflow and
+quality gates defined in its SKILL.md.
+
+**Arguments:** `$ARGUMENTS`
+
+Focus order:
+
+1. Identify the PR (from argument or current branch).
+2. Fetch all reviewer comments (reviews, inline, general).
+3. Classify by severity and present one-by-one using AskUserQuestion.
+4. On Fix: edit code, run ruff immediately.
+5. After all comments: run ty, stage modified files.
+6. Output summary with addressed comment IDs.
+
+If `--auto` is provided, fix all actionable comments without prompting.
+Does NOT commit — use `/backend-skills:commit-and-reply` after.

--- a/plugins/backend-skills/skills/codebase-reuse-finder/SKILL.md
+++ b/plugins/backend-skills/skills/codebase-reuse-finder/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: codebase-reuse-finder
+description: >
+    Scan current changes for hardcoded values, magic numbers, and reimplemented
+    patterns. Search the codebase for existing constants, utilities, and
+    abstractions that could replace them. Reports findings with import paths.
+    Respects the Diversio/Optimo product boundary.
+user-invocable: true
+argument-hint: '[file-or-directory] [--apply]'
+allowed-tools: [Bash, Read, Glob, Grep, Edit]
+---
+
+# Codebase Reuse Finder Skill
+
+Scan code for hardcoded values, magic numbers, and reimplemented patterns.
+Search the codebase for existing constants, utilities, and abstractions that
+could replace them. Standalone skill — use anytime, not tied to the PR workflow.
+
+**Reference documentation:**
+
+- `AGENTS.md` — product boundaries and global rules
+- `docs/architecture/overview.md` — system architecture and module relationships
+
+---
+
+## Step 1: Determine Scope
+
+Three ways to determine what code to scan:
+
+### A: Explicit file or directory (argument)
+
+If a file or directory is provided as argument, scan that directly.
+
+### B: Staged and unstaged changes (default)
+
+If no argument is provided, scan current changes:
+
+```bash
+# Staged changes
+git diff --cached --name-only | grep -E '\.py$'
+
+# Unstaged changes
+git diff --name-only | grep -E '\.py$'
+```
+
+### C: Combined
+
+If both argument and changes exist, scan only the argument.
+
+If no argument and no changes, tell the user:
+
+> "No changes detected and no file/directory specified. Please provide a target
+> or make some changes first."
+
+---
+
+## Step 2: Auto-Detect Product Boundary
+
+Determine which product the scanned files belong to, which controls the search
+scope for replacements:
+
+| Scanned file path starts with | Product    | Search scope                                                             |
+| ------------------------------ | ---------- | ------------------------------------------------------------------------ |
+| `optimo_*`                     | Optimo     | `optimo_core/`, `optimo_surveys/`, `optimo_integrations/`, `optimo_hris_csv_processing/`, `utils/` |
+| `dashboardapp/`                | Diversio   | `dashboardapp/`, `survey/`, `pulse_iq/`, `titan/`, `utils/`             |
+| `survey/`                      | Diversio   | `dashboardapp/`, `survey/`, `pulse_iq/`, `titan/`, `utils/`             |
+| `pulse_iq/`                    | Diversio   | `dashboardapp/`, `survey/`, `pulse_iq/`, `titan/`, `utils/`             |
+| `titan/`                       | Diversio   | `dashboardapp/`, `survey/`, `pulse_iq/`, `titan/`, `utils/`             |
+| `utils/`                       | Shared     | Everything (shared code can reference any module)                        |
+| Other                          | Contextual | Infer from imports in the file                                           |
+
+**Hard boundary:**
+
+- Optimo code must **never** suggest imports from Diversio apps
+- Diversio code must **never** suggest imports from `optimo_*` apps
+- `utils/` is always fair game for both products
+
+---
+
+## Step 3: Extract Candidates
+
+Read each file in scope and identify:
+
+### String literals
+
+- Hardcoded URLs, API paths, email addresses
+- Hardcoded status strings (`"active"`, `"pending"`, `"completed"`)
+- Hardcoded error messages that might exist as constants elsewhere
+- Hardcoded feature flags or config keys
+
+### Magic numbers
+
+- Numeric literals other than `0`, `1`, `-1` (these are generally acceptable)
+- HTTP status codes used as raw integers (`404`, `200`, `403`)
+- Timeout values, retry counts, page sizes
+- Percentage thresholds, scoring weights
+
+### Reimplemented patterns
+
+- Manual date/time formatting (vs `timezone.now()`, `timedelta`, etc.)
+- Manual decimal rounding (vs `Decimal` utilities)
+- Manual queryset filtering patterns that exist as manager methods
+- Manual string normalization that exists as utility functions
+- Manual permission checks that exist as policy functions
+
+### Repeated patterns
+
+- Same literal appearing 2+ times in the scanned files
+- Copy-pasted logic blocks that could be a shared function
+
+---
+
+## Step 4: Search for Existing Replacements
+
+For each candidate, search in this order (respecting product boundary from
+Step 2):
+
+### 1. Constants files
+
+```bash
+# Common constant locations
+Grep for the literal value or a semantically similar constant name in:
+  utils/constants.py
+  optimo_core/services/constants.py
+  optimo_surveys/constants.py
+  <app>/constants.py  (for the current app)
+  settings/*.py
+```
+
+### 2. Utility modules
+
+```bash
+# Common utility locations
+Grep for similar function names or patterns in:
+  utils/*.py
+  optimo_core/utils/*.py
+  <app>/utils.py or <app>/utils/*.py
+```
+
+### 3. Model choices (TextChoices / IntegerChoices)
+
+```bash
+# Search for Django choice enums
+Grep for "TextChoices\|IntegerChoices" in models.py and choices.py files
+  within the search scope
+```
+
+### 4. Service methods
+
+```bash
+# Search for existing service classes with similar logic
+Grep in:
+  <app>/services/*.py
+  optimo_core/services/*.py
+```
+
+### 5. Django and DRF built-ins
+
+Check if the hardcoded value maps to a well-known constant:
+
+| Hardcoded value | Replacement                            |
+| --------------- | -------------------------------------- |
+| `200`           | `rest_framework.status.HTTP_200_OK`    |
+| `201`           | `rest_framework.status.HTTP_201_CREATED` |
+| `400`           | `rest_framework.status.HTTP_400_BAD_REQUEST` |
+| `403`           | `rest_framework.status.HTTP_403_FORBIDDEN` |
+| `404`           | `rest_framework.status.HTTP_404_NOT_FOUND` |
+| `"utf-8"`       | Usually fine as-is                     |
+| Raw `datetime.now()` | `django.utils.timezone.now()`     |
+| Raw `json.dumps()` on response | `JsonResponse` or DRF serializer |
+
+---
+
+## Step 5: Tag Findings by Severity
+
+### `[BLOCKING]`
+
+Hardcoded secrets, API keys, passwords, database connection strings, or tokens.
+These must be fixed immediately — they should use `settings` or environment
+variables.
+
+### `[SHOULD_FIX]`
+
+The hardcoded value **matches an existing constant** or the pattern
+**reimplements an existing utility**. Include the exact import path:
+
+```
+[SHOULD_FIX] optimo_surveys/views/response.py:42
+  Current:  status_code = 400
+  Replace:  from rest_framework import status; status_code = status.HTTP_400_BAD_REQUEST
+```
+
+### `[NIT]`
+
+The value could benefit from being a constant, but no existing constant was
+found. This is a suggestion for future improvement, not a required change.
+
+---
+
+## Step 6: Present Findings
+
+For each finding, show:
+
+```
+[SEVERITY] file_path:line_number
+  Current code:   <the line with the hardcoded value>
+  Existing replacement: <constant/utility name>
+  Import path:    <from X import Y>
+  Reason:         <why this replacement is better>
+```
+
+Group findings by file, then by severity within each file.
+
+---
+
+## Step 7: Apply Fixes (if `--apply`)
+
+When `--apply` is passed:
+
+1. For each `[BLOCKING]` and `[SHOULD_FIX]` finding:
+   - Add the necessary import (respecting existing import style)
+   - Replace the hardcoded value with the constant/utility
+   - Do **not** fix `[NIT]` findings automatically
+
+2. After all replacements, run quality gates:
+
+```bash
+.bin/ruff check --fix <modified-files>
+.bin/ruff format <modified-files>
+.bin/ty check <modified-files>
+```
+
+3. Stage modified files:
+
+```bash
+git add <modified-files>
+```
+
+---
+
+## Step 8: Output Summary
+
+```
+Codebase Reuse Finder Summary
+==============================
+Scope: <files/directory scanned>
+Product boundary: <Optimo | Diversio | Shared>
+
+Files analyzed: <N>
+
+Findings:
+  [BLOCKING]:   <N>
+  [SHOULD_FIX]: <N>
+  [NIT]:        <N>
+
+Top reuse opportunities:
+  1. <constant/utility> — used in <N> places, could replace <N> hardcoded values
+  2. <constant/utility> — ...
+  3. <constant/utility> — ...
+
+<if --apply>
+Applied fixes: <N> ([BLOCKING] + [SHOULD_FIX] only)
+Quality gates: passed
+Files staged: <list>
+</if>
+```
+
+---
+
+## Rules
+
+- **Respect the Diversio/Optimo product boundary** — never suggest cross-product
+  imports.
+- **`utils/` is shared** — always search `utils/` regardless of product.
+- **Don't flag `0`, `1`, `-1`** — these are generally acceptable magic numbers.
+- **Include import paths** — every `[SHOULD_FIX]` must include a working import
+  statement.
+- **Don't create new constants** — this skill finds existing reuse opportunities,
+  it does not create new abstractions.
+- **`--apply` only fixes `[BLOCKING]` and `[SHOULD_FIX]`** — `[NIT]` findings
+  are informational only.
+
+---
+
+## Example Prompts
+
+> `/codebase-reuse-finder`
+>
+> Scans all staged and unstaged changes for reuse opportunities.
+
+> `/codebase-reuse-finder optimo_surveys/views/`
+>
+> Scans all files in the optimo_surveys views directory.
+
+> `/codebase-reuse-finder optimo_core/services/onboarding.py --apply`
+>
+> Scans the file and automatically applies fixes for BLOCKING and SHOULD_FIX
+> findings.
+
+---
+
+## Example Finding Output
+
+```
+[SHOULD_FIX] optimo_surveys/views/response.py:42
+  Current code:   if response.status_code == 400:
+  Existing replacement: HTTP_400_BAD_REQUEST
+  Import path:    from rest_framework.status import HTTP_400_BAD_REQUEST
+  Reason:         DRF provides named constants for all HTTP status codes
+
+[SHOULD_FIX] optimo_core/services/invitation.py:87
+  Current code:   expires_in = 72 * 60 * 60  # 72 hours
+  Existing replacement: INVITATION_EXPIRY_SECONDS
+  Import path:    from optimo_core.services.constants import INVITATION_EXPIRY_SECONDS
+  Reason:         This exact value is already defined as a named constant
+
+[BLOCKING] dashboardapp/views/export.py:15
+  Current code:   api_key = "sk-prod-abc123..."
+  Existing replacement: settings.EXPORT_API_KEY
+  Import path:    from django.conf import settings
+  Reason:         Hardcoded API key — must use settings/environment variable
+
+[NIT] survey/tasks.py:203
+  Current code:   batch_size = 500
+  Existing replacement: (none found)
+  Reason:         Consider extracting to a constant if used in multiple places
+```

--- a/plugins/backend-skills/skills/commit-and-reply/SKILL.md
+++ b/plugins/backend-skills/skills/commit-and-reply/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: commit-and-reply
+description: >
+    Invoke /backend-atomic-commit:commit for quality gates and commit creation,
+    then push to remote, then reply to each addressed PR reviewer comment on
+    GitHub with the commit SHA link. No AI signatures anywhere.
+user-invocable: true
+argument-hint: '[--all]'
+allowed-tools: [Bash, Read, Edit, Glob, Grep, Skill]
+---
+
+# Commit and Reply Skill
+
+Commit staged changes via `/backend-atomic-commit:commit`, push to remote, and
+reply to each addressed PR reviewer comment with a commit SHA link. Designed to
+run after `/pr-review-fix`.
+
+**Reference documentation:**
+
+- `docs/runbooks/pr-review-posting-hygiene.md` — posting protocol and dedupe rules
+- `docs/quality/gates.md` — quality gate definitions
+- `AGENTS.md` — product boundaries, commit conventions, and global rules
+
+---
+
+## Step 1: Verify Preconditions
+
+Check that there are staged changes and detect the PR:
+
+```bash
+# Verify staged changes exist
+git diff --cached --name-only
+
+# Detect PR from current branch
+gh pr view --json number,url,headRefName
+```
+
+Set up environment:
+
+```bash
+OWNER="DiversioTeam"
+REPO="Django4Lyfe"
+ME="$(gh api user --jq '.login')"
+PR=<detected-pr-number>
+```
+
+**If nothing is staged**, stop and tell the user:
+
+> "No staged changes found. Run `/pr-review-fix` first to address reviewer
+> comments and stage fixes."
+
+**If no PR is found**, stop and tell the user to push the branch and open a PR
+first.
+
+---
+
+## Step 2: Invoke Atomic Commit
+
+Invoke the backend atomic commit skill to handle all quality gates and create
+the commit:
+
+```
+/backend-atomic-commit:commit
+```
+
+This handles:
+
+- Ruff check and format
+- `ty` check
+- Django system checks
+- Ticket-prefixed commit message (extracted from branch name)
+- Pre-commit hook compliance
+- **No AI signatures** in the commit message
+
+**If BLOCKING issues are found**, stop. The atomic commit skill will report
+what needs to be fixed. Fix the issues, re-stage, and re-run this skill.
+
+---
+
+## Step 3: Push to Remote
+
+Push the commit to the remote branch:
+
+```bash
+git push
+```
+
+**If push fails** (e.g., remote has new commits):
+
+> "Push failed. Try `git pull --rebase` to incorporate remote changes, then
+> re-run `/commit-and-reply`."
+
+Do not force-push.
+
+---
+
+## Step 4: Get Commit SHA
+
+Capture the commit SHA for use in reply comments:
+
+```bash
+FULL_SHA="$(git rev-parse HEAD)"
+SHORT_SHA="$(git rev-parse --short HEAD)"
+COMMIT_MSG="$(git log -1 --format='%s')"
+```
+
+---
+
+## Step 5: Determine Comments to Reply To
+
+Three modes for selecting which comments get replies:
+
+### Mode A: Conversation Context (default)
+
+If `/pr-review-fix` was run earlier in this conversation, use the addressed
+comment IDs it tracked. This is the preferred flow.
+
+### Mode B: `--all` Flag
+
+If `--all` is passed, fetch all unresolved reviewer comments:
+
+```bash
+# Inline comments from other reviewers
+gh api "repos/$OWNER/$REPO/pulls/$PR/comments" --paginate \
+  --jq "[.[] | select(.user.login != \"$ME\") | {id, path, body}]"
+
+# General comments from other reviewers
+gh api "repos/$OWNER/$REPO/issues/$PR/comments" --paginate \
+  --jq "[.[] | select(.user.login != \"$ME\") | {id, body}]"
+```
+
+### Mode C: No IDs, No `--all`
+
+If no addressed IDs are available and `--all` was not passed, ask the user:
+
+> "I don't have a list of addressed comments from a prior `/pr-review-fix` run.
+> Would you like me to:
+>
+> 1. Reply to **all** reviewer comments with this commit SHA
+> 2. **Skip** replies (just commit and push)
+> 3. **List** reviewer comments so you can pick which ones to reply to"
+
+---
+
+## Step 6: Pre-Audit for Duplicates
+
+Before posting any replies, check for existing replies from self to avoid
+duplicates (per `pr-review-posting-hygiene.md` MUST_04):
+
+```bash
+# Check existing inline comment replies from self
+gh api "repos/$OWNER/$REPO/pulls/$PR/comments" --paginate \
+  --jq "[.[] | select(.user.login == \"$ME\") | {id, in_reply_to_id, body, created_at}]"
+
+# Check existing issue-level comments from self
+gh api "repos/$OWNER/$REPO/issues/$PR/comments" --paginate \
+  --jq "[.[] | select(.user.login == \"$ME\") | {id, body, created_at}]"
+```
+
+For each comment we plan to reply to:
+
+- If a reply from self already exists with the same SHA → **skip** (already
+  replied)
+- If a reply from self exists with a different SHA → **skip** (previous
+  attempt, don't double-post)
+
+---
+
+## Step 7: Post Replies
+
+### Reply format
+
+All replies use the same format — short, factual, no AI signatures:
+
+```
+Addressed in [<SHORT_SHA>](https://github.com/DiversioTeam/Django4Lyfe/commit/<FULL_SHA>).
+```
+
+### For inline review comments
+
+Reply as a thread response to the original comment:
+
+```bash
+gh api "repos/$OWNER/$REPO/pulls/$PR/comments/$COMMENT_ID/replies" \
+  -f body="Addressed in [$SHORT_SHA](https://github.com/DiversioTeam/Django4Lyfe/commit/$FULL_SHA)."
+```
+
+### For general PR comments
+
+Post a new issue comment referencing the original:
+
+```bash
+gh api "repos/$OWNER/$REPO/issues/$PR/comments" \
+  -f body="Addressed in [$SHORT_SHA](https://github.com/DiversioTeam/Django4Lyfe/commit/$FULL_SHA)."
+```
+
+### Posting rules
+
+- Post **one reply per comment** — do not batch multiple comments into one reply
+- Do **not** retry blindly on failure — check state first
+- If a reply fails with HTTP 422, log the error and continue to the next comment
+- No AI signatures, no co-author tags, no emoji
+
+---
+
+## Step 8: Post-Audit for Duplicates
+
+Run the dedupe detector from `pr-review-posting-hygiene.md` STEP_05:
+
+```bash
+# Check inline comment duplicates
+gh api "repos/$OWNER/$REPO/pulls/$PR/comments" --paginate --slurp \
+  | jq --arg me "$ME" '
+      map(if type == "array" then . else [.] end)
+      | flatten
+      | map(select(.user.login == $me))
+      | group_by([.path, (.line // -1), ((.body // "") | split("\n")[0])])
+      | map(select(length > 1) | {
+          duplicate_count: length,
+          path: .[0].path,
+          line: .[0].line,
+          sample_ids: map(.id)
+        })
+    '
+
+# Check issue-level comment duplicates
+gh api "repos/$OWNER/$REPO/issues/$PR/comments" --paginate --slurp \
+  | jq --arg me "$ME" '
+      map(if type == "array" then . else [.] end)
+      | flatten
+      | map(select(.user.login == $me))
+      | group_by(((.body // "") | split("\n")[0]))
+      | map(select(length > 1) | {
+          duplicate_count: length,
+          first_line: ((.[0].body // "") | split("\n")[0]),
+          sample_ids: map(.id)
+        })
+    '
+```
+
+**If duplicates are found**, delete the extras immediately:
+
+```bash
+# Delete duplicate inline comments
+gh api -X DELETE "repos/$OWNER/$REPO/pulls/comments/$DUPLICATE_ID"
+
+# Delete duplicate issue comments
+gh api -X DELETE "repos/$OWNER/$REPO/issues/comments/$DUPLICATE_ID"
+```
+
+Keep only the earliest comment per unique intent.
+
+---
+
+## Step 9: Output Summary
+
+```
+Commit and Reply Summary
+========================
+Commit: <SHORT_SHA> — <commit-message>
+Push: success
+PR: #<number> — <url>
+
+Replies posted: <N>
+  - Comment #<id> by <reviewer> → replied
+  - Comment #<id> by <reviewer> → replied
+  - Comment #<id> by <reviewer> → skipped (already replied)
+
+Dedupe audit: clean (no duplicates) | removed <N> duplicates
+```
+
+---
+
+## Rules
+
+- **No AI signatures** — no `Co-Authored-By: Claude`, no bot tags, no emoji
+  signatures in commits or GitHub comments.
+- **Follow `pr-review-posting-hygiene.md`** — dedupe audit before and after
+  posting, one reply per comment, no blind retries.
+- **Never post duplicate replies** — always check existing replies first.
+- **Do not force-push** — if push fails, tell the user to rebase.
+- **Skill invocation** — step 2 must use `/backend-atomic-commit:commit`, not
+  manual commit logic. This keeps commit quality gates DRY.
+
+---
+
+## Example Prompts
+
+> `/commit-and-reply`
+>
+> After running `/pr-review-fix`, commits staged changes, pushes, and replies
+> to each addressed comment with the commit SHA.
+
+> `/commit-and-reply --all`
+>
+> Commits, pushes, and replies to ALL reviewer comments on the PR (not just
+> those addressed in the current session).

--- a/plugins/backend-skills/skills/pr-review-fix/SKILL.md
+++ b/plugins/backend-skills/skills/pr-review-fix/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: pr-review-fix
+description: >
+    Fetch and address PR reviewer comments from GitHub. Reads reviewer feedback,
+    presents each with code context, implements fixes, runs quality gates, and
+    stages changes. Does NOT commit — use /commit-and-reply after.
+user-invocable: true
+argument-hint: '[pr-number] [--auto]'
+allowed-tools: [Bash, Read, Edit, Glob, Grep, AskUserQuestion]
+---
+
+# PR Review Fix Skill
+
+Fetch PR reviewer comments, present each interactively, implement fixes, run
+quality gates, and stage changes. Does **not** commit — use `/commit-and-reply`
+after.
+
+---
+
+## Step 1: Identify PR
+
+```bash
+OWNER="DiversioTeam"
+REPO="Django4Lyfe"
+ME="$(gh api user --jq '.login')"
+```
+
+If a PR number is provided as argument, use it. Otherwise detect from branch:
+
+```bash
+gh pr view --json number,title,url,headRefName
+```
+
+If no PR found, stop and tell the user.
+
+---
+
+## Step 2: Fetch All Comments
+
+Run all three in parallel:
+
+```bash
+# Review submissions (exclude self)
+gh api "repos/$OWNER/$REPO/pulls/$PR/reviews" --paginate
+
+# Inline review comments (exclude self)
+gh api "repos/$OWNER/$REPO/pulls/$PR/comments" --paginate
+
+# General PR comments (exclude self)
+gh api "repos/$OWNER/$REPO/issues/$PR/comments" --paginate
+```
+
+Filter out:
+
+- Your own comments (`user.login == $ME`)
+- Bot comments (GitHub Actions, CI bots)
+- Reply chains you started
+
+Classify each by severity:
+
+| Tag | Criteria |
+|-----|----------|
+| `[BLOCKING]` | Correctness, security, data integrity, multi-tenant boundary |
+| `[SHOULD_FIX]` | Performance, missing validation, confusing logic |
+| `[NIT]` | Style, naming, minor readability |
+
+Comments that are purely questions with no actionable fix get tagged as
+non-actionable and presented last.
+
+Sort: BLOCKING first, then SHOULD_FIX, then NIT, then non-actionable.
+
+---
+
+## Step 3: Interactive Loop
+
+For each comment:
+
+1. **Display context** — show the reviewer's comment, the diff hunk (for inline
+   comments), and ~10 lines of current code around the referenced location.
+
+2. **Prompt with `AskUserQuestion`** — use the interactive selection UI:
+
+```yaml
+question: "[SEVERITY] @reviewer on file.py:L120 — How should I handle this?"
+header: "Action"
+options:
+  - label: "Fix (Recommended)"
+    description: "Implement the requested change"
+    preview: |
+      <proposed diff when inferable from the comment>
+  - label: "Skip"
+    description: "Leave for now, move to next comment"
+  - label: "More context"
+    description: "Show more surrounding code, then ask again"
+  - label: "Reply only"
+    description: "Don't change code, draft a reply to the reviewer"
+```
+
+3. **On Fix**: edit the code, then run ruff on that file immediately:
+
+```bash
+.bin/ruff check --fix <file>
+.bin/ruff format <file>
+```
+
+4. **On Skip**: record the comment ID as skipped, move on.
+
+5. **On Reply only**: draft a reply message, record the comment ID for
+   `/commit-and-reply` to post.
+
+6. **Track progress** — after each comment, show a brief status line
+   (e.g. `3/12 done — 2 fixed, 1 skipped`).
+
+### `--auto` mode
+
+When `--auto` is passed:
+
+- Fix all actionable comments without prompting (skip non-actionable ones)
+- Still display each comment and the fix applied
+- Still run ruff after each fix
+
+---
+
+## Step 4: Final Quality Gates
+
+After all comments are processed, run `ty` on all modified Python files:
+
+```bash
+.bin/ty check <modified-files>
+```
+
+If errors: fix, re-run until clean.
+
+Then stage:
+
+```bash
+git add <modified-files>
+```
+
+Do **not** stage unrelated changes. Do **not** commit.
+
+---
+
+## Step 5: Summary
+
+```text
+PR Review Fix Summary
+=====================
+PR: #<number> — <title>
+
+Comments: <addressed> fixed, <skipped> skipped, <total> total
+Files modified:
+  - path/to/file1.py
+  - path/to/file2.py
+
+Quality gates: all passed
+Next step: /commit-and-reply
+```
+
+Track addressed comment IDs in conversation context (both inline and general)
+so `/commit-and-reply` knows which comments to reply to.
+
+---
+
+## Rules
+
+- **Do NOT commit.** Staging only.
+- **Respect the Diversio/Optimo product boundary** — `optimo_*` must not import
+  from `dashboardapp/`/`survey/`/`pulse_iq/`/`titan/` and vice versa. `utils/`
+  is shared.
+- **Track addressed comment IDs** for `/commit-and-reply`.
+- **Run ruff after every fix** — do not accumulate lint errors.
+- **Do not modify files** not referenced by reviewer comments.
+
+---
+
+## Example Prompts
+
+> `/pr-review-fix` — detect PR from branch, walk through comments interactively.
+
+> `/pr-review-fix 2750` — fetch comments for PR #2750.
+
+> `/pr-review-fix --auto` — auto-fix all comments on current branch's PR.


### PR DESCRIPTION
## Summary

- Adds new `backend-skills` plugin with 3 skills and 3 command wrappers
- Updates `marketplace.json` with the new plugin entry

### Skills

| Skill | Command | Purpose |
|-------|---------|---------|
| `pr-review-fix` | `/backend-skills:pr-review-fix` | Fetch PR reviewer comments, present interactively with AskUserQuestion, implement fixes, run quality gates, stage changes |
| `commit-and-reply` | `/backend-skills:commit-and-reply` | Invoke `/backend-atomic-commit:commit`, push, reply to reviewer comments with commit SHA |
| `codebase-reuse-finder` | `/backend-skills:codebase-reuse-finder` | Scan for hardcoded values/magic numbers, find existing constants/utilities, respect Diversio/Optimo boundary |

### Workflow relationship

```
Reviewer leaves comments → /backend-skills:pr-review-fix → /backend-skills:commit-and-reply → Reviewer sees replies
/backend-skills:codebase-reuse-finder → standalone, use anytime
```

### Checklist

- [x] Plugin manifest and marketplace entry are in sync
- [x] Every skill has a command wrapper
- [x] All SKILL.md files under 500 lines (183, 297, 327)
- [x] JSON validates cleanly
- [x] `scripts/validate-skills.sh` passes