### PR TITLE
Harden marketplace GitHub Actions workflows

### DIFF
--- a/.github/workflows/notify-plugin-updates.yml
+++ b/.github/workflows/notify-plugin-updates.yml
@@ -6,14 +6,18 @@ on:
     paths:
       - 'plugins/**'
 
+permissions:
+  contents: read
+
 jobs:
   notify-slack:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 2  # Need previous commit to diff
+          persist-credentials: false
 
       - name: Detect updated plugins and build notification
         id: detect

--- a/.github/workflows/notify-plugin-updates.yml
+++ b/.github/workflows/notify-plugin-updates.yml
@@ -167,7 +167,7 @@ jobs:
             }')
 
           # Post to Slack
-          curl -X POST \
+          curl --fail-with-body -X POST \
             -H 'Content-type: application/json' \
             --data "$PAYLOAD" \
             "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/notify-plugin-updates.yml
+++ b/.github/workflows/notify-plugin-updates.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   notify-slack:
     runs-on: ubuntu-latest
+    environment: notifications
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -104,15 +105,18 @@ jobs:
       - name: Post to Slack
         if: steps.detect.outputs.has_updates == 'true'
         env:
+          AUTHOR: ${{ github.actor }}
+          PLUGIN_COUNT: ${{ steps.detect.outputs.plugin_count }}
+          SLACK_MESSAGE: ${{ steps.detect.outputs.message }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PLUGIN_UPDATES_WEBHOOK }}
         run: |
+          set -euo pipefail
+
           # Build the payload
           COMMIT_URL="${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
           COMMIT_MSG=$(git log -1 --pretty=%s)
-          AUTHOR="${{ github.actor }}"
 
           # Determine header based on plugin count
-          PLUGIN_COUNT="${{ steps.detect.outputs.plugin_count }}"
           if [ "$PLUGIN_COUNT" -eq 1 ]; then
             HEADER=":package: Plugin Updated"
           else
@@ -123,7 +127,7 @@ jobs:
           # Using legacy webhook - can specify channel in payload
           PAYLOAD=$(jq -n \
             --arg header "$HEADER" \
-            --arg message "${{ steps.detect.outputs.message }}" \
+            --arg message "$SLACK_MESSAGE" \
             --arg commit_url "$COMMIT_URL" \
             --arg commit_msg "$COMMIT_MSG" \
             --arg author "$AUTHOR" \

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -15,14 +15,18 @@ on:
       - "scripts/**"
       - ".github/workflows/validate-marketplace.yml"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate JSON and plugin consistency
         shell: bash

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -28,6 +28,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Configure authenticated git fetches for validation scripts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          AUTH_HEADER="$(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64 | tr -d '\n')"
+          git config --local "http.${GITHUB_SERVER_URL}/.extraheader" "AUTHORIZATION: basic ${AUTH_HEADER}"
+
       - name: Validate JSON and plugin consistency
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

This PR hardens the marketplace workflows, including the plugin-update notification path and validation-path git fetch behavior.

## What Changed

- pinned mutable action references to reviewed SHAs where applicable
- kept `persist-credentials: false` in marketplace validation while restoring explicit authenticated fetches for `scripts/validate-skills.sh`
- made the Slack notification step fail on non-2xx responses instead of silently succeeding
- tightened checkout, permissions, and environment usage for the workflows in scope

## Files Changed

- `.github/workflows/notify-plugin-updates.yml`
- `.github/workflows/validate-marketplace.yml`

## Validation

- `git diff --check`
- `pinact --check --verify --diff`
- `zizmor --persona regular .github/workflows/validate-marketplace.yml .github/workflows/notify-plugin-updates.yml`

## Related Context

- Refs `DiversioTeam/monolith#230`
- Related monolith tracking PR: `DiversioTeam/monolith#238`
