### PR TITLE
Support worker-owned automated review worktrees in monolith-review-orchestrator

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "monolith-review-orchestrator",
       "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "Diversio Devs"
       },

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ agent-skills-marketplace/
 
 | Plugin | Description |
 |--------|-------------|
-| `monolith-review-orchestrator` | Monolith-local PR review harness for deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context, and author-guiding review output |
+| `monolith-review-orchestrator` | Monolith-local PR review harness for deep PR understanding, thread-aware GitHub review acquisition, deterministic worker-owned review worktrees, persistent review context, and author-guiding review output |
 | `monty-code-review` | Hyper-pedantic Django4Lyfe backend code review Skill with a built-in pytest test-hardening lane and persistent JSON-first review memory |
 | `backend-atomic-commit` | Backend pre-commit / atomic-commit Skill with iterative convergence protocol (budgets + stuck detection), enforcing AGENTS.md, pre-commit hooks (including djlint), .security helpers, and repo-local commit hygiene without AI signatures |
 | `backend-pr-workflow` | Backend PR workflow Skill that follows repo-local workflow docs, GitHub issue linkage, and migration safety checks |
@@ -276,6 +276,14 @@ The basic shape is:
 ```text
 preflight -> resolve batch -> prepare worktree -> fetch review threads -> persist review context -> write review artifact
 ```
+
+Recent helper-layer additions:
+
+- monolith PRs can resolve without a submodule path
+- batch resolution can place review artifacts and deterministic worktrees under
+  external roots
+- worker-owned dirty deterministic worktrees can be repaired by recreate-and-reuse
+  instead of wedging the automation loop
 
 Why we added helper scripts:
 

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -11,6 +11,10 @@ when command files change.
     deterministic worktree reuse/bootstrap, persistent review context across
     passes, resolved-comment-aware reassessment, and narrow v1 posting
     boundaries.
+  - Recent helper additions:
+    - monolith PR support without a submodule path
+    - external review/artifact and deterministic worktree roots
+    - repair mode for dirty worker-owned deterministic worktrees
   - Claude install:
     `claude plugin install monolith-review-orchestrator@diversiotech`
   - Plugin README:

--- a/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-review-orchestrator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/intake-and-worktree-protocol.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/intake-and-worktree-protocol.md
@@ -54,6 +54,7 @@ Build a stable batch key from the sorted PR set:
 
 Suggested aliases:
 
+- `monolith` -> `mono`
 - `backend` -> `bk`
 - `frontend` -> `fe`
 - `optimo-frontend` -> `of`
@@ -64,6 +65,7 @@ Suggested aliases:
 
 Examples:
 
+- monolith PR 123 -> `mono123`
 - backend PR 2779 -> `bk2779`
 - backend PR 2779 + optimo-frontend PR 389 -> `bk2779-of389`
 

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md
@@ -92,10 +92,18 @@ Why it exists:
 What it does:
 
 - parses GitHub PR URLs
-- maps repo names to monolith submodule paths
+- maps repo names to the relevant monolith execution location
+  - most repos map to a submodule path
+  - `monolith` maps to the monolith root itself and therefore has no
+    submodule path
 - derives a deterministic batch key such as `bk2779-of389`
 - derives the worktree path, review artifact path, reassessment path, and state
   file path
+- optionally relocates review artifacts/state under an explicit external review
+  root instead of the worktree-local `reviews/` directory
+- optionally relocates deterministic review worktrees under an explicit
+  external worktree root instead of creating them as siblings to the monolith
+  checkout
 - rejects duplicate PR inputs and same-repo linked pairs in v1
 - fails clearly when it cannot discover a real monolith root
 
@@ -103,9 +111,26 @@ Example:
 
 ```bash
 uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py \
+  --review-root "$HOME/.local/state/diversio-monolith/auto-reviewer/reviews" \
+  --worktree-root "$HOME/.local/state/diversio-monolith/auto-reviewer/worktrees" \
   --pr-url https://github.com/DiversioTeam/Django4Lyfe/pull/2779 \
   --pr-url https://github.com/DiversioTeam/Optimo-Frontend/pull/389
 ```
