### PR TITLE
Improve github-ticket project hydration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -119,8 +119,8 @@
     },
     {
       "name": "github-ticket",
-      "description": "Create, route, and inspect GitHub issues with gh CLI-backed defaults for DiversioTeam/monolith and repo-local execution repos.",
-      "version": "0.1.0",
+      "description": "Create, route, and inspect GitHub issues with gh CLI-backed defaults for DiversioTeam/monolith, repo-local execution repos, and project-board hydration.",
+      "version": "0.1.1",
       "author": {
         "name": "Diversio Devs"
       },

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ agent-skills-marketplace/
 | `process-code-review` | Process code review findings - interactively fix or skip issues from monty-code-review output with status tracking |
 | `mixpanel-analytics` | MixPanel tracking implementation and review Skill for Django4Lyfe optimo_analytics module with PII protection and pattern enforcement |
 | `clickup-ticket` | Legacy ClickUp ticket management during the GitHub work-management migration |
-| `github-ticket` | GitHub-native issue management with smart defaults for `monolith`, backlog capture, and repo-local execution routing |
+| `github-ticket` | GitHub-native issue management with smart defaults for `monolith`, backlog capture, repo-local execution routing, and project-board hydration |
 | `repo-docs` | Generate and canonicalize repository harness docs: short AGENTS.md maps, README.md, CLAUDE.md stubs, and focused repo-local docs for architecture, gates, and runbooks |
 | `visual-explainer` | Generate presentation-ready HTML explainers for plans, diffs, diagrams, audits, and stakeholder updates with interactive intake, explicit fact-vs-inference separation, and optional Netlify preview publishing |
 | `backend-release` | Django4Lyfe backend release workflow - create release PRs, date-based version bumping (YYYY.MM.DD), and GitHub release publishing |
@@ -364,7 +364,7 @@ Once plugins are installed:
    /clickup-ticket:switch-org                # Switch between organizations
    /clickup-ticket:add-org                   # Add a new organization
    /clickup-ticket:refresh-cache             # Force refresh cached data
-   /github-ticket:configure                  # Configure planning repo, execution repos, and default labels
+   /github-ticket:configure                  # Configure planning repo, execution repos, project defaults, and labels
    /github-ticket:get-issue                  # Fetch one GitHub issue in detail
    /github-ticket:list-issues                # List/search issues across one repo or a small repo set
    /github-ticket:my-issues                  # Show assigned work across configured repos

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -108,7 +108,7 @@ when command files change.
     `/clickup-ticket:add-org`, `/clickup-ticket:list-spaces`,
     `/clickup-ticket:refresh-cache`
 - `github-ticket`
-  - Purpose: GitHub-native issue management with planning-hub and execution-repo routing defaults.
+  - Purpose: GitHub-native issue management with planning-hub routing, repo-local execution issues, and project-board defaults.
   - Claude install: `claude plugin install github-ticket@diversiotech`
   - Skill path: `plugins/github-ticket/skills/github-ticket`
   - Slash commands: `/github-ticket:configure`,

--- a/plugins/github-ticket/.claude-plugin/plugin.json
+++ b/plugins/github-ticket/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "github-ticket",
-  "version": "0.1.0",
-  "description": "Create, route, and inspect GitHub issues from Claude Code or Codex with gh CLI-backed defaults for DiversioTeam/monolith and repo-local execution repos.",
+  "version": "0.1.1",
+  "description": "Create, route, and inspect GitHub issues from Claude Code or Codex with gh CLI-backed defaults for DiversioTeam/monolith, repo-local execution repos, and project-board hydration.",
   "author": {
     "name": "Diversio Devs"
   }

--- a/plugins/github-ticket/commands/add-to-backlog.md
+++ b/plugins/github-ticket/commands/add-to-backlog.md
@@ -1,5 +1,5 @@
 ---
-description: Add a low-friction backlog item to the planning repo with default backlog labels.
+description: Add a low-friction backlog item to the planning repo with default backlog labels and Inbox-style project placement.
 ---
 
 Use your `github-ticket` Skill in **add-to-backlog** mode.
@@ -8,3 +8,4 @@ This is the fastest capture path:
 1. Title only.
 2. Create in `DiversioTeam/monolith` by default.
 3. Apply `triage` plus configured backlog labels.
+4. If it lands in `Diversio Work`, prefer `Status: Inbox`.

--- a/plugins/github-ticket/commands/configure.md
+++ b/plugins/github-ticket/commands/configure.md
@@ -1,5 +1,5 @@
 ---
-description: Validate gh auth and set github-ticket defaults for planning, execution repos, labels, and backlog behavior.
+description: Validate gh auth and set github-ticket defaults for planning, execution repos, project hydration, labels, and backlog behavior.
 ---
 
 Use your `github-ticket` Skill in **configure** mode.
@@ -7,6 +7,6 @@ Use your `github-ticket` Skill in **configure** mode.
 This command should:
 1. Run `gh auth status`.
 2. Create or update local config in `${XDG_CONFIG_HOME:-$HOME/.config}/github-ticket/config.json` (by default, `~/.config/github-ticket/config.json`).
-3. Confirm planning repo, preferred execution repos, default labels, and optional project settings.
+3. Confirm planning repo, preferred execution repos, default labels, and project settings including field defaults.
 
 See the `SKILL.md` for the full config model and routing rules.

--- a/plugins/github-ticket/commands/create-issue.md
+++ b/plugins/github-ticket/commands/create-issue.md
@@ -1,5 +1,5 @@
 ---
-description: Create a full GitHub issue with canonical sections, smart repo routing, and default labels.
+description: Create a full GitHub issue with canonical sections, smart repo routing, default labels, and project-board hydration.
 ---
 
 Use your `github-ticket` Skill in **create-issue** mode.
@@ -8,5 +8,6 @@ Gather enough context to create an implementation-ready issue, then:
 1. Route it to `DiversioTeam/monolith` or the chosen execution repo.
 2. Generate the canonical issue body.
 3. Apply sensible default labels.
+4. Add it to the configured project when appropriate and hydrate common board fields.
 
 Prefer fewer prompts over perfect completeness.

--- a/plugins/github-ticket/commands/create-linked-issue.md
+++ b/plugins/github-ticket/commands/create-linked-issue.md
@@ -1,7 +1,7 @@
 ---
-description: Create a linked GitHub follow-up or execution issue from an existing planning or execution issue.
+description: Create a linked GitHub follow-up or execution issue from an existing planning or execution issue, with project-board hydration.
 ---
 
 Use your `github-ticket` Skill in **create-linked-issue** mode.
 
-Create the new issue, then add reciprocal links with `gh issue comment` so the relationship is visible without relying on GitHub child-issue beta features.
+Create the new issue, add reciprocal links with `gh issue comment`, and hydrate project fields so execution work does not land on the board with blank status.

--- a/plugins/github-ticket/commands/quick-issue.md
+++ b/plugins/github-ticket/commands/quick-issue.md
@@ -1,5 +1,5 @@
 ---
-description: Create a GitHub issue quickly from a title with inferred repo routing and default labels.
+description: Create a GitHub issue quickly from a title with inferred repo routing, default labels, and sensible project status defaults.
 ---
 
 Use your `github-ticket` Skill in **quick-issue** mode.
@@ -8,3 +8,4 @@ Required input:
 - a title
 
 Prefer the current repo when running inside a repo checkout, otherwise default to the planning repo.
+If the capture is still rough, prefer `Status: Inbox` when adding it to a project.

--- a/plugins/github-ticket/commands/route.md
+++ b/plugins/github-ticket/commands/route.md
@@ -1,7 +1,7 @@
 ---
-description: Route planning work from monolith into the right execution repo with low-prompt defaults.
+description: Route planning work from monolith into the right execution repo with low-prompt defaults and project-board hydration.
 ---
 
 Use your `github-ticket` Skill in **route** mode.
 
-This command should help turn a planning issue into repo-local execution work while preserving the planning issue as the coordination hub.
+This command should help turn a planning issue into repo-local execution work while preserving the planning issue as the coordination hub and giving the new issue the right board fields.

--- a/plugins/github-ticket/skills/github-ticket/SKILL.md
+++ b/plugins/github-ticket/skills/github-ticket/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-ticket
-description: "Create, route, and inspect GitHub issues from Claude Code or Codex with gh CLI-backed defaults for DiversioTeam/monolith and repo-local execution repos."
+description: "Create, route, and inspect GitHub issues from Claude Code or Codex with gh CLI-backed defaults for DiversioTeam/monolith, repo-local execution repos, and project-board hydration."
 allowed-tools: Bash Read Edit Write Glob Grep
 ---
 
@@ -15,6 +15,7 @@ Use this Skill when you want to:
 - fetch or list issues across `monolith` and a small repo set
 - view your assigned work
 - route planning work into repo-local execution issues
+- add created issues to `Diversio Work` with the right board fields
 - keep GitHub issue creation skill-driven instead of form-driven
 
 This Skill is the GitHub-native replacement for the old `clickup-ticket`
@@ -27,12 +28,18 @@ Before doing anything else:
 
 1. Run `gh auth status`.
 2. Confirm `gh` is authenticated for the right GitHub account.
-3. Fail fast if `gh` is missing or unauthenticated.
+3. Confirm the token has the scopes needed for the requested action:
+   - `repo` for issue read/write
+   - `read:org` for org visibility
+   - `project` when project add or field hydration is expected
+4. Fail fast if `gh` is missing or unauthenticated.
 
 Preferred auth model:
 
 - normal `gh` login
 - no plugin-specific token in the common case
+- if project hydration is part of the workflow and `project` scope is missing,
+  prefer `gh auth refresh -s project`
 
 ## Default Operating Model
 
@@ -50,6 +57,8 @@ them:
   - `DiversioTeam/diversio-serverless`
   - `DiversioTeam/launchpad`
   - `DiversioTeam/skiddie`
+  - `DiversioTeam/terraform-modules`
+  - `DiversioTeam/agent-skills-marketplace`
 - canonical IDs: native GitHub issue numbers
 - legacy ClickUp `GH-xxxx` IDs: metadata only when applicable
 
@@ -58,11 +67,14 @@ Routing rules:
 - If you are in the monolith root and no repo is specified, prefer
   `DiversioTeam/monolith`.
 - If you are inside a repo checkout and no repo is specified, prefer that repo
-  as the execution repo.
+  as the execution repo after normalizing the git remote into `owner/repo`.
 - If the work clearly spans repos or still needs planning, create the issue in
   `DiversioTeam/monolith`.
 - If the user asks for implementation work in a specific repo, create the
   issue in that repo when issues are enabled there.
+- If repo detection yields a GitHub repo outside the default execution list,
+  it is still valid to use that repo; do not reject it only because it is not
+  prelisted in config.
 
 ## Local Config
 
@@ -81,9 +93,18 @@ Use a small JSON file with fields like:
 - `quick_issue_labels`
 - `project_owner`
 - `project_number`
-- `path_repo_map`
+- `project_field_defaults`
+- optional `path_repo_map`
 
 See `references/config-and-body-shape.md` for a sample config and issue body.
+
+For the current Diversio baseline, prefer organization project `#2`
+(`Diversio Work`) unless the user overrides project placement.
+Treat `project_field_defaults` as a display-name keyed map for stable defaults
+like `Status` and `Priority`, not as a place to hard-code field or option IDs.
+Prefer runtime repo detection from the current git checkout before falling back
+to `path_repo_map`. In worktree-heavy setups, avoid hard-coded absolute path
+maps unless there is a real non-git edge case.
 
 ## Repo Alias Map
 
@@ -99,6 +120,9 @@ Allow these shorthand values when the user names a repo informally:
 - `diversio-serverless` -> `DiversioTeam/diversio-serverless`
 - `launchpad` -> `DiversioTeam/launchpad`
 - `skiddie` -> `DiversioTeam/skiddie`
+- `terraform-modules` -> `DiversioTeam/terraform-modules`
+- `agent-skills-marketplace` -> `DiversioTeam/agent-skills-marketplace`
+- `skills-marketplace` -> `DiversioTeam/agent-skills-marketplace`
 
 If a repo alias is ambiguous, ask one short clarifying question.
 
@@ -115,16 +139,23 @@ Goal:
 Workflow:
 
 1. Run `gh auth status`.
-2. Detect the current checkout path and repo if possible.
+2. Detect the current checkout path and repo if possible:
+   - prefer `git rev-parse --show-toplevel`
+   - then `git remote get-url origin`
+   - normalize SSH or HTTPS GitHub remotes into `owner/repo`
 3. Create `${XDG_CONFIG_HOME:-$HOME/.config}/github-ticket/config.json` if missing.
 4. Gather only the missing defaults:
    - planning repo
    - preferred execution repos
    - backlog labels
    - quick-issue labels
-   - optional project owner/number
+   - project owner/number
+   - optional project field defaults such as `Status` and `Priority`
+   - only add `path_repo_map` when repo detection via git is insufficient
 
 Use `jq` to write or update the config rather than inventing a custom format.
+If project config is present but `gh auth status` shows no `project` scope,
+surface that clearly instead of pretending project hydration will work.
 
 ### `get-issue`
 
@@ -196,8 +227,24 @@ Then:
    - always include `triage` unless the user says otherwise
    - map work type to `type:*` labels when available
 4. Create the issue with `gh issue create`.
-5. Best-effort add it to a project only if project config is present and auth
-   allows it. Never block issue creation on project assignment.
+5. If project config exists, or the current Diversio baseline applies, add the
+   issue to the project with `gh project item-add`.
+6. If the project add succeeds, hydrate the common project fields immediately:
+   - `Status`
+   - `Target Repo`
+   - optional `Priority`
+7. For `Status`, prefer:
+   - `Ready` for scoped, actionable work
+   - `Blocked` when the issue depends on incomplete upstream work
+   - `Inbox` only for intentionally rough capture
+8. For `Target Repo`, map the destination repository to the matching project
+   option when that field exists. If there is no exact option for that repo,
+   use `other` instead of leaving the field blank.
+9. Never block issue creation on project assignment or field hydration, but do
+   report the failure clearly so the user is not left with invisible board
+   items.
+10. If project hydration fails because of missing `project` scope, say that
+    explicitly and point at `gh auth refresh -s project`.
 
 ### `quick-issue`
 
@@ -212,7 +259,10 @@ Preferred flow:
 1. Infer repo from current directory or config.
 2. Use default quick-issue labels.
 3. Create a minimal but useful body.
-4. Return the created issue URL.
+4. If the result is still intentionally rough, prefer `Status: Inbox` when
+   adding it to a project. Only upgrade to `Ready` when the issue is already
+   actionable from the captured context.
+5. Return the created issue URL.
 
 ### `add-to-backlog`
 
@@ -223,6 +273,7 @@ Default behavior:
 - repo: `DiversioTeam/monolith`
 - labels: `triage` plus configured backlog labels
 - minimal body with problem/request plus optional links
+- when added to `Diversio Work`, prefer `Status: Inbox`
 
 Do not over-prompt. If the user only gives a title, create the issue.
 
@@ -236,6 +287,8 @@ Safe default:
 2. Create the new issue in the target repo.
 3. Mention the source issue in the new body.
 4. Add reciprocal comments with `gh issue comment` on both issues.
+5. If the new issue is added to a project, prefer `Ready` unless its own
+   dependency chain means it should start in `Blocked`.
 
 Do not rely on child-issue-only GitHub features for MVP behavior.
 
@@ -250,6 +303,51 @@ Behavior:
 2. Decide the target repo or confirm it with one short question.
 3. Call the same creation logic as `create-linked-issue`.
 4. Leave the planning issue open unless the user explicitly wants it closed.
+
+## Project Hygiene
+
+When the issue lands in `Diversio Work`, treat project visibility as part of
+the ticket workflow instead of optional cleanup.
+
+- If a work item should show up in active board views, do not leave `Status`
+  blank.
+- `Inbox` is appropriate for rough backlog capture; it is not appropriate for
+  already-scoped execution work.
+- `quick-issue` and `add-to-backlog` may legitimately choose `Inbox` even when
+  a global config default says `Ready`, because the capture mode is part of the
+  semantics.
+- `Ready` is the default for issue-sized, actionable work that can be picked
+  up now.
+- `Blocked` is the default when dependency text like `requires`, `depends on`,
+  or `blocked by` means the issue should exist on the board but not enter the
+  active queue yet.
+- When the project has a `Target Repo` field, set it to the repo that will own
+  execution so grouped board views stay useful. If the project does not have a
+  dedicated option for that repo, use `other`.
+- After creation, verify the issue is attached to the expected project and is
+  not hidden by a blank `Status`.
+
+## Project Commands
+
+Use the GitHub CLI's project commands directly instead of inventing ad hoc
+GraphQL:
+
+1. Resolve the project metadata:
+   - `gh project view <number> --owner <owner> --format json`
+2. Resolve field ids and single-select option ids:
+   - `gh project field-list <number> --owner <owner> --format json`
+3. Add the issue to the project:
+   - `gh project item-add <number> --owner <owner> --url <issue-url>`
+4. Resolve the project item id by matching the created issue:
+   - `gh project item-list <number> --owner <owner> --format json`
+5. Update one field per call with `gh project item-edit`:
+   - `--single-select-option-id` for fields like `Status`, `Target Repo`, and
+     `Priority`
+   - `--project-id` is required for non-draft issue field edits
+
+Do not assume field ids or option ids are stable across projects. Read them
+from the active project each time unless a higher-level cache is explicitly in
+scope.
 
 ## Canonical Issue Body
 
@@ -275,6 +373,11 @@ Prefer this command set:
 - `gh issue list`
 - `gh search issues`
 - `gh issue comment`
+- `gh project view`
+- `gh project field-list`
+- `gh project item-add`
+- `gh project item-list`
+- `gh project item-edit`
 - `gh api`
 
 Use `gh api` only when a simpler `gh issue ...` subcommand does not cover the
@@ -290,6 +393,7 @@ When this Skill completes a write action, always return:
 - URL
 - labels applied
 - whether project add succeeded or was skipped
+- which project fields were applied, skipped, or failed
 
 When it completes a read or list action, keep the response scan-friendly and
 show enough context that the user does not need to open GitHub immediately.

--- a/plugins/github-ticket/skills/github-ticket/references/config-and-body-shape.md
+++ b/plugins/github-ticket/skills/github-ticket/references/config-and-body-shape.md
@@ -13,15 +13,124 @@
   "quick_issue_labels": [],
   "project_owner": "DiversioTeam",
   "project_number": 2,
-  "path_repo_map": {
-    "/path/to/monolith/backend": "DiversioTeam/Django4Lyfe",
-    "/path/to/monolith/optimo-frontend": "DiversioTeam/Optimo-Frontend"
+  "project_field_defaults": {
+    "Status": "Ready",
+    "Priority": "Normal"
   }
 }
 ```
 
 For the current Diversio migration baseline, `Diversio Work` is organization
 project `#2`.
+
+Project hydration assumes the authenticated `gh` session has `project` scope.
+If not, issue creation can still succeed but project add / field edits will
+fail until the user refreshes auth, for example:
+
+```bash
+gh auth refresh -s project
+```
+
+When adding issues there, prefer:
+
+- `Status: Ready` for scoped, actionable work
+- `Status: Blocked` for dependency-held work
+- `Status: Inbox` only for intentionally rough capture
+- `Target Repo` mapped to the execution repo when the field exists
+- if the project does not have a dedicated repo option, use `other`
+- `Priority` from config when the user or team has a default
+
+Mode-specific overrides should beat global defaults:
+
+- `add-to-backlog` should normally force `Status: Inbox`
+- `quick-issue` should use `Inbox` unless the captured context is already
+  actionable
+- `create-linked-issue` and `route` should normally use `Ready` or `Blocked`
+  rather than `Inbox`
+
+## Optional Path Repo Map
+
+`path_repo_map` is optional. Prefer runtime repo detection from the current git
+checkout before adding path-specific overrides.
+
+Why:
+
+- worktree roots move
+- absolute local paths do not belong in public checked-in guidance
+- most repo selection can be derived from `git rev-parse --show-toplevel` plus
+  `git remote get-url origin`
+
+When using `git remote get-url origin`, normalize both of these forms into
+`owner/repo` before routing:
+
+- `git@github.com:Owner/Repo.git`
+- `https://github.com/Owner/Repo.git`
+
+Use `path_repo_map` only when a real workflow enters directories where git
+checkout detection is not enough.
+
+## Project Hydration Recipe
+
+Use the project field display names from config, but resolve the live ids at
+runtime:
+
+1. Get the project id:
+
+```bash
+gh project view 2 --owner DiversioTeam --format json
+```
+
+2. Get field ids and option ids:
+
+```bash
+gh project field-list 2 --owner DiversioTeam --format json
+```
+
+3. Add the issue to the project:
+
+```bash
+gh project item-add 2 --owner DiversioTeam --url <issue-url>
+```
+
+4. Find the project item id for that issue:
+
+```bash
+gh project item-list 2 --owner DiversioTeam --format json
+```
+
+5. Edit one field at a time:
+
+```bash
+gh project item-edit \
+  --id <item-id> \
+  --project-id <project-id> \
+  --field-id <field-id> \
+  --single-select-option-id <option-id>
+```
+
+For the current Diversio baseline, the common single-select fields are:
+
+- `Status`
+- `Target Repo`
+- `Priority`
+
+For `Target Repo`, the current project has dedicated options for:
+
+- `monolith`
+- `backend`
+- `frontend`
+- `optimo-frontend`
+- `design-system`
+- `infrastructure`
+- `naboo`
+- `diversio-serverless`
+- `launchpad`
+- `skiddie`
+- `other`
+
+So repos like `agent-skills-marketplace` and `terraform-modules` should
+normally map to `other` in that project unless the board schema later grows a
+dedicated option.
 
 ## Canonical Issue Body
 


### PR DESCRIPTION
## Summary

Improves the `github-ticket` plugin so it can do more than create issues: it now documents and supports project-board hydration for `Diversio Work`, uses git-based repo detection by default so worktrees are safe, and clarifies mode-specific board status behavior.

Closes #41.

### Key Features

| Feature | Description |
|---------|-------------|
| Project hydration | Documents and supports `gh project` add + field-edit flows so created issues do not land on the board with blank status |
| Worktree-safe routing | Shifts guidance away from absolute path maps and toward git-derived repo detection (`git rev-parse`, `git remote get-url origin`) |
| Mode-aware status defaults | Clarifies when issues should default to `Inbox`, `Ready`, or `Blocked` |
| Repo fallback behavior | Adds missing aliases and makes `Target Repo -> other` explicit when the board schema lacks a dedicated option |
| Auth clarity | Calls out that project hydration needs `gh` `project` scope and how to refresh auth when it is missing |

## Flow Update

```text
Before
  create issue
    -> maybe add to project
    -> board fields often left implicit
    -> filtered project views can hide the item

After
  detect repo from git context
    -> create issue
    -> add to project
    -> resolve field/option ids at runtime
    -> set Status / Target Repo / Priority
    -> report any hydration failure explicitly
```

---

## What Changed

### 1. Upgraded `github-ticket` skill guidance

The core `SKILL.md` now treats project-board hydration as first-class behavior rather than optional cleanup.

Key additions:
- explicit `gh project view` / `field-list` / `item-add` / `item-list` / `item-edit` flow
- `gh auth status` scope expectations, including `project`
- git-based repo detection before any optional `path_repo_map`
- repo aliases for `terraform-modules` and `agent-skills-marketplace`
- explicit `Target Repo -> other` fallback when the project has no dedicated repo option

### 2. Clarified mode-specific defaults

The plugin now distinguishes capture modes from execution modes more clearly:
- `add-to-backlog` should usually produce `Inbox`
- `quick-issue` should stay `Inbox` unless the captured context is already actionable
- `create-linked-issue` / `route` / implementation-ready work should become `Ready` or `Blocked`

That keeps the project board semantically useful instead of treating all issue creation the same way.

### 3. Synced wrappers and catalog/docs

The command wrappers, plugin manifest text, marketplace entry, README, and plugin catalog were updated to match the new behavior so the docs do not drift from the skill itself.

### 4. Collapsed the version bump to one final increment

The final repo diff bumps `github-ticket` exactly once:
- `0.1.0` -> `0.1.1`

No unrelated plugin version churn remains in the manifest diff.

---

## Files Changed

<details>
<summary>Plugin skill and references</summary>

- `plugins/github-ticket/skills/github-ticket/SKILL.md` - core workflow, repo detection, auth expectations, project hydration, mode semantics
- `plugins/github-ticket/skills/github-ticket/references/config-and-body-shape.md` - config model, optional path map guidance, project hydration recipe, repo fallback notes

</details>

<details>
<summary>Command wrappers</summary>

- `plugins/github-ticket/commands/configure.md`
- `plugins/github-ticket/commands/create-issue.md`
- `plugins/github-ticket/commands/quick-issue.md`
- `plugins/github-ticket/commands/add-to-backlog.md`
- `plugins/github-ticket/commands/create-linked-issue.md`
- `plugins/github-ticket/commands/route.md`

These now reflect project hydration and mode-specific board behavior.

</details>

<details>
<summary>Manifest and marketplace docs</summary>

- `plugins/github-ticket/.claude-plugin/plugin.json` - final version bump + description update
- `.claude-plugin/marketplace.json` - synced plugin metadata and final version bump
- `README.md` - plugin inventory/command wording
- `docs/plugins/catalog.md` - plugin purpose wording

</details>

## How to Test

```bash
cd agent-skills-marketplace
bash scripts/validate-skills.sh
bash scripts/validate-skills.sh --all
jq -e . .claude-plugin/marketplace.json >/dev/null
jq -e . plugins/github-ticket/.claude-plugin/plugin.json >/dev/null
git diff --check
```

### Manual Review

1. Read `plugins/github-ticket/skills/github-ticket/SKILL.md` and confirm it prefers git-based repo detection over hardcoded path maps.
2. Confirm the skill explains how to hydrate `Diversio Work` items with `Status`, `Target Repo`, and `Priority`.
3. Confirm the wrappers and README/catalog wording all match the upgraded plugin behavior.
4. Confirm the manifest diff shows a single `github-ticket` version bump from `0.1.0` to `0.1.1`.

## Notes

- This PR does not commit machine-local config or installed skill state under `~/.config` / `~/.codex`.
- This PR does not attempt to define a universal repo branch naming policy; it focuses on the `github-ticket` plugin itself.
- The current board-specific guidance is intentionally written against Project `#2` (`Diversio Work`) because that is the active Diversio baseline today.