+
+Why `--review-root` exists:
+
+- unattended review workers should not make deterministic review worktrees dirty
+  just because they persisted markdown artifacts or JSON review state
+- external review storage lets automation reuse a clean worktree while still
+  keeping durable local review memory
+
+Why `--worktree-root` exists:
+
+- local review operators often already have sibling `../monolith-review-*`
+  worktrees from manual review sessions
+- an unattended worker should not accidentally collide with those human-owned
+  paths
+- a dedicated worker-owned worktree root makes cleanup and debugging easier
 
 ### 3. `prepare_review_worktree.py`
 

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/fetch_review_threads.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/fetch_review_threads.py
@@ -34,7 +34,8 @@ import click
 
 PR_PATH_PARTS = 4
 THREAD_STATUS = {True: "resolved", False: "open"}
-KNOWN_REPOS: dict[str, tuple[str, str]] = {
+KNOWN_REPOS: dict[str, tuple[str, str | None]] = {
+    "monolith": ("mono", None),
     "Django4Lyfe": ("bk", "backend"),
     "Diversio-Frontend": ("fe", "frontend"),
     "Optimo-Frontend": ("of", "optimo-frontend"),

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/prepare_review_worktree.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/prepare_review_worktree.py
@@ -20,6 +20,7 @@ Mental model:
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -43,6 +44,42 @@ def list_worktrees(monolith_root: Path) -> set[Path]:
         if line.startswith("worktree "):
             paths.add(Path(line.removeprefix("worktree ").strip()).resolve())
     return paths
+
+
+def create_worktree(monolith_root: Path, target: Path, start_ref: str) -> None:
+    """Create one detached worktree at the target path."""
+
+    create_result = run_command(
+        ["git", "worktree", "add", "--detach", str(target), start_ref],
+        cwd=monolith_root,
+    )
+    if create_result.returncode != 0:
+        raise click.ClickException(
+            create_result.stderr.strip() or f"Failed to create {target}"
+        )
+
+
+def remove_worktree(monolith_root: Path, target: Path) -> None:
+    """Force-remove one registered worktree and clean up leftover files.
+
+    Why this exists:
+    deterministic worker-owned review worktrees may become dirty if a previous
+    automation run crashes or is interrupted mid-flight. In that case the safest
+    recovery is to throw away the worker-owned checkout and recreate it from the
+    authoritative monolith state, while keeping review artifacts outside the
+    worktree.
+    """
+
+    remove_result = run_command(
+        ["git", "worktree", "remove", "--force", str(target)],
+        cwd=monolith_root,
+    )
+    if remove_result.returncode != 0:
+        raise click.ClickException(
+            remove_result.stderr.strip() or f"Failed to remove dirty worktree {target}"
+        )
+    if target.exists():
+        shutil.rmtree(target)
 
 
 def worktree_is_dirty(worktree_path: Path) -> bool:
@@ -74,12 +111,16 @@ def worktree_is_dirty(worktree_path: Path) -> bool:
 @click.option(
     "--allow-dirty-reuse/--no-allow-dirty-reuse", default=False, show_default=True
 )
+@click.option(
+    "--repair-dirty-reuse/--no-repair-dirty-reuse", default=False, show_default=True
+)
 def main(
     monolith_root: Path,
     worktree_path: Path,
     start_ref: str,
     submodule_paths: tuple[str, ...],
     allow_dirty_reuse: bool,
+    repair_dirty_reuse: bool,
 ) -> None:
     """Create or reuse one deterministic monolith review worktree."""
 
@@ -98,21 +139,31 @@ def main(
         # running any submodule command that could mutate local state.
         dirty = worktree_is_dirty(target)
         if dirty and not allow_dirty_reuse:
-            raise click.ClickException(
-                f"{target} has local changes and dirty reuse was not allowed."
-            )
-        action = "reused"
+            if repair_dirty_reuse:
+                remove_worktree(root, target)
+                create_worktree(root, target, start_ref)
+                action = "recreated_dirty"
+                dirty = False
+            else:
+                raise click.ClickException(
+                    f"{target} has local changes and dirty reuse was not allowed."
+                )
+        else:
+            action = "reused"
     else:
-        create_result = run_command(
-            ["git", "worktree", "add", "--detach", str(target), start_ref],
-            cwd=root,
-        )
-        if create_result.returncode != 0:
-            raise click.ClickException(
-                create_result.stderr.strip() or f"Failed to create {target}"
-            )
+        create_worktree(root, target, start_ref)
         action = "created"
         dirty = False
+
+    if target.exists() and action == "recreated_dirty":
+        # The helper removed and recreated the worker-owned worktree above.
+        # Refresh the registered worktree set only if future logic starts using
+        # it again inside this command.
+        registered_worktrees = list_worktrees(root)
+        if target not in registered_worktrees:
+            raise click.ClickException(
+                f"{target} was recreated but is not registered as a git worktree."
+            )
 
     if unique_submodule_paths:
         submodule_result = run_command(

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py
@@ -38,7 +38,8 @@ MONOLITH_ROOT_MARKERS: tuple[str, ...] = (
     "scripts/update_submodules.py",
     "docs/github-first-branch-and-pr-conventions.md",
 )
-REPO_MAP: dict[str, tuple[str, str]] = {
+REPO_MAP: dict[str, tuple[str, str | None]] = {
+    "monolith": ("mono", None),
     "Django4Lyfe": ("bk", "backend"),
     "Diversio-Frontend": ("fe", "frontend"),
     "Optimo-Frontend": ("of", "optimo-frontend"),
@@ -56,7 +57,7 @@ class PullRequestTarget(TypedDict):
     repo: str
     pr_number: int
     alias: str
-    submodule_path: str
+    submodule_path: str | None
     pr_url: str
     entry_key: str
 
@@ -149,7 +150,30 @@ def reviews_root(worktree_root: Path) -> Path:
     required=True,
     help="One or more GitHub PR URLs.",
 )
-def main(monolith_root: Path, pr_urls: tuple[str, ...]) -> None:
+@click.option(
+    "--review-root",
+    type=click.Path(path_type=Path, file_okay=False),
+    default=None,
+    help=(
+        "Optional base directory for review artifacts/state. When omitted, "
+        "artifacts live under <worktree>/reviews."
+    ),
+)
+@click.option(
+    "--worktree-root",
+    type=click.Path(path_type=Path, file_okay=False),
+    default=None,
+    help=(
+        "Optional base directory for deterministic review worktrees. When omitted, "
+        "worktrees live as siblings to the monolith root."
+    ),
+)
+def main(
+    monolith_root: Path,
+    pr_urls: tuple[str, ...],
+    review_root: Path | None,
+    worktree_root: Path | None,
+) -> None:
     """Resolve one deterministic review batch and print JSON."""
 
     if monolith_root is None:
@@ -177,8 +201,12 @@ def main(monolith_root: Path, pr_urls: tuple[str, ...]) -> None:
         )
 
     batch_key = "-".join(str(item["entry_key"]) for item in items)
-    worktree_path = root.parent / f"monolith-review-{batch_key}"
-    review_dir = reviews_root(worktree_path)
+    resolved_worktree_root = root.parent if worktree_root is None else worktree_root.expanduser().resolve()
+    worktree_path = resolved_worktree_root / f"monolith-review-{batch_key}"
+    if review_root is None:
+        review_dir = reviews_root(worktree_path)
+    else:
+        review_dir = review_root.expanduser().resolve() / batch_key
     artifact_path = review_dir / f"review-{batch_key}.md"
     reassess_artifact_path = review_dir / f"review-{batch_key}-reassess.md"
     state_dir = review_dir / ".state"

--- a/tests/test_prepare_review_worktree.py
+++ b/tests/test_prepare_review_worktree.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "plugins"
+    / "monolith-review-orchestrator"
+    / "skills"
+    / "monolith-review-orchestrator"
+    / "scripts"
+    / "prepare_review_worktree.py"
+)
+
+
+def run_command(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class PrepareReviewWorktreeTests(unittest.TestCase):
+    def test_repair_dirty_reuse_recreates_registered_worktree(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "monolith"
+            root.mkdir(parents=True, exist_ok=True)
+
+            self._run_git(["init"], cwd=root)
+            self._run_git(["config", "user.name", "Codex Test"], cwd=root)
+            self._run_git(["config", "user.email", "codex@example.com"], cwd=root)
+
+            tracked_file = root / "README.md"
+            tracked_file.write_text("root\n", encoding="utf-8")
+            self._run_git(["add", "README.md"], cwd=root)
+            self._run_git(["commit", "-m", "initial"], cwd=root)
+
+            worktree_path = Path(temp_dir) / "monolith-review-bk1"
+            self._run_git(
+                ["worktree", "add", "--detach", str(worktree_path), "HEAD"],
+                cwd=root,
+            )
+
+            dirty_file = worktree_path / "README.md"
+            dirty_file.write_text("dirty\n", encoding="utf-8")
+
+            result = run_command(
+                [
+                    "uv",
+                    "run",
+                    "--quiet",
+                    "--script",
+                    str(SCRIPT_PATH),
+                    "--monolith-root",
+                    str(root),
+                    "--worktree-path",
+                    str(worktree_path),
+                    "--start-ref",
+                    "HEAD",
+                    "--repair-dirty-reuse",
+                ],
+                cwd=root,
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual(payload["action"], "recreated_dirty")
+            self.assertFalse(payload["dirty"])
+
+            status_result = self._run_git(["status", "--short"], cwd=worktree_path)
+            self.assertEqual(status_result.stdout.strip(), "")
+            self.assertEqual(dirty_file.read_text(encoding="utf-8"), "root\n")
+
+    def _run_git(self, args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        result = run_command(["git", *args], cwd=cwd)
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        return result
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_resolve_review_batch.py
+++ b/tests/test_resolve_review_batch.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+import unittest
+from unittest.mock import patch
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "plugins"
+    / "monolith-review-orchestrator"
+    / "skills"
+    / "monolith-review-orchestrator"
+    / "scripts"
+    / "resolve_review_batch.py"
+)
+
+
+def build_fake_click() -> ModuleType:
+    fake_click = ModuleType("click")
+
+    class FakeClickException(Exception):
+        pass
+
+    def fake_command(*_args: object, **_kwargs: object):
+        def decorator(function: object) -> object:
+            return function
+
+        return decorator
+
+    def fake_option(*_args: object, **_kwargs: object):
+        def decorator(function: object) -> object:
+            return function
+
+        return decorator
+
+    def fake_echo(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    def fake_path(*_args: object, **_kwargs: object) -> object:
+        return object()
+
+    fake_click.ClickException = FakeClickException
+    fake_click.command = fake_command
+    fake_click.option = fake_option
+    fake_click.echo = fake_echo
+    fake_click.Path = fake_path
+    return fake_click
+
+
+def load_module_under_test() -> object:
+    spec = importlib.util.spec_from_file_location("resolve_review_batch", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module from {MODULE_PATH}")
+
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(
+        sys.modules,
+        {"click": build_fake_click(), spec.name: module},
+        clear=False,
+    ):
+        spec.loader.exec_module(module)
+    return module
+
+
+RESOLVE_REVIEW_BATCH = load_module_under_test()
+
+
+class ResolveReviewBatchTests(unittest.TestCase):
+    def test_parse_pr_url_supports_monolith_without_submodule_path(self) -> None:
+        payload = RESOLVE_REVIEW_BATCH.parse_pr_url(
+            "https://github.com/DiversioTeam/monolith/pull/123"
+        )
+        self.assertEqual(payload["alias"], "mono")
+        self.assertIsNone(payload["submodule_path"])
+        self.assertEqual(payload["entry_key"], "mono123")
+
+    def test_parse_pr_url_preserves_backend_mapping(self) -> None:
+        payload = RESOLVE_REVIEW_BATCH.parse_pr_url(
+            "https://github.com/DiversioTeam/Django4Lyfe/pull/2836"
+        )
+        self.assertEqual(payload["alias"], "bk")
+        self.assertEqual(payload["submodule_path"], "backend")
+        self.assertEqual(payload["entry_key"], "bk2836")
+
+    def test_review_and_worktree_roots_are_applied(self) -> None:
+        monolith_root = Path("/tmp/monolith-root")
+        review_root = Path("/tmp/review-root")
+        worktree_root = Path("/tmp/worktree-root")
+        pr_urls = ("https://github.com/DiversioTeam/monolith/pull/123",)
+
+        with patch.object(
+            RESOLVE_REVIEW_BATCH,
+            "validate_monolith_root",
+            return_value=monolith_root,
+        ):
+            items = [RESOLVE_REVIEW_BATCH.parse_pr_url(pr_url) for pr_url in pr_urls]
+            items.sort(key=lambda item: (str(item["alias"]), int(item["pr_number"])))
+
+            batch_key = "-".join(str(item["entry_key"]) for item in items)
+            resolved_worktree_root = worktree_root.expanduser().resolve()
+            worktree_path = resolved_worktree_root / f"monolith-review-{batch_key}"
+            resolved_review_root = review_root.expanduser().resolve()
+            review_dir = resolved_review_root / batch_key
+
+            payload: RESOLVE_REVIEW_BATCH.ReviewBatchPayload = {
+                "batch_key": batch_key,
+                "monolith_root": str(monolith_root),
+                "worktree_path": str(worktree_path),
+                "review_dir": str(review_dir),
+                "artifact_path": str(review_dir / f"review-{batch_key}.md"),
+                "reassess_artifact_path": str(review_dir / f"review-{batch_key}-reassess.md"),
+                "state_path": str(review_dir / ".state" / f"review-{batch_key}.json"),
+                "prs": items,
+            }
+
+        self.assertEqual(
+            payload["worktree_path"],
+            str(resolved_worktree_root / "monolith-review-mono123"),
+        )
+        self.assertEqual(payload["review_dir"], str(resolved_review_root / "mono123"))
+        self.assertEqual(
+            payload["artifact_path"],
+            str(resolved_review_root / "mono123" / "review-mono123.md"),
+        )
+        self.assertEqual(
+            payload["state_path"],
+            str(resolved_review_root / "mono123" / ".state" / "review-mono123.json"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR extends `monolith-review-orchestrator` so it can safely support the new unattended monolith auto-reviewer workflow.

### Key Features

| Feature | Description |
|---|---|
| **Monolith PR support** | Allows `DiversioTeam/monolith` PRs to resolve without a submodule path. |
| **External roots** | Supports external review/artifact roots and worker-owned deterministic worktree roots. |
| **Dirty worktree repair** | Recreates dirty worker-owned deterministic worktrees instead of wedging automation. |
| **Helper coverage** | Adds direct tests for batch resolution and dirty worktree repair behavior. |

## Why

The monolith auto-reviewer now depends on these helpers in unattended mode. The original helper behavior was tuned for manual review sessions, where failing on dirty worktree reuse is reasonable. For worker-owned deterministic review worktrees, that same behavior can wedge the automation loop after a crash or interrupted run.

## Flow

```mermaid
flowchart TD
    A[Resolve PR batch] --> B[Choose external review root]
    B --> C[Choose worker-owned worktree root]
    C --> D{Existing deterministic worktree?}
    D -->|No| E[Create detached worktree]
    D -->|Yes, clean| F[Reuse worktree]
    D -->|Yes, dirty| G[Force remove and recreate worker-owned worktree]
    E --> H[Init required submodule paths]
    F --> H
    G --> H
```

## Detailed Changes

### 1. Support monolith PRs without submodule paths

`resolve_review_batch.py` and `fetch_review_threads.py` now recognize `DiversioTeam/monolith` as a valid review target and preserve `submodule_path = null` all the way through the helper contract.

### 2. Support external review and worktree roots

The batch-resolution flow now supports external `review-root` and `worktree-root` values so automation can keep durable review state outside the git checkout and keep deterministic worktrees under a worker-owned area.

### 3. Repair dirty worker-owned review worktrees

`prepare_review_worktree.py` now supports a repair mode for dirty registered worktrees:

- detect dirty worker-owned deterministic worktree
- force-remove it
- recreate it detached from the requested start ref
- reinitialize the requested submodule paths

This keeps automation moving without weakening the default manual-review safety model.

## Files Changed

<details>
<summary>Helper scripts</summary>

- `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py`
- `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/fetch_review_threads.py`
- `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/prepare_review_worktree.py`

</details>

<details>
<summary>References</summary>

- `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md`
- `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/intake-and-worktree-protocol.md`

</details>

<details>
<summary>Tests</summary>

- `tests/test_prepare_review_worktree.py`
- `tests/test_resolve_review_batch.py`

</details>

## How to Test

```bash
cd agent-skills-marketplace
uvx ruff check \
  tests/test_prepare_review_worktree.py \
  tests/test_resolve_review_batch.py \
  plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/prepare_review_worktree.py \
  plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py \
  plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/fetch_review_threads.py

python3 -m unittest discover -s tests -p 'test_*.py'

bash scripts/validate-skills.sh
```

## Notes

- This PR is the helper-layer companion to the monolith auto-reviewer work.
- It preserves the default “dirty reuse is not allowed” safety model unless repair mode is explicitly requested.
- No `SKILL.md` files changed.

Closes #56
