### PR TITLE
Tighten monolith-review-orchestrator live validation gates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "monolith-review-orchestrator",
       "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "author": {
         "name": "Diversio Devs"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "monolith-review-orchestrator",
       "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "author": {
         "name": "Diversio Devs"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "monolith-review-orchestrator",
       "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
-      "version": "0.2.0",
+      "version": "0.3.3",
       "author": {
         "name": "Diversio Devs"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "monolith-review-orchestrator",
       "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "author": {
         "name": "Diversio Devs"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "monolith-review-orchestrator",
       "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "author": {
         "name": "Diversio Devs"
       },

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ failure-prone steps that should not be re-derived from scratch every run:
 The basic shape is:
 
 ```text
-preflight -> resolve batch -> prepare worktree -> fetch review threads -> persist review context -> write review artifact
+preflight -> resolve batch -> fetch live PR context -> prepare exact-head worktree -> persist review context -> write review artifact
 ```
 
 Why we added helper scripts:
@@ -301,11 +301,16 @@ Where to read more:
 Example helper usage:
 
 ```bash
-uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/preflight_review_env.py
+uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/preflight_review_env.py \
+  --mode review \
+  --pr-url https://github.com/DiversioTeam/Django4Lyfe/pull/2779
 
 uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py \
+  --mode review \
   --pr-url https://github.com/DiversioTeam/Django4Lyfe/pull/2779 \
-  --pr-url https://github.com/DiversioTeam/Optimo-Frontend/pull/389
+  --pr-url https://github.com/DiversioTeam/Optimo-Frontend/pull/389 \
+  --linked-pair-reason "Backend and frontend must ship together for the end-to-end behavior to work." \
+  --authoritative-pr Django4Lyfe:2779
 ```
 
 ### Copy-Paste Workflow
@@ -325,7 +330,9 @@ Why:
 export MONOLITH_ROOT="/path/to/monolith"
 cd "$MONOLITH_ROOT"
 
-uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/preflight_review_env.py
+uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/preflight_review_env.py \
+  --mode review \
+  --pr-url https://github.com/DiversioTeam/Django4Lyfe/pull/2779
 ```
 
 #### 2. Resolve one stable review batch identity
@@ -338,8 +345,11 @@ Why:
 cd "$MONOLITH_ROOT"
 
 uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py \
+  --mode review \
   --pr-url https://github.com/DiversioTeam/Django4Lyfe/pull/2779 \
-  --pr-url https://github.com/DiversioTeam/Optimo-Frontend/pull/389
+  --pr-url https://github.com/DiversioTeam/Optimo-Frontend/pull/389 \
+  --linked-pair-reason "Backend and frontend must ship together for the end-to-end behavior to work." \
+  --authoritative-pr Django4Lyfe:2779
 ```
 
 Expected shape:
@@ -357,34 +367,12 @@ also includes keys such as `monolith_root`, `review_dir`,
 }
 ```
 
-#### 3. Create or reuse the detached review worktree
-
-Why:
-- keep the review run isolated
-- avoid attached-branch worktree lock pain
-- initialize only this worktree instead of broad monolith mutation
-
-```bash
-cd "$MONOLITH_ROOT"
-
-uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/prepare_review_worktree.py \
-  --monolith-root "$MONOLITH_ROOT" \
-  --worktree-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389" \
-  --submodule-path backend \
-  --submodule-path optimo-frontend \
-  --start-ref HEAD
-```
-
-Important:
-- this helper intentionally does **not** run `scripts/update_submodules.py`
-- review prep should stay narrow and not normalize unrelated submodules
-
-#### 4. Fetch thread-aware GitHub review history
+#### 3. Fetch thread-aware GitHub review history
 
 Why:
 - resolved and outdated threads carry important review context
-- the orchestrator now owns a first-class GraphQL acquisition path for thread
-  state and thread comments
+- the fetch helper also gives you the live PR head SHAs you need for exact local
+  checkout
 
 ```bash
 cd "$MONOLITH_ROOT"
@@ -393,6 +381,31 @@ uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/sk
   --pr-url https://github.com/DiversioTeam/Django4Lyfe/pull/2779 \
   --pr-url https://github.com/DiversioTeam/Optimo-Frontend/pull/389
 ```
+
+#### 4. Create or reuse the detached review worktree
+
+Why:
+- keep the review run isolated
+- avoid attached-branch worktree lock pain
+- initialize only this worktree instead of broad monolith mutation
+- fail closed unless each review submodule lands on the exact PR head SHA being
+  reviewed
+
+```bash
+cd "$MONOLITH_ROOT"
+
+uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/prepare_review_worktree.py \
+  --monolith-root "$MONOLITH_ROOT" \
+  --worktree-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389" \
+  --review-target "backend:2779:<backend-head-sha>:<backend-head-ref-name>" \
+  --review-target "optimo-frontend:389:<optimo-head-sha>:<optimo-head-ref-name>" \
+  --start-ref HEAD
+```
+
+Important:
+- this helper intentionally does **not** run `scripts/update_submodules.py`
+- review prep should stay narrow and not normalize unrelated submodules
+- do not continue unless every reported review target is `status=matched`
 
 #### 5. Initialize structured review state
 
@@ -410,7 +423,10 @@ uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/sk
   --worktree-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389" \
   --artifact-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/review-bk2779-of389.md" \
   --pr Django4Lyfe:2779 \
-  --pr Optimo-Frontend:389
+  --pr Optimo-Frontend:389 \
+  --link-type explicit_cross_repo_pair \
+  --linked-pair-reason "Backend and frontend must ship together for the end-to-end behavior to work." \
+  --authoritative-pr Django4Lyfe:2779
 ```
 
 If the state file already exists and you intentionally want to replace it, add
@@ -435,6 +451,10 @@ cd "$MONOLITH_ROOT"
 
 uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py summarize-context \
   --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json"
+
+uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py validate-live-state \
+  --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json" \
+  --pr-context-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/pr-context-bk2779-of389.json"
 ```
 
 Then record the new pass after reviewing:
@@ -457,16 +477,31 @@ cat <<EOF | uv run --script agent-skills-marketplace/plugins/monolith-review-orc
       "pr_number": 2779,
       "base_branch": "main",
       "head_sha": "<backend-head-sha>",
-      "merge_base": "<backend-merge-base-sha>"
+      "merge_base": "<backend-merge-base-sha>",
+      "pr_state": "OPEN",
+      "is_draft": false
     },
     {
       "repo": "Optimo-Frontend",
       "pr_number": 389,
       "base_branch": "main",
       "head_sha": "<optimo-head-sha>",
-      "merge_base": "<optimo-merge-base-sha>"
+      "merge_base": "<optimo-merge-base-sha>",
+      "pr_state": "OPEN",
+      "is_draft": false
     }
   ],
+  "backend_handoff": {
+    "repo": "Django4Lyfe",
+    "pr_number": 2779,
+    "worktree_path": "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389",
+    "pr_url": "https://github.com/DiversioTeam/Django4Lyfe/pull/2779",
+    "head_sha": "<backend-head-sha>",
+    "prior_open_finding_ids": [],
+    "thread_context_summary": "Fetched full GitHub thread history before invoking monty."
+  },
+  "no_author_claims": true,
+  "no_findings_after_full_review": true,
   "comment_context": {
     "thread_source": "gh_graphql",
     "summary": "Read existing review threads, including resolved ones, before reassessing."
@@ -485,8 +520,8 @@ Important:
 - `entries` must include every PR in the batch
 - findings and inline targets should stay repo-scoped inside linked PR batches
 - inline comment targets should reference active findings, not free-form IDs
-- `summarize-context` is intentionally compact and should prioritize recent-pass
-  context instead of replaying every historical note forever
+- `summarize-context` is intentionally compact and trims at the item level while
+  still merging durable context across all passes
 
 #### Visual summary
 

--- a/README.md
+++ b/README.md
@@ -460,12 +460,14 @@ cd "$MONOLITH_ROOT"
 uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py summarize-context \
   --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json"
 
-uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py validate-live-state \
+uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py report-live-drift \
   --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json" \
   --pr-context-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/pr-context-bk2779-of389.json"
 ```
 
-Then record the new pass after reviewing:
+Then record the new pass after reviewing. Reserve `validate-live-state` for the
+final posting gate, when the recorded pass should already match the live PR
+heads:
 
 ```bash
 cd "$MONOLITH_ROOT"

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -8,9 +8,8 @@ when command files change.
 
 - `monolith-review-orchestrator`
   - Purpose: monolith-local PR review harness with structured intake,
-    deterministic worktree reuse/bootstrap, persistent review context across
-    passes, resolved-comment-aware reassessment, and narrow v1 posting
-    boundaries.
+    deterministic exact-head worktree reuse/bootstrap, persistent review context
+    across passes, validated reassessment, and narrow v1 posting boundaries.
   - Claude install:
     `claude plugin install monolith-review-orchestrator@diversiotech`
   - Plugin README:

--- a/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-review-orchestrator",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-review-orchestrator",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-review-orchestrator",
-  "version": "0.2.0",
+  "version": "0.3.3",
   "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-review-orchestrator",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-review-orchestrator",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/monolith-review-orchestrator/README.md
+++ b/plugins/monolith-review-orchestrator/README.md
@@ -24,6 +24,8 @@ you provide:
 
 the plugin figures out:
   - review batch identity
+  - linked-pair metadata when two PRs must be reviewed together
+  - live PR head SHAs before local checkout
   - worktree reuse or preparation
   - thread-aware GitHub review history
   - durable local review context
@@ -40,6 +42,8 @@ The workflow is strongest when your prompt includes:
 - the PR URL
 - linked PR URLs when the change spans repos
 - whether this is `status`, `review`, `reassess`, or `post`
+- for linked PRs: why they are linked and which PR is authoritative if the
+  verdicts diverge
 - whether GitHub posting is allowed in this run
 
 Only mention a local worktree or submodule path when you explicitly want the
@@ -115,9 +119,15 @@ follows.
 ## Notes
 
 - The plugin uses a thread-aware GitHub acquisition helper when GitHub auth is
-  available.
+  available, and that deterministic path currently uses `gh`.
 - The cache is strongest when you reuse the same deterministic review worktree
   and batch state across passes.
+- Worktree prep should fail closed unless each review submodule is detached at
+  the exact PR head SHA being reviewed.
+- `post` should only run after current-head validation plus a prior substantive
+  pass on the same heads, and it should consume the live-state validation token
+  from that check while it is still fresh. That validation now re-reads GitHub
+  from the thread-helper artifact instead of trusting caller-typed state.
 - This plugin is still intentionally narrow on generic non-backend posting and
   broad multi-PR automation.
 

--- a/plugins/monolith-review-orchestrator/commands/post-review.md
+++ b/plugins/monolith-review-orchestrator/commands/post-review.md
@@ -7,6 +7,8 @@ Use the `monolith-review-orchestrator` skill.
 Operate in posting mode:
 - load the latest local review artifacts and PR context
 - load the latest compact review context before drafting the final review
+- validate that the live PR heads still match the latest recorded batch state
+- require a prior substantive pass on the exact same heads before posting
 - treat thread-resolution status as reliable when it came from the orchestrator's
   thread-aware `fetch_review_threads.py` helper
 - dedupe against existing comments conservatively

--- a/plugins/monolith-review-orchestrator/commands/reassess-prs.md
+++ b/plugins/monolith-review-orchestrator/commands/reassess-prs.md
@@ -9,6 +9,8 @@ Operate in reassessment mode:
 - refresh local state safely
 - refresh thread-aware GitHub review history when GitHub access is available
 - load compact structured review context first
+- validate the live PR heads against the latest recorded batch state before
+  trusting the cached reassessment identity
 - inspect new commits and comment deltas since the prior pass
 - verify whether previously raised concerns are actually resolved
 - keep resolved comments in context when they explain the author's changes

--- a/plugins/monolith-review-orchestrator/commands/reassess-prs.md
+++ b/plugins/monolith-review-orchestrator/commands/reassess-prs.md
@@ -9,8 +9,10 @@ Operate in reassessment mode:
 - refresh local state safely
 - refresh thread-aware GitHub review history when GitHub access is available
 - load compact structured review context first
-- validate the live PR heads against the latest recorded batch state before
-  trusting the cached reassessment identity
+- report live PR drift against the latest recorded batch state before trusting
+  the cached reassessment identity
+- treat reported head drift as the normal trigger for exact-head reassessment,
+  not as a pre-review blocker
 - inspect new commits and comment deltas since the prior pass
 - verify whether previously raised concerns are actually resolved
 - keep resolved comments in context when they explain the author's changes

--- a/plugins/monolith-review-orchestrator/commands/review-prs.md
+++ b/plugins/monolith-review-orchestrator/commands/review-prs.md
@@ -6,6 +6,8 @@ Use the `monolith-review-orchestrator` skill.
 
 Default to v1 intake, deterministic worktree reuse/bootstrap, deep PR/context
 review, structured local state, and a final synthesis for the invoker.
+Default to `review` mode whenever the user is asking for a new correctness
+judgment.
 
 Read existing review comments thoroughly, including resolved ones when they add
 context about prior concerns or fixes.

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/SKILL.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/SKILL.md
@@ -347,7 +347,9 @@ Use `scripts/review_state.py` for:
 
 - `init` once per batch
 - `summarize-context` before reassessment or posting
-- `validate-live-state` before reassessment or posting
+- `report-live-drift` before reassessment when new commits may have moved the
+  PR heads
+- `validate-live-state` immediately before posting
 - `record-review` after each substantive status/review/reassess/post pass
 - `record-pass` only for explicit migration/recovery with
   `--compatibility-only --justification`
@@ -457,9 +459,11 @@ Final response should include:
 When the user says the author pushed changes and wants another pass:
 
 - reuse the existing review worktree if possible
-- fetch latest refs and verify the tracked review refs are current with
-  `validate-live-state`
 - load the structured review state first with `summarize-context`
+- fetch latest refs and run `report-live-drift` against the latest
+  `fetch_review_threads.py` artifact
+- treat reported head drift as the normal trigger for exact-head checkout and
+  reassessment, not as a pre-review blocker
 - compare against the prior structured state and linked artifact
 - identify commits since the prior review
 - re-check every previously material finding

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/SKILL.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/SKILL.md
@@ -44,8 +44,8 @@ Explicitly out of scope for v1:
 This skill is an orchestrator. It does not replace repo-specific review taste.
 
 - For Django4Lyfe/backend slices, invoke `monty-code-review`.
-- For GitHub issue/PR metadata and comments, prefer the GitHub plugin/app when
-  available; fall back to `gh` only when needed.
+- For thread-aware GitHub acquisition, use this plugin's deterministic
+  `fetch_review_threads.py` helper, which currently uses `gh`.
 - For frontend or other non-backend slices, keep v1 narrower: do deep repo
   reading and synthesis, but do not pretend there is a stable repo-specific
   review adapter unless one actually exists.
@@ -82,21 +82,26 @@ For the deep-understanding, comment-history, and author-guidance protocol, load:
 Choose one mode early and state it explicitly to the user:
 
 1. `status`
-   - Understand the PRs, read discussion history, audit unresolved comments,
-     and report current status without doing a fresh full review.
+   - Report current state from the current code plus full review history.
+   - Use this only when the user explicitly wants state reporting without a new
+     correctness pass.
 2. `review`
-   - Do a full deep review, create/update local review artifacts, and stop
-     before posting unless the user asked to post.
+   - Default here whenever the user asks for a new correctness judgment.
 3. `reassess`
    - Re-review after new commits, focusing on deltas, prior findings, and still
      open concerns.
 4. `post`
-   - Publish the latest validated review to GitHub, including inline comments
-     when warranted and approval only if clean.
+   - Publish the latest validated review to GitHub.
+   - This is illegal as an entry mode unless a current-head prior pass already
+     exists and `validate-live-state` still matches the live PR heads.
 
-If the prompt implies more than one mode, use this order:
+If the prompt mixes intents, use this routing rule:
 
-`status/review -> reassess if needed -> post`
+- default to `review` for any new code judgment
+- use `status` only for explicit state-only asks
+- use `reassess` only when there is prior state and new commits
+- run `post` only after the review or reassessment is validated and the user
+  explicitly asked to post
 
 ## Deep Understanding First
 
@@ -127,7 +132,8 @@ Gather this data:
 - whether the run is read-only or local mutation is allowed
 - whether an existing dirty worktree may be reused
 - whether tests/builds should run or this is code-reading only
-- which PR is authoritative if linked PR verdicts diverge
+- for linked PRs: why the pair is linked, and which PR is authoritative if the
+  verdicts diverge
 - whether parallel sub-agents are allowed
 - whether GitHub posting is allowed in this run
 - if posting is allowed, whether this run is eligible for `COMMENT`,
@@ -186,6 +192,7 @@ result in your notes:
 - target branch / checked-out branch
 - mode
 - review artifact path
+- linked-pair metadata when the batch contains two PRs
 
 Map common Diversio repos to monolith paths:
 
@@ -198,40 +205,50 @@ Map common Diversio repos to monolith paths:
 
 If a repo cannot be mapped confidently, ask once.
 
-### 2. Prepare Or Reuse Local State
+Pass `--mode` to the helper. For linked PR pairs, also pass
+`--linked-pair-reason` and `--authoritative-pr`.
 
-Run preflight first with `scripts/preflight_review_env.py`.
+### 2. Preflight And Gather Live PR Context
+
+Run preflight first with `scripts/preflight_review_env.py`, passing the mode and
+PR URLs so GitHub auth is treated as mandatory by default.
+
+Then fetch live PR metadata and thread-aware review history with
+`scripts/fetch_review_threads.py` before local checkout so you know the exact
+`head_sha`, base branch, draft state, and review-thread history you are about
+to validate.
+
+Do not fall back to flat comment reads when the workflow needs reliable thread
+state. Stop instead of pretending the context is complete.
+
+### 3. Prepare Or Reuse Local State
 
 In the selected monolith root or review worktree:
 
 - confirm current path and git status
 - if the worktree is dirty and reuse was not explicitly allowed, stop and ask
-- fetch remotes needed for the monolith and relevant submodules
-- initialize submodules if needed
-- for each relevant submodule:
-  - verify the requested branch/ref exists locally or fetch it
-  - prefer detached checkout of the remote ref or exact commit under review
-    rather than attaching a local branch
-  - only attach a local branch if the user explicitly asked for that behavior
-  - avoid adjusting repos outside the review batch
+- initialize only the review-batch submodules
+- for each relevant submodule, use the live PR metadata to fetch and detach the
+  exact PR head SHA under review
+- do not proceed until the helper reports `status=matched` for every review
+  target and every `actual_head_sha` matches the expected SHA
 
 Do not use `uv run scripts/update_submodules.py` as routine review prep. That
 script enforces monolith branch policy and can mutate unrelated submodules.
 Refreshing utility repos is opt-in only.
 
 Use `scripts/prepare_review_worktree.py` for deterministic worktree
-create/reuse and safe submodule initialization.
+create/reuse, safe submodule initialization, and exact PR-head checkout.
 
 State clearly what you updated and what you intentionally left untouched.
 
-### 3. Gather PR And Comment Context
+### 4. Review Code Deeply
 
 For each PR:
 
 - read the PR metadata, description, and changed files
-- read all review comments, replies, and resolved threads when available
-- use `scripts/fetch_review_threads.py` as the default thread-aware acquisition
-  path when GitHub auth is available
+- read all review comments, replies, and resolved threads from the fetched
+  thread-aware context
 - identify unresolved threads only when you have a reliable thread-resolution
   source
 - cross-check whether each still-open claim is actually legitimate against the
@@ -243,7 +260,10 @@ review history and often explain why the current code looks the way it does.
 Do not discard that context during review or reassessment.
 
 Do not claim reliable unresolved-thread state from flat comment lists alone.
-If `fetch_review_threads.py` cannot be used, call the result provisional.
+If `fetch_review_threads.py` cannot be used and thread-resolution fidelity
+materially affects the result, stop and report that the run is blocked. Use flat
+comments only for explicitly provisional context where thread state is not
+decision-critical.
 
 When the user asked for "final status", explicitly separate:
 
@@ -251,9 +271,7 @@ When the user asked for "final status", explicitly separate:
 - what is still unresolved
 - what looks misunderstood or no longer applicable
 
-### 4. Review Code Deeply
-
-For each PR, inspect:
+Inspect the code for:
 
 - business logic and product behavior
 - correctness and data/contract invariants
@@ -275,6 +293,11 @@ Non-backend rule:
 - Keep v1 to code reading, repo-local pattern checks, and synthesis.
 - Do not manufacture Monty-specific Django findings for frontend-only work.
 - If a stable repo-specific review adapter does not exist, say so explicitly.
+
+Before invoking `monty-code-review` for backend work, persist a
+`backend_handoff` object that includes the worktree path, PR URL, head SHA,
+prior open finding IDs, and thread-context summary. The handoff must match the
+backend batch entry exactly.
 
 ### 5. Use Parallel Agents Carefully
 
@@ -334,8 +357,20 @@ Use `scripts/review_state.py` for:
 
 - `init` once per batch
 - `summarize-context` before reassessment or posting
+- `validate-live-state` before reassessment or posting
 - `record-review` after each substantive status/review/reassess/post pass
-- `record-pass` only as a compatibility fallback
+- `record-pass` only for explicit migration/recovery with
+  `--compatibility-only --justification`
+
+Hard gates:
+
+- `record-review` requires the markdown artifact to already exist
+- `status` requires non-empty `comment_context` plus explicit status buckets
+- `review` and `reassess` require comment-context evidence, author-claim
+  checks or `no_author_claims=true`, and either findings or
+  `no_findings_after_full_review=true`
+- backend batches require `backend_handoff` on `review`, `reassess`, and `post`
+- `approve` and `posted_approved` are forbidden while active findings remain
 
 Create or update deterministic markdown artifacts under a `reviews/` directory
 at the monolith root of the chosen worktree unless the user specified another
@@ -375,6 +410,13 @@ V1 posting boundary:
   machinery
 - generic multi-PR or non-backend posting should be treated as not yet
   productized unless dedicated helpers exist
+
+Before posting:
+
+- run `validate-live-state` against the current `fetch_review_threads.py` artifact
+- consume the fresh `validation_token` it returns
+- confirm a prior `status`, `review`, or `reassess` pass already exists on the
+  exact same heads
 
 Posting rules:
 
@@ -420,7 +462,8 @@ Final response should include:
 When the user says the author pushed changes and wants another pass:
 
 - reuse the existing review worktree if possible
-- fetch latest refs and verify the tracked review refs are current
+- fetch latest refs and verify the tracked review refs are current with
+  `validate-live-state`
 - load the structured review state first with `summarize-context`
 - compare against the prior structured state and linked artifact
 - identify commits since the prior review
@@ -442,6 +485,8 @@ The reassessment summary must distinguish:
 - Never hard-reset, delete, or recreate a user worktree without explicit approval.
 - Never post GitHub comments from sidecar agents.
 - Never approve a PR while simultaneously documenting legitimate blocking issues.
+- Never call a worktree "ready" unless each review submodule is on the exact PR
+  head SHA being reviewed.
 - Never treat an unresolved thread as valid without checking the current code.
 - Never treat a resolved thread as safe without checking whether the underlying
   issue was actually fixed.
@@ -450,4 +495,5 @@ The reassessment summary must distinguish:
 - Never post vague review comments that fail to explain risk and the next step.
 - Never let one PR's finding or inline target overwrite another PR's context in a
   linked cross-repo batch.
+- Never use `record-pass` for a normal review run.
 - Never use `uv run scripts/update_submodules.py` as a default review refresh.

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/intake-and-worktree-protocol.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/intake-and-worktree-protocol.md
@@ -26,7 +26,8 @@ Collect only what is missing:
 - whether the run is read-only or local mutation is allowed
 - whether an existing dirty worktree may be reused
 - whether tests/builds should run or this is code-reading only
-- which PR is authoritative if linked PR verdicts diverge
+- for linked PRs: why they are linked, and which PR is authoritative if the
+  verdicts diverge
 - whether GitHub posting is allowed now
 - if posting is allowed, whether this run is `COMMENT`, `REQUEST_CHANGES`, or
   `APPROVE` eligible
@@ -67,10 +68,12 @@ Examples:
 - backend PR 2779 -> `bk2779`
 - backend PR 2779 + optimo-frontend PR 389 -> `bk2779-of389`
 
-In v1, a linked PR pair is intentionally cross-repo only.
+In v1, a linked PR pair is intentionally cross-repo only and must carry
+machine-readable link metadata.
 
 Use `scripts/resolve_review_batch.py` so the model does not re-implement this
-logic inconsistently.
+logic inconsistently. Pass `--mode` on every run. For linked pairs, also pass
+`--linked-pair-reason` and `--authoritative-pr`.
 
 ## Deterministic Worktree Name
 
@@ -133,7 +136,13 @@ Use `scripts/prepare_review_worktree.py` to encapsulate this flow.
 
 ## Safe Refresh Pattern
 
-Inside the chosen worktree:
+Before local checkout, fetch live PR metadata and thread-aware review context:
+
+```bash
+uv run --script .../fetch_review_threads.py --pr-url <github-pr-url> [...]
+```
+
+Then, inside the chosen worktree:
 
 ```bash
 git fetch --all --prune
@@ -149,9 +158,16 @@ git status --short
 
 For the actual review ref:
 
-- prefer `git switch --detach <remote-ref-or-sha>` over attaching a local branch
+- use `scripts/prepare_review_worktree.py --review-target ...` so each relevant
+  submodule is fetched and detached at the exact PR head SHA
+- prefer the PR pull ref or an exact matching remote ref over attaching a local
+  branch
+- when a pull-ref fallback is needed, let the helper infer the correct remote
+  from the preferred ref or configured remotes instead of assuming `origin`
 - use an attached local branch only when the user explicitly asked for that
   behavior or the local path is already intentionally configured that way
+- do not continue until every reported row is `status=matched` and
+  `actual_head_sha == expected_head_sha`
 
 Do not use `uv run scripts/update_submodules.py` as routine refresh here. It is
 a mutating branch-policy updater for the monolith, not a safe read-only review
@@ -179,6 +195,7 @@ Persist a structured local state file keyed by the batch key. Minimum fields:
 - artifact path
 - review pass number
 - posting status
+- linked-batch metadata when two PRs are reviewed together
 
 For substantive passes, also persist:
 
@@ -189,11 +206,12 @@ For substantive passes, also persist:
   - moot / no longer applicable
   - resolved but still useful context
 - teaching points and inline comment targets
+- `backend_handoff` for Django4Lyfe-backed review batches
 
 Reassessment should load this state before comparing deltas.
 
-Use `scripts/review_state.py` for initialization, compact context lookup, and
-review recording.
+Use `scripts/review_state.py` for initialization, compact context lookup,
+live-state validation, and review recording.
 
 ## Combined Review Artifact Path
 

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/intake-and-worktree-protocol.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/intake-and-worktree-protocol.md
@@ -62,6 +62,7 @@ Suggested aliases:
 - `design-system` -> `ds`
 - `infrastructure` -> `infra`
 - `diversio-serverless` -> `sls`
+- `agent-skills-marketplace` -> `asm`
 - `monolith` -> `mono`
 
 Examples:

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/review-context-protocol.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/review-context-protocol.md
@@ -23,17 +23,19 @@ For each PR:
 
 1. Read the PR metadata, description, and changed files.
 2. Read all review comments and replies.
-3. When resolution or outdated-state fidelity matters, prefer a thread-aware
-   source such as `gh api graphql` or the GitHub plugin workflow that exposes
-   `reviewThreads`, `isResolved`, and `isOutdated`.
+3. When resolution or outdated-state fidelity matters, use the orchestrator's
+   deterministic `fetch_review_threads.py` helper so the acquisition path is
+   explicit and repeatable.
 4. Build three buckets:
    - still legitimate
    - moot / no longer applicable
    - resolved but still useful context
 5. Validate author claims against the current code instead of repeating them.
 
-If you only have flat comments, say thread state is provisional. Still read the
-comments and reuse the context.
+If `fetch_review_threads.py` is unavailable and thread-resolution fidelity
+materially affects the result, stop and report that the run is blocked. Only
+fall back to flat comments when the user explicitly accepts a provisional
+context-only read that does not depend on reliable resolved/open thread state.
 
 Default acquisition path:
 
@@ -42,9 +44,8 @@ uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orch
   --pr-url <github-pr-url> [...]
 ```
 
-Use that helper whenever GitHub auth is available. Fall back to flat comments
-only when the helper cannot be used, and mark thread state provisional in that
-case.
+Use that helper whenever GitHub auth is available. If it cannot be used and the
+request still depends on reliable thread state, fail closed instead of guessing.
 
 Mental model:
 
@@ -68,7 +69,11 @@ Recommended flow:
 
 1. `init` once per batch.
 2. `summarize-context` before reassessment or posting.
-3. `record-review` after every substantive pass.
+3. `validate-live-state` before reassessment or posting. It now uses the
+   `fetch_review_threads.py` artifact as a PR-url input and then performs a
+   fresh live GitHub read before minting a token. For `post`, consume the
+   returned `validation_token` in the posting payload.
+4. `record-review` after every substantive pass.
 
 `record-review` should persist:
 
@@ -77,11 +82,12 @@ Recommended flow:
 - scope summary
 - entries with repo, PR number, base branch, head SHA, and merge base for the
   full batch
-- author claims checked
+- author claims checked, or `no_author_claims=true`
 - comment context, including structured review-thread records when available
-- findings with repo-scoped stable IDs
+- findings with repo-scoped stable IDs, or `no_findings_after_full_review=true`
 - teaching points
 - inline comment targets
+- `backend_handoff` when the batch includes Django4Lyfe
 
 Thread-record note:
 
@@ -89,7 +95,8 @@ Thread-record note:
   `resolved`, `moot`)
 - `is_resolved` is the raw GitHub resolution state when known
 - the helper should reject obviously contradictory combinations such as
-  `status=open` with `is_resolved=true`
+  `status=open` with `is_resolved=true` or `status=resolved` with
+  `is_resolved=false`
 
 Guardrails:
 
@@ -98,9 +105,11 @@ Guardrails:
   rejected during normalization rather than silently upgraded
 - every inline comment target must include a `finding_id`, and that ID should
   exist in the active `new` or `carried_forward` findings for the pass
+- `record-pass` is compatibility-only and should not be used for normal review
+  runs
 - omitting comment context or teaching points in a later pass should not erase
   them from `summarize-context`; the helper merges persistent context across
-  passes
+  all passes, then trims at the item level for compact output
 - `summarize-context` should stay compact by prioritizing recent-pass context
   instead of replaying every historical thread record or teaching point forever
 - capped `open_findings` output should prefer the most recent surviving active
@@ -159,16 +168,39 @@ cat <<'EOF' | uv run --script plugins/monolith-review-orchestrator/skills/monoli
       "pr_number": 2779,
       "base_branch": "main",
       "head_sha": "abc123",
-      "merge_base": "def456"
+      "merge_base": "def456",
+      "pr_state": "OPEN",
+      "is_draft": false
     },
     {
       "repo": "Optimo-Frontend",
       "pr_number": 389,
       "base_branch": "main",
       "head_sha": "ghi789",
-      "merge_base": "jkl012"
+      "merge_base": "jkl012",
+      "pr_state": "OPEN",
+      "is_draft": false
     }
   ],
+  "author_claims_checked": [
+    {
+      "repo": "Django4Lyfe",
+      "pr_number": 2779,
+      "claim": "This now scopes the queryset by tenant.",
+      "status": "verified",
+      "evidence": "Confirmed the service now passes the tenant-bound queryset into the reused helper."
+    }
+  ],
+  "backend_handoff": {
+    "repo": "Django4Lyfe",
+    "pr_number": 2779,
+    "worktree_path": "/path/to/monolith-review-bk2779-of389",
+    "pr_url": "https://github.com/DiversioTeam/Django4Lyfe/pull/2779",
+    "head_sha": "abc123",
+    "prior_open_finding_ids": [],
+    "thread_context_summary": "Fetched full GitHub thread history before invoking monty.",
+    "allowed_posting_action": "request_changes"
+  },
   "comment_context": {
     "thread_source": "gh_graphql",
     "summary": "Read all review threads, including resolved ones, before reassessing.",
@@ -190,6 +222,9 @@ cat <<'EOF' | uv run --script plugins/monolith-review-orchestrator/skills/monoli
     ],
     "still_legit": [
       "Frontend still renders an empty body when backend returns an empty string."
+    ],
+    "moot_or_no_longer_applicable": [
+      "An earlier thread about a missing import is no longer applicable after the component split."
     ],
     "resolved_for_context": [
       "Previous spacing/thread cleanup is resolved but explains the current component split."
@@ -224,6 +259,24 @@ cat <<'EOF' | uv run --script plugins/monolith-review-orchestrator/skills/monoli
 }
 EOF
 ```
+
+If a reassessment or posting run depends on current PR heads still matching the
+stored batch identity, validate that from the live `fetch_review_threads.py`
+artifact:
+
+```bash
+uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py \
+  validate-live-state \
+  --state-path "$STATE_PATH" \
+  --pr-context-path /path/to/fetch-review-threads.json
+```
+
+That command now writes a one-time live-state proof into the state file and
+returns a `token`. `mode=post` must consume that token before it can record the
+posting pass. The proof is intentionally short-lived; stale proofs must be
+rejected and revalidated immediately before posting. The supplied artifact must
+come from `fetch_review_threads.py`, and the helper re-reads GitHub before
+minting the token.
 
 ## Author-Guiding Review Output
 

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/review-context-protocol.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/review-context-protocol.md
@@ -69,11 +69,14 @@ Recommended flow:
 
 1. `init` once per batch.
 2. `summarize-context` before reassessment or posting.
-3. `validate-live-state` before reassessment or posting. It now uses the
+3. `report-live-drift` before reassessment when author pushes may have moved
+   the PR heads. It compares the latest recorded substantive pass against live
+   GitHub state and reports drift without mutating the state file.
+4. `validate-live-state` immediately before `post`. It uses the
    `fetch_review_threads.py` artifact as a PR-url input and then performs a
    fresh live GitHub read before minting a token. For `post`, consume the
    returned `validation_token` in the posting payload.
-4. `record-review` after every substantive pass.
+5. `record-review` after every substantive pass.
 
 `record-review` should persist:
 
@@ -322,9 +325,20 @@ cat <<'EOF' | uv run --script plugins/monolith-review-orchestrator/skills/monoli
 EOF
 ```
 
-If a reassessment or posting run depends on current PR heads still matching the
-stored batch identity, validate that from the live `fetch_review_threads.py`
-artifact:
+Before reassessment, report live drift from the latest recorded substantive pass
+without mutating state:
+
+```bash
+uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py \
+  report-live-drift \
+  --state-path "$STATE_PATH" \
+  --pr-context-path /path/to/fetch-review-threads.json
+```
+
+Treat reported head drift as the normal trigger for exact-head reassessment,
+not as a blocker.
+
+Immediately before posting, mint the one-time live-state proof:
 
 ```bash
 uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py \
@@ -333,12 +347,12 @@ uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orch
   --pr-context-path /path/to/fetch-review-threads.json
 ```
 
-That command now writes a one-time live-state proof into the state file and
-returns a `token`. `mode=post` must consume that token before it can record the
-posting pass. The proof is intentionally short-lived; stale proofs must be
-rejected and revalidated immediately before posting. The supplied artifact must
-come from `fetch_review_threads.py`, and the helper re-reads GitHub before
-minting the token.
+That command writes a one-time live-state proof into the state file and returns
+a `token`. `mode=post` must consume that token before it can record the posting
+pass. The proof is intentionally short-lived; stale proofs must be rejected and
+revalidated immediately before posting. The supplied artifact must come from
+`fetch_review_threads.py`, and the helper re-reads GitHub before minting the
+token.
 
 ## Author-Guiding Review Output
 

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md
@@ -328,7 +328,19 @@ uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orch
   --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json"
 ```
 
-Live-state validation example:
+Reassessment drift-report example:
+
+```bash
+uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py \
+  report-live-drift \
+  --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json" \
+  --pr-context-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/pr-context-bk2779-of389.json"
+```
+
+Treat reported head drift as the normal trigger for exact-head reassessment, not
+as a pre-review blocker.
+
+Live-state validation example for posting:
 
 ```bash
 uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py \
@@ -524,7 +536,7 @@ For reassessment:
 
 ```bash
 uv run --script .../review_state.py summarize-context --state-path ...
-uv run --script .../review_state.py validate-live-state --state-path ... --pr-context-path ...
+uv run --script .../review_state.py report-live-drift --state-path ... --pr-context-path ...
 ```
 
 Then load the stored identity before comparing new commits or writing a new

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md
@@ -94,7 +94,8 @@ Why it exists:
 What it does:
 
 - parses GitHub PR URLs
-- maps `(owner, repo)` pairs to the relevant monolith execution location
+- maps `(owner, repo)` pairs to the relevant monolith execution location from
+  one shared source of truth, including `DiversioTeam/agent-skills-marketplace`
   - most repos map to a submodule path
   - `DiversioTeam/monolith` maps to the monolith root itself and therefore has no
     submodule path
@@ -162,7 +163,8 @@ What it does:
 - creates one detached worktree, or reuses an existing registered one
 - initializes only the explicitly listed review-batch submodules in that
   worktree
-- blocks dirty reuse unless explicitly allowed
+- blocks dirty reuse unless explicitly allowed, but does not treat the expected
+  detached review-target submodule SHA drift as generic dirtiness
 - fetches and detaches each review submodule at the exact expected PR head SHA
 - fails closed if a submodule cannot be matched to the requested PR head
 - rejects duplicate `--review-target` values for the same submodule path

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md
@@ -410,27 +410,39 @@ cat <<EOF | uv run --script plugins/monolith-review-orchestrator/skills/monolith
   record-review \
   --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json"
 {
-  "mode": "post",
+  "mode": "review",
   "artifact_path": "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/review-bk2779-of389.md",
   "posting_status": "not_posted",
   "recommendation": "request_changes",
-  "scope_summary": "Prepared the final review draft and one stable inline anchor.",
+  "scope_summary": "Recorded one active finding and one stable inline anchor during the initial review pass.",
   "entries": [
     {
       "repo": "Django4Lyfe",
       "pr_number": 2779,
       "base_branch": "main",
       "head_sha": "<backend-head-sha>",
-      "merge_base": "<backend-merge-base>"
+      "merge_base": "<backend-merge-base>",
+      "pr_state": "OPEN",
+      "is_draft": false
     },
     {
       "repo": "Optimo-Frontend",
       "pr_number": 389,
       "base_branch": "main",
       "head_sha": "<optimo-head-sha>",
-      "merge_base": "<optimo-merge-base>"
+      "merge_base": "<optimo-merge-base>",
+      "pr_state": "OPEN",
+      "is_draft": false
     }
   ],
+  "no_author_claims": true,
+  "comment_context": {
+    "thread_source": "gh_graphql",
+    "summary": "Read all review threads before recording the inline anchor plan.",
+    "resolved_for_context": [
+      "An earlier resolved thread still explains why this inline anchor belongs on the active frontend finding."
+    ]
+  },
   "findings": {
     "new": [
       {

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md
@@ -29,10 +29,10 @@ preflight
 resolve review batch
    |
    v
-prepare or reuse worktree
+fetch live PR context
    |
    v
-fetch thread-aware review history
+prepare or reuse worktree
    |
    v
 initialize / update structured state
@@ -64,13 +64,15 @@ What it checks:
 
 - monolith markers such as `.gitmodules` and the monolith scripts/docs
 - `git`, `uv`, and `git worktree`
-- optional GitHub auth via `gh auth status`
+- GitHub auth via `gh auth status` whenever a mode or PR URL is provided
 - sibling directory suitability for deterministic worktrees
 
 Example:
 
 ```bash
-uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/preflight_review_env.py
+uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/preflight_review_env.py \
+  --mode review \
+  --pr-url https://github.com/DiversioTeam/Django4Lyfe/pull/2779
 ```
 
 ### 2. `resolve_review_batch.py`
@@ -92,20 +94,28 @@ Why it exists:
 What it does:
 
 - parses GitHub PR URLs
-- maps repo names to monolith submodule paths
+- maps `(owner, repo)` pairs to monolith submodule paths
+- carries the selected mode into the resolved batch payload
 - derives a deterministic batch key such as `bk2779-of389`
 - derives the worktree path, review artifact path, reassessment path, and state
   file path
 - rejects duplicate PR inputs and same-repo linked pairs in v1
+- requires linked-pair metadata for linked cross-repo review batches
 - fails clearly when it cannot discover a real monolith root
 
 Example:
 
 ```bash
 uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py \
+  --mode review \
   --pr-url https://github.com/DiversioTeam/Django4Lyfe/pull/2779 \
-  --pr-url https://github.com/DiversioTeam/Optimo-Frontend/pull/389
+  --pr-url https://github.com/DiversioTeam/Optimo-Frontend/pull/389 \
+  --linked-pair-reason "Backend and frontend must ship together for the end-to-end behavior to work." \
+  --authoritative-pr Django4Lyfe:2779
 ```
+
+This helper now mirrors preflight's sibling-worktree root discovery instead of
+requiring the caller to stand in the monolith root specifically.
 
 ### 3. `prepare_review_worktree.py`
 
@@ -128,6 +138,9 @@ What it does:
 - initializes only the explicitly listed review-batch submodules in that
   worktree
 - blocks dirty reuse unless explicitly allowed
+- fetches and detaches each review submodule at the exact expected PR head SHA
+- fails closed if a submodule cannot be matched to the requested PR head
+- rejects duplicate `--review-target` values for the same submodule path
 
 Important non-goal:
 
@@ -144,10 +157,14 @@ Example:
 uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/prepare_review_worktree.py \
   --monolith-root "$MONOLITH_ROOT" \
   --worktree-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389" \
-  --submodule-path backend \
-  --submodule-path optimo-frontend \
+  --review-target "backend:2779:<backend-head-sha>:<backend-head-ref-name>" \
+  --review-target "optimo-frontend:389:<optimo-head-sha>:<optimo-head-ref-name>" \
   --start-ref HEAD
 ```
+
+If the helper must fall back to the pull-ref fetch path, it now infers the
+remote from the preferred ref or the configured remotes instead of hardcoding
+`origin`.
 
 ### 4. `fetch_review_threads.py`
 
@@ -172,6 +189,8 @@ What it does:
 - paginates PR comments, review submissions, and review threads
 - follows up for extra thread-comment pages when a thread has more than the
   first page of comments
+- enforces the same v1 scope as the batch resolver: one PR or one linked
+  cross-repo pair under the known Diversio repos
 - emits normalized thread-aware JSON keyed by repo and PR number
 
 Why the helper owns this instead of leaving it to prompts:
@@ -217,7 +236,12 @@ Why it exists:
 What it does:
 
 - initializes one structured state file for a batch
+- enforces the same v1 batch scope as `resolve_review_batch.py`
 - summarizes the latest reusable review context for reassessment/posting
+- validates live GitHub PR metadata against the latest recorded substantive
+  batch identity by re-reading GitHub from the supplied `fetch_review_threads.py`
+  artifact
+- emits a one-time validation token that `mode=post` must consume
 - records one completed batch-scoped review pass
 - records one completed review pass plus compact review context from stdin JSON
 - rejects review-pass records for PRs outside the batch
@@ -233,24 +257,16 @@ uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orch
   --worktree-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389" \
   --artifact-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/review-bk2779-of389.md" \
   --pr Django4Lyfe:2779 \
-  --pr Optimo-Frontend:389
+  --pr Optimo-Frontend:389 \
+  --link-type explicit_cross_repo_pair \
+  --linked-pair-reason "Backend and frontend must ship together for the end-to-end behavior to work." \
+  --authoritative-pr Django4Lyfe:2779
 ```
 
 If the state file already exists and you intentionally want to replace it:
 
 ```bash
 uv run --script .../review_state.py init --force ...
-```
-
-Batch-scoped pass recording example:
-
-```bash
-uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py record-pass \
-  --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json" \
-  --review-target "Django4Lyfe:2779:main:<backend-head-sha>:<backend-merge-base-sha>" \
-  --review-target "Optimo-Frontend:389:main:<optimo-head-sha>:<optimo-merge-base-sha>" \
-  --artifact-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/review-bk2779-of389.md" \
-  --posting-status not_posted
 ```
 
 Compact context read example:
@@ -260,6 +276,21 @@ uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orch
   summarize-context \
   --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json"
 ```
+
+Live-state validation example:
+
+```bash
+uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py \
+  validate-live-state \
+  --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json" \
+  --pr-context-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/pr-context-bk2779-of389.json"
+```
+
+For posting, take the returned `token` and include it as
+`validation_token` in the `record-review` payload for `mode=post`. That proof is
+time-limited and must still be fresh when posting occurs. It is now sourced from
+structured live GitHub metadata, not caller-typed entries. The current
+live-validation proof covers base branch, head SHA, PR state, and draft state.
 
 Rich review-context write example:
 
@@ -279,16 +310,38 @@ cat <<EOF | uv run --script plugins/monolith-review-orchestrator/skills/monolith
       "pr_number": 2779,
       "base_branch": "main",
       "head_sha": "<backend-head-sha>",
-      "merge_base": "<backend-merge-base>"
+      "merge_base": "<backend-merge-base>",
+      "pr_state": "OPEN",
+      "is_draft": false
     },
     {
       "repo": "Optimo-Frontend",
       "pr_number": 389,
       "base_branch": "main",
       "head_sha": "<optimo-head-sha>",
-      "merge_base": "<optimo-merge-base>"
+      "merge_base": "<optimo-merge-base>",
+      "pr_state": "OPEN",
+      "is_draft": false
     }
   ],
+  "backend_handoff": {
+    "repo": "Django4Lyfe",
+    "pr_number": 2779,
+    "worktree_path": "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389",
+    "pr_url": "https://github.com/DiversioTeam/Django4Lyfe/pull/2779",
+    "head_sha": "<backend-head-sha>",
+    "prior_open_finding_ids": [],
+    "thread_context_summary": "Fetched full GitHub thread history before invoking monty."
+  },
+  "no_author_claims": true,
+  "no_findings_after_full_review": true,
+  "comment_context": {
+    "thread_source": "gh_graphql",
+    "summary": "Read all GitHub review threads, including resolved ones, before concluding the pass.",
+    "resolved_for_context": [
+      "A resolved earlier thread still explains why the helper now owns the PR ref validation."
+    ]
+  },
   "findings": {
     "new": [],
     "carried_forward": [],
@@ -304,10 +357,16 @@ Guardrails:
 - `entries` must cover the full batch, not just one side of a linked PR pair
 - `inline_comment_targets[].finding_id` must point at an active `new` or
   `carried_forward` finding ID
-- `summarize-context` merges durable context across recent passes instead of
-  exposing only the latest pass's thread notes and teaching points
+- `summarize-context` merges durable context across all passes and only trims at
+  the item level for compact output
 - incomplete persisted linked-batch passes should fail normalization instead of
   being silently upgraded
+- `mode=post` must reuse the latest validated recommendation and active finding
+  set instead of inventing a new verdict at write time
+- `backend_handoff` must match the backend batch entry's PR, SHA, recommendation,
+  and recorded worktree path
+- `record-pass` is disabled for normal review runs and only available behind
+  `--compatibility-only --justification`
 
 ## What These Helpers Do Not Solve Yet
 
@@ -329,9 +388,9 @@ For a normal review run:
 
 ```bash
 uv run --script .../preflight_review_env.py
-uv run --script .../resolve_review_batch.py --pr-url ...
-uv run --script .../prepare_review_worktree.py --monolith-root ... --worktree-path ... --submodule-path ...
+uv run --script .../resolve_review_batch.py --mode review --pr-url ...
 uv run --script .../fetch_review_threads.py --pr-url ...
+uv run --script .../prepare_review_worktree.py --monolith-root ... --worktree-path ... --review-target ...
 uv run --script .../review_state.py init ...
 ```
 
@@ -339,6 +398,7 @@ For reassessment:
 
 ```bash
 uv run --script .../review_state.py summarize-context --state-path ...
+uv run --script .../review_state.py validate-live-state --state-path ... --pr-context-path ...
 ```
 
 Then load the stored identity before comparing new commits or writing a new

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/fetch_review_threads.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/fetch_review_threads.py
@@ -34,13 +34,13 @@ import click
 
 PR_PATH_PARTS = 4
 THREAD_STATUS = {True: "resolved", False: "open"}
-KNOWN_REPOS: dict[str, tuple[str, str]] = {
-    "Django4Lyfe": ("bk", "backend"),
-    "Diversio-Frontend": ("fe", "frontend"),
-    "Optimo-Frontend": ("of", "optimo-frontend"),
-    "diversio-ds": ("ds", "design-system"),
-    "infrastructure": ("infra", "infrastructure"),
-    "diversio-serverless": ("sls", "diversio-serverless"),
+KNOWN_REPOS: dict[tuple[str, str], tuple[str, str]] = {
+    ("DiversioTeam", "Django4Lyfe"): ("bk", "backend"),
+    ("DiversioTeam", "Diversio-Frontend"): ("fe", "frontend"),
+    ("DiversioTeam", "Optimo-Frontend"): ("of", "optimo-frontend"),
+    ("DiversioTeam", "diversio-ds"): ("ds", "design-system"),
+    ("DiversioTeam", "infrastructure"): ("infra", "infrastructure"),
+    ("DiversioTeam", "diversio-serverless"): ("sls", "diversio-serverless"),
 }
 
 MAIN_QUERY = """\
@@ -58,6 +58,7 @@ query(
       url
       title
       state
+      isDraft
       body
       baseRefName
       headRefName
@@ -257,6 +258,7 @@ class RawPullRequest(TypedDict, total=False):
     url: str
     title: str
     state: str
+    isDraft: bool
     body: str | None
     baseRefName: str | None
     headRefName: str | None
@@ -291,6 +293,7 @@ class PullRequestMetadata(TypedDict, total=False):
     url: str
     title: str
     state: str
+    is_draft: bool
     body: str
     author_login: str | None
     base_ref_name: str | None
@@ -494,10 +497,16 @@ def parse_pr_url(pr_url: str) -> PullRequestRef:
     except ValueError as exc:
         raise click.ClickException(f"Invalid PR number in URL: {pr_url}") from exc
 
-    alias: str | None = None
-    submodule_path: str | None = None
-    if repo in KNOWN_REPOS:
-        alias, submodule_path = KNOWN_REPOS[repo]
+    repo_key = (owner, repo)
+    if repo_key not in KNOWN_REPOS:
+        known = ", ".join(
+            f"{known_owner}/{known_repo}" for known_owner, known_repo in sorted(KNOWN_REPOS)
+        )
+        raise click.ClickException(
+            f"Unknown monolith review target `{owner}/{repo}` in {pr_url}. "
+            f"Known repo owners: {known}"
+        )
+    alias, submodule_path = KNOWN_REPOS[repo_key]
 
     return PullRequestRef(
         owner=owner,
@@ -521,6 +530,18 @@ def ensure_unique_prs(pr_refs: list[PullRequestRef]) -> list[PullRequestRef]:
         seen.add(identity)
         unique.append(pr_ref)
     return unique
+
+
+def ensure_v1_scope(pr_refs: list[PullRequestRef]) -> list[PullRequestRef]:
+    if len(pr_refs) > 2:
+        raise click.ClickException(
+            "V1 only supports one PR or one explicitly linked cross-repo PR pair."
+        )
+    if len(pr_refs) == 2 and pr_refs[0].repo == pr_refs[1].repo:
+        raise click.ClickException(
+            "V1 linked pairs must be cross-repo. Use a single PR batch for same-repo review."
+        )
+    return pr_refs
 
 
 def ensure_gh_authenticated() -> None:
@@ -785,6 +806,9 @@ def fetch_pull_request_context(pr_ref: PullRequestRef) -> PullRequestReviewConte
                 "url": require_str(pull_request.get("url"), "pull_request.url"),
                 "title": require_str(pull_request.get("title"), "pull_request.title"),
                 "state": require_str(pull_request.get("state"), "pull_request.state"),
+                "is_draft": require_bool(
+                    pull_request.get("isDraft"), "pull_request.isDraft"
+                ),
                 "body": optional_str(pull_request.get("body"), "pull_request.body")
                 or "",
                 "author_login": parse_author_login(
@@ -933,7 +957,9 @@ def main(pr_urls: tuple[str, ...]) -> None:
     """Fetch thread-aware PR review context for one PR or a linked PR set."""
 
     ensure_gh_authenticated()
-    pr_refs = ensure_unique_prs([parse_pr_url(pr_url) for pr_url in pr_urls])
+    pr_refs = ensure_v1_scope(
+        ensure_unique_prs([parse_pr_url(pr_url) for pr_url in pr_urls])
+    )
     pr_refs.sort(key=lambda pr_ref: ((pr_ref.alias or pr_ref.repo), pr_ref.pr_number))
 
     payload: FetchResult = {

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/fetch_review_threads.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/fetch_review_threads.py
@@ -26,23 +26,22 @@ from __future__ import annotations
 import json
 import subprocess
 from dataclasses import dataclass
+from pathlib import Path
+import sys
 from typing import Literal, TypedDict
 from urllib.parse import urlparse
 
 import click
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from review_targets import REVIEW_TARGETS, format_known_review_targets
+
 
 PR_PATH_PARTS = 4
 THREAD_STATUS = {True: "resolved", False: "open"}
-KNOWN_REPOS: dict[tuple[str, str], tuple[str, str | None]] = {
-    ("DiversioTeam", "monolith"): ("mono", None),
-    ("DiversioTeam", "Django4Lyfe"): ("bk", "backend"),
-    ("DiversioTeam", "Diversio-Frontend"): ("fe", "frontend"),
-    ("DiversioTeam", "Optimo-Frontend"): ("of", "optimo-frontend"),
-    ("DiversioTeam", "diversio-ds"): ("ds", "design-system"),
-    ("DiversioTeam", "infrastructure"): ("infra", "infrastructure"),
-    ("DiversioTeam", "diversio-serverless"): ("sls", "diversio-serverless"),
-}
 
 MAIN_QUERY = """\
 query(
@@ -499,23 +498,20 @@ def parse_pr_url(pr_url: str) -> PullRequestRef:
         raise click.ClickException(f"Invalid PR number in URL: {pr_url}") from exc
 
     repo_key = (owner, repo)
-    if repo_key not in KNOWN_REPOS:
-        known = ", ".join(
-            f"{known_owner}/{known_repo}" for known_owner, known_repo in sorted(KNOWN_REPOS)
-        )
+    target = REVIEW_TARGETS.get(repo_key)
+    if target is None:
         raise click.ClickException(
             f"Unknown monolith review target `{owner}/{repo}` in {pr_url}. "
-            f"Known targets: {known}"
+            f"Known targets: {format_known_review_targets()}"
         )
-    alias, submodule_path = KNOWN_REPOS[repo_key]
 
     return PullRequestRef(
         owner=owner,
         repo=repo,
         pr_number=pr_number,
         pr_url=pr_url,
-        alias=alias,
-        submodule_path=submodule_path,
+        alias=target["alias"],
+        submodule_path=target["submodule_path"],
     )
 
 

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/preflight_review_env.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/preflight_review_env.py
@@ -29,6 +29,7 @@ import click
 
 
 REQUIRED_TOOLS: tuple[str, ...] = ("git", "uv")
+ALLOWED_MODES: tuple[str, ...] = ("status", "review", "reassess", "post")
 MONOLITH_MARKERS: tuple[str, ...] = (
     ".gitmodules",
     ".submodule-branches",
@@ -51,6 +52,32 @@ def resolve_root(candidate: Path) -> Path:
     return path
 
 
+def has_monolith_markers(path: Path) -> bool:
+    return all((path / marker).exists() for marker in MONOLITH_MARKERS)
+
+
+def discover_monolith_root_from_siblings(start: Path) -> Path | None:
+    current = resolve_root(start)
+    for candidate in (current, *current.parents):
+        parent = candidate.parent
+        if not parent.exists() or not parent.is_dir():
+            continue
+        matches = [
+            child
+            for child in parent.iterdir()
+            if child.is_dir() and has_monolith_markers(child)
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise click.ClickException(
+                "Could not uniquely resolve the monolith root from sibling review "
+                f"worktree `{current}`. Matching roots: "
+                f"{', '.join(str(match) for match in sorted(matches))}."
+            )
+    return None
+
+
 def discover_monolith_root(start: Path) -> Path:
     """Walk upward until we find the real monolith root markers.
 
@@ -60,8 +87,11 @@ def discover_monolith_root(start: Path) -> Path:
 
     current = resolve_root(start)
     for candidate in (current, *current.parents):
-        if all((candidate / marker).exists() for marker in MONOLITH_MARKERS):
+        if has_monolith_markers(candidate):
             return candidate
+    sibling_match = discover_monolith_root_from_siblings(current)
+    if sibling_match is not None:
+        return sibling_match
     return current
 
 
@@ -75,15 +105,40 @@ def discover_monolith_root(start: Path) -> Path:
 )
 @click.option(
     "--require-github-auth/--no-require-github-auth",
-    default=False,
-    show_default=True,
-    help="Check for gh auth status when GitHub access is required.",
+    default=None,
+    help=(
+        "Override GitHub auth inference. By default, GitHub auth is required "
+        "whenever a mode or PR URL is provided."
+    ),
 )
-def main(monolith_root: Path, require_github_auth: bool) -> None:
+@click.option(
+    "--mode",
+    type=click.Choice(ALLOWED_MODES, case_sensitive=False),
+    default=None,
+    help="Resolved execution mode for the run being preflighted.",
+)
+@click.option(
+    "--pr-url",
+    "pr_urls",
+    multiple=True,
+    help="Repeat for each PR URL this run intends to inspect or post against.",
+)
+def main(
+    monolith_root: Path,
+    require_github_auth: bool | None,
+    mode: str | None,
+    pr_urls: tuple[str, ...],
+) -> None:
     """Verify that the local environment can run the monolith review harness."""
 
-    root = resolve_root(monolith_root)
+    root = discover_monolith_root(monolith_root)
     errors: list[str] = []
+    normalized_mode = mode.lower() if mode is not None else None
+    github_required = (
+        require_github_auth
+        if require_github_auth is not None
+        else bool(pr_urls or normalized_mode is not None)
+    )
 
     if not (root / ".git").exists():
         errors.append(f"{root} is not a git repository.")
@@ -106,7 +161,7 @@ def main(monolith_root: Path, require_github_auth: bool) -> None:
     if not sibling_dir.exists() or not sibling_dir.is_dir():
         errors.append(f"Sibling worktree parent is not usable: {sibling_dir}")
 
-    if require_github_auth:
+    if github_required:
         if shutil.which("gh") is None:
             errors.append("GitHub auth required but `gh` is not installed.")
         else:
@@ -121,7 +176,11 @@ def main(monolith_root: Path, require_github_auth: bool) -> None:
 
     click.echo(f"OK: monolith root={root}")
     click.echo(f"OK: sibling worktree parent={sibling_dir}")
-    if require_github_auth:
+    if normalized_mode is not None:
+        click.echo(f"OK: mode={normalized_mode}")
+    if pr_urls:
+        click.echo(f"OK: pr_url_count={len(pr_urls)}")
+    if github_required:
         click.echo("OK: GitHub auth available")
 
 

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/prepare_review_worktree.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/prepare_review_worktree.py
@@ -92,16 +92,59 @@ def remove_worktree(monolith_root: Path, target: Path) -> None:
         shutil.rmtree(target)
 
 
-def worktree_is_dirty(worktree_path: Path) -> bool:
-    """Return whether the target worktree currently has local changes."""
+def read_status_entries(repo_path: Path) -> list[tuple[str, str]]:
+    """Return parsed porcelain status entries for the given repository."""
 
-    result = run_command(["git", "status", "--short"], cwd=worktree_path)
+    result = run_command(
+        ["git", "status", "--short", "--ignore-submodules=none"],
+        cwd=repo_path,
+    )
     if result.returncode != 0:
         raise click.ClickException(
             result.stderr.strip()
-            or f"Failed to inspect worktree status for {worktree_path}"
+            or f"Failed to inspect worktree status for {repo_path}"
         )
-    return bool(result.stdout.strip())
+    entries: list[tuple[str, str]] = []
+    for line in result.stdout.splitlines():
+        if len(line) < 4:
+            raise click.ClickException(
+                f"Unexpected porcelain status line for `{repo_path}`: {line!r}"
+            )
+        path = line[3:]
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        entries.append((line[:2], path))
+    return entries
+
+
+def repository_is_dirty(repo_path: Path) -> bool:
+    return bool(read_status_entries(repo_path))
+
+
+def worktree_is_dirty(
+    worktree_path: Path, review_target_submodule_paths: set[str] | None = None
+) -> bool:
+    """Return whether the target worktree has blocking local changes.
+
+    Detaching a review-target submodule at the exact PR head intentionally
+    changes the superproject's recorded submodule SHA. Treat that exact clean
+    detached-submodule state as reusable, while still blocking genuine local
+    edits in the worktree or within the review-target submodule itself.
+    """
+
+    allowed_review_targets = review_target_submodule_paths or set()
+    clean_review_target_cache: dict[str, bool] = {}
+
+    for status, path in read_status_entries(worktree_path):
+        if path in allowed_review_targets and status == " M":
+            is_clean = clean_review_target_cache.get(path)
+            if is_clean is None:
+                is_clean = not repository_is_dirty(worktree_path / path)
+                clean_review_target_cache[path] = is_clean
+            if is_clean:
+                continue
+        return True
+    return False
 
 
 def parse_review_target(raw_value: str) -> ReviewTarget:
@@ -334,6 +377,9 @@ def main(
     parsed_review_targets = ensure_unique_review_targets(
         [parse_review_target(raw_value) for raw_value in review_targets]
     )
+    review_target_submodule_paths = {
+        entry["submodule_path"] for entry in parsed_review_targets
+    }
     target_submodule_paths = [entry["submodule_path"] for entry in parsed_review_targets]
     unique_submodule_paths = tuple(dict.fromkeys((*submodule_paths, *target_submodule_paths)))
 
@@ -343,7 +389,7 @@ def main(
             raise click.ClickException(
                 f"{target} exists but is not a registered git worktree."
             )
-        dirty = worktree_is_dirty(target)
+        dirty = worktree_is_dirty(target, review_target_submodule_paths)
         if dirty and not allow_dirty_reuse:
             if repair_dirty_reuse:
                 remove_worktree(root, target)
@@ -385,7 +431,7 @@ def main(
         checkout_exact_review_ref(target, review_target)
         for review_target in parsed_review_targets
     ]
-    dirty = worktree_is_dirty(target)
+    dirty = worktree_is_dirty(target, review_target_submodule_paths)
 
     payload = {
         "action": action,

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/prepare_review_worktree.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/prepare_review_worktree.py
@@ -11,10 +11,12 @@ Why this helper exists:
 - `scripts/create_worktree.py` is interactive and aimed at humans
 - the review harness needs deterministic automation
 - review prep should stay narrow and avoid mutating unrelated submodules
+- deep review must fail closed if the local code is not on the exact PR head
 
 Mental model:
     "Give me exactly one detached review worktree for this batch, or reuse the
-    existing one if it is already registered and safe."
+    existing one if it is already registered and safe. Then put each review
+    submodule on the exact PR head SHA we claim to review."
 """
 
 from __future__ import annotations
@@ -22,8 +24,16 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
+from typing import TypedDict
 
 import click
+
+
+class ReviewTarget(TypedDict):
+    submodule_path: str
+    pr_number: int
+    expected_head_sha: str
+    preferred_ref: str | None
 
 
 def run_command(
@@ -57,6 +67,190 @@ def worktree_is_dirty(worktree_path: Path) -> bool:
     return bool(result.stdout.strip())
 
 
+def parse_review_target(raw_value: str) -> ReviewTarget:
+    parts = raw_value.split(":", 3)
+    if len(parts) not in {3, 4}:
+        raise click.ClickException(
+            "Invalid `--review-target` value. Use "
+            "submodule_path:pr_number:expected_head_sha[:preferred_ref]."
+        )
+
+    submodule_path = parts[0].strip()
+    pr_number_text = parts[1].strip()
+    expected_head_sha = parts[2].strip()
+    preferred_ref = parts[3].strip() if len(parts) == 4 and parts[3].strip() else None
+
+    if not submodule_path or not expected_head_sha:
+        raise click.ClickException(
+            "Invalid `--review-target` value. `submodule_path` and "
+            "`expected_head_sha` must be non-empty."
+        )
+
+    try:
+        pr_number = int(pr_number_text)
+    except ValueError as exc:
+        raise click.ClickException(
+            "Invalid `--review-target` value. `pr_number` must be an integer."
+        ) from exc
+    if isinstance(pr_number, bool) or pr_number < 1:
+        raise click.ClickException(
+            "Invalid `--review-target` value. `pr_number` must be a positive integer."
+        )
+
+    return {
+        "submodule_path": submodule_path,
+        "pr_number": pr_number,
+        "expected_head_sha": expected_head_sha,
+        "preferred_ref": preferred_ref,
+    }
+
+
+def ensure_unique_review_targets(review_targets: list[ReviewTarget]) -> list[ReviewTarget]:
+    seen_targets: dict[str, ReviewTarget] = {}
+    for review_target in review_targets:
+        submodule_path = review_target["submodule_path"]
+        existing_target = seen_targets.get(submodule_path)
+        if existing_target is None:
+            seen_targets[submodule_path] = review_target
+            continue
+        raise click.ClickException(
+            "Conflicting `--review-target` values for submodule "
+            f"`{submodule_path}`. Existing target expects "
+            f"PR #{existing_target['pr_number']} at `{existing_target['expected_head_sha']}`"
+            f"{' via ' + existing_target['preferred_ref'] if existing_target.get('preferred_ref') else ''}; "
+            f"new target expects PR #{review_target['pr_number']} at "
+            f"`{review_target['expected_head_sha']}`"
+            f"{' via ' + review_target['preferred_ref'] if review_target.get('preferred_ref') else ''}."
+        )
+    return review_targets
+
+
+def rev_parse_commit(repo_path: Path, ref: str) -> str | None:
+    result = run_command(["git", "rev-parse", "--verify", f"{ref}^{{commit}}"], cwd=repo_path)
+    if result.returncode != 0:
+        return None
+    resolved = result.stdout.strip()
+    return resolved or None
+
+
+def list_remotes(repo_path: Path) -> list[str]:
+    result = run_command(["git", "remote"], cwd=repo_path)
+    if result.returncode != 0:
+        raise click.ClickException(
+            result.stderr.strip() or f"Failed to list remotes for `{repo_path}`."
+        )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def infer_pr_remote_name(repo_path: Path, preferred_ref: str | None) -> str:
+    remotes = list_remotes(repo_path)
+    if preferred_ref is not None:
+        if preferred_ref.startswith("refs/remotes/"):
+            parts = preferred_ref.split("/", 3)
+            if len(parts) >= 4 and parts[2] in remotes:
+                return parts[2]
+        if "/" in preferred_ref and not preferred_ref.startswith("refs/"):
+            candidate_remote = preferred_ref.split("/", 1)[0]
+            if candidate_remote in remotes:
+                return candidate_remote
+
+    if "origin" in remotes:
+        return "origin"
+    if len(remotes) == 1:
+        return remotes[0]
+    raise click.ClickException(
+        "Could not infer which remote should serve GitHub pull refs for "
+        f"`{repo_path}`. Pass `preferred_ref` with an explicit remote-qualified "
+        "name such as `origin/branch`."
+    )
+
+
+def checkout_exact_review_ref(worktree_path: Path, review_target: ReviewTarget) -> dict[str, object]:
+    submodule_root = worktree_path / review_target["submodule_path"]
+    if not submodule_root.exists():
+        raise click.ClickException(
+            f"Expected initialized submodule path `{submodule_root}` does not exist."
+        )
+
+    fetch_all_result = run_command(["git", "fetch", "--all", "--prune"], cwd=submodule_root)
+    if fetch_all_result.returncode != 0:
+        raise click.ClickException(
+            fetch_all_result.stderr.strip()
+            or f"Failed to fetch remotes for `{review_target['submodule_path']}`."
+        )
+
+    expected_head_sha = review_target["expected_head_sha"]
+    preferred_ref = review_target.get("preferred_ref")
+    checkout_ref: str | None = None
+    checkout_source = "unknown"
+
+    candidate_refs: list[str] = []
+    if preferred_ref is not None:
+        candidate_refs.extend(
+            [
+                preferred_ref,
+                f"origin/{preferred_ref}",
+                f"refs/remotes/origin/{preferred_ref}",
+            ]
+        )
+
+    for candidate_ref in candidate_refs:
+        resolved_sha = rev_parse_commit(submodule_root, candidate_ref)
+        if resolved_sha == expected_head_sha:
+            checkout_ref = candidate_ref
+            checkout_source = "preferred_ref"
+            break
+
+    if checkout_ref is None:
+        pr_remote_name = infer_pr_remote_name(submodule_root, preferred_ref)
+        fetch_pr_result = run_command(
+            ["git", "fetch", pr_remote_name, f"pull/{review_target['pr_number']}/head"],
+            cwd=submodule_root,
+        )
+        if fetch_pr_result.returncode != 0:
+            raise click.ClickException(
+                fetch_pr_result.stderr.strip()
+                or (
+                    "Failed to fetch exact PR head for "
+                    f"`{review_target['submodule_path']}` via "
+                    f"`{pr_remote_name}:pull/{review_target['pr_number']}/head`."
+                )
+            )
+        fetch_head_sha = rev_parse_commit(submodule_root, "FETCH_HEAD")
+        if fetch_head_sha != expected_head_sha:
+            raise click.ClickException(
+                f"`{review_target['submodule_path']}` fetched PR head SHA "
+                f"`{fetch_head_sha}` but expected `{expected_head_sha}`."
+            )
+        checkout_ref = "FETCH_HEAD"
+        checkout_source = f"{pr_remote_name}_pull_ref"
+
+    checkout_result = run_command(["git", "switch", "--detach", checkout_ref], cwd=submodule_root)
+    if checkout_result.returncode != 0:
+        raise click.ClickException(
+            checkout_result.stderr.strip()
+            or f"Failed to detach `{review_target['submodule_path']}` at `{checkout_ref}`."
+        )
+
+    actual_head_sha = rev_parse_commit(submodule_root, "HEAD")
+    if actual_head_sha != expected_head_sha:
+        raise click.ClickException(
+            f"`{review_target['submodule_path']}` checked out `{actual_head_sha}` but "
+            f"expected `{expected_head_sha}`."
+        )
+
+    return {
+        "submodule_path": review_target["submodule_path"],
+        "pr_number": review_target["pr_number"],
+        "preferred_ref": preferred_ref,
+        "expected_head_sha": expected_head_sha,
+        "actual_head_sha": actual_head_sha,
+        "checkout_ref": checkout_ref,
+        "checkout_source": checkout_source,
+        "status": "matched",
+    }
+
+
 @click.command()
 @click.option(
     "--monolith-root", type=click.Path(path_type=Path, file_okay=False), required=True
@@ -72,6 +266,15 @@ def worktree_is_dirty(worktree_path: Path) -> bool:
     help="Repeat for each review-batch submodule path to initialize.",
 )
 @click.option(
+    "--review-target",
+    "review_targets",
+    multiple=True,
+    help=(
+        "Repeat as submodule_path:pr_number:expected_head_sha[:preferred_ref] "
+        "to fetch and detach the exact PR head under review."
+    ),
+)
+@click.option(
     "--allow-dirty-reuse/--no-allow-dirty-reuse", default=False, show_default=True
 )
 def main(
@@ -79,6 +282,7 @@ def main(
     worktree_path: Path,
     start_ref: str,
     submodule_paths: tuple[str, ...],
+    review_targets: tuple[str, ...],
     allow_dirty_reuse: bool,
 ) -> None:
     """Create or reuse one deterministic monolith review worktree."""
@@ -86,7 +290,11 @@ def main(
     root = monolith_root.expanduser().resolve()
     target = worktree_path.expanduser().resolve()
     registered_worktrees = list_worktrees(root)
-    unique_submodule_paths = tuple(dict.fromkeys(submodule_paths))
+    parsed_review_targets = ensure_unique_review_targets(
+        [parse_review_target(raw_value) for raw_value in review_targets]
+    )
+    target_submodule_paths = [entry["submodule_path"] for entry in parsed_review_targets]
+    unique_submodule_paths = tuple(dict.fromkeys((*submodule_paths, *target_submodule_paths)))
 
     action: str
     if target.exists():
@@ -94,8 +302,6 @@ def main(
             raise click.ClickException(
                 f"{target} exists but is not a registered git worktree."
             )
-        # Reused worktrees are the risky case: we should reject dirtiness before
-        # running any submodule command that could mutate local state.
         dirty = worktree_is_dirty(target)
         if dirty and not allow_dirty_reuse:
             raise click.ClickException(
@@ -112,7 +318,6 @@ def main(
                 create_result.stderr.strip() or f"Failed to create {target}"
             )
         action = "created"
-        dirty = False
 
     if unique_submodule_paths:
         submodule_result = run_command(
@@ -125,9 +330,10 @@ def main(
                 or "Failed to initialize review-batch submodules."
             )
 
-    # Report final dirtiness after submodule init too. A clean create should
-    # usually stay clean, but surfacing the real post-init state makes the
-    # helper easier to trust when something unusual happens.
+    review_target_results = [
+        checkout_exact_review_ref(target, review_target)
+        for review_target in parsed_review_targets
+    ]
     dirty = worktree_is_dirty(target)
 
     payload = {
@@ -136,6 +342,7 @@ def main(
         "dirty": dirty,
         "start_ref": start_ref,
         "submodule_paths": list(unique_submodule_paths),
+        "review_targets": review_target_results,
     }
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
 

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py
@@ -24,11 +24,18 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from pathlib import Path
 from typing import TypedDict
 from urllib.parse import urlparse
 
 import click
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from review_targets import REVIEW_TARGETS, format_known_review_targets
 
 
 MONOLITH_ROOT_MARKERS: tuple[str, ...] = (
@@ -39,15 +46,6 @@ MONOLITH_ROOT_MARKERS: tuple[str, ...] = (
     "docs/github-first-branch-and-pr-conventions.md",
 )
 ALLOWED_MODES: set[str] = {"status", "review", "reassess", "post"}
-REPO_MAP: dict[tuple[str, str], tuple[str, str | None]] = {
-    ("DiversioTeam", "monolith"): ("mono", None),
-    ("DiversioTeam", "Django4Lyfe"): ("bk", "backend"),
-    ("DiversioTeam", "Diversio-Frontend"): ("fe", "frontend"),
-    ("DiversioTeam", "Optimo-Frontend"): ("of", "optimo-frontend"),
-    ("DiversioTeam", "diversio-ds"): ("ds", "design-system"),
-    ("DiversioTeam", "infrastructure"): ("infra", "infrastructure"),
-    ("DiversioTeam", "diversio-serverless"): ("sls", "diversio-serverless"),
-}
 PR_PATH_PATTERN = re.compile(
     r"^/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)(?:/.*)?$"
 )
@@ -158,23 +156,22 @@ def parse_pr_url(pr_url: str) -> PullRequestTarget:
     owner = match.group("owner")
     repo_name = match.group("repo")
     repo_key = (owner, repo_name)
-    if repo_key not in REPO_MAP:
-        known = ", ".join(f"{known_owner}/{repo}" for known_owner, repo in sorted(REPO_MAP))
+    target = REVIEW_TARGETS.get(repo_key)
+    if target is None:
         raise click.ClickException(
             f"Unknown monolith review target `{owner}/{repo_name}` in {pr_url}. "
-            f"Known targets: {known}"
+            f"Known targets: {format_known_review_targets()}"
         )
 
-    alias, submodule_path = REPO_MAP[repo_key]
     pr_number = int(match.group("number"))
     return {
         "owner": owner,
         "repo": repo_name,
         "pr_number": pr_number,
-        "alias": alias,
-        "submodule_path": submodule_path,
+        "alias": target["alias"],
+        "submodule_path": target["submodule_path"],
         "pr_url": pr_url,
-        "entry_key": f"{alias}{pr_number}",
+        "entry_key": f"{target['alias']}{pr_number}",
     }
 
 

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py
@@ -38,13 +38,14 @@ MONOLITH_ROOT_MARKERS: tuple[str, ...] = (
     "scripts/update_submodules.py",
     "docs/github-first-branch-and-pr-conventions.md",
 )
-REPO_MAP: dict[str, tuple[str, str]] = {
-    "Django4Lyfe": ("bk", "backend"),
-    "Diversio-Frontend": ("fe", "frontend"),
-    "Optimo-Frontend": ("of", "optimo-frontend"),
-    "diversio-ds": ("ds", "design-system"),
-    "infrastructure": ("infra", "infrastructure"),
-    "diversio-serverless": ("sls", "diversio-serverless"),
+ALLOWED_MODES: set[str] = {"status", "review", "reassess", "post"}
+REPO_MAP: dict[tuple[str, str], tuple[str, str]] = {
+    ("DiversioTeam", "Django4Lyfe"): ("bk", "backend"),
+    ("DiversioTeam", "Diversio-Frontend"): ("fe", "frontend"),
+    ("DiversioTeam", "Optimo-Frontend"): ("of", "optimo-frontend"),
+    ("DiversioTeam", "diversio-ds"): ("ds", "design-system"),
+    ("DiversioTeam", "infrastructure"): ("infra", "infrastructure"),
+    ("DiversioTeam", "diversio-serverless"): ("sls", "diversio-serverless"),
 }
 PR_PATH_PATTERN = re.compile(
     r"^/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)(?:/.*)?$"
@@ -61,15 +62,52 @@ class PullRequestTarget(TypedDict):
     entry_key: str
 
 
+class BatchPrIdentity(TypedDict):
+    repo: str
+    pr_number: int
+
+
 class ReviewBatchPayload(TypedDict):
     batch_key: str
+    mode: str
     monolith_root: str
     worktree_path: str
     review_dir: str
     artifact_path: str
     reassess_artifact_path: str
     state_path: str
+    link_type: str
+    is_explicitly_linked: bool
+    linked_pair_reason: str | None
+    cross_repo_dependency_summary: str | None
+    authoritative_pr: BatchPrIdentity | None
     prs: list[PullRequestTarget]
+
+
+def has_monolith_markers(root: Path) -> bool:
+    return all((root / marker).exists() for marker in MONOLITH_ROOT_MARKERS)
+
+
+def discover_monolith_root_from_siblings(start: Path) -> Path | None:
+    current = start.expanduser().resolve()
+    for candidate in (current, *current.parents):
+        parent = candidate.parent
+        if not parent.exists() or not parent.is_dir():
+            continue
+        matches = [
+            child
+            for child in parent.iterdir()
+            if child.is_dir() and has_monolith_markers(child)
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise click.ClickException(
+                "Could not uniquely resolve the monolith root from sibling review "
+                f"worktree `{current}`. Matching roots: "
+                f"{', '.join(str(match) for match in sorted(matches))}."
+            )
+    return None
 
 
 def validate_monolith_root(root: Path) -> Path:
@@ -77,6 +115,9 @@ def validate_monolith_root(root: Path) -> Path:
         marker for marker in MONOLITH_ROOT_MARKERS if not (root / marker).exists()
     ]
     if missing_markers:
+        sibling_match = discover_monolith_root_from_siblings(root)
+        if sibling_match is not None:
+            return sibling_match
         required_markers = ", ".join(MONOLITH_ROOT_MARKERS)
         raise click.ClickException(
             "Could not validate monolith root "
@@ -89,8 +130,11 @@ def validate_monolith_root(root: Path) -> Path:
 def discover_monolith_root(start: Path) -> Path:
     current = start.expanduser().resolve()
     for candidate in (current, *current.parents):
-        if all((candidate / marker).exists() for marker in MONOLITH_ROOT_MARKERS):
+        if has_monolith_markers(candidate):
             return candidate
+    sibling_match = discover_monolith_root_from_siblings(current)
+    if sibling_match is not None:
+        return sibling_match
     required_markers = ", ".join(MONOLITH_ROOT_MARKERS)
     raise click.ClickException(
         "Could not discover monolith root from "
@@ -110,17 +154,20 @@ def parse_pr_url(pr_url: str) -> PullRequestTarget:
     if match is None:
         raise click.ClickException(f"Unsupported PR URL path: {pr_url}")
 
+    owner = match.group("owner")
     repo_name = match.group("repo")
-    if repo_name not in REPO_MAP:
-        known = ", ".join(sorted(REPO_MAP))
+    repo_key = (owner, repo_name)
+    if repo_key not in REPO_MAP:
+        known = ", ".join(f"{known_owner}/{repo}" for known_owner, repo in sorted(REPO_MAP))
         raise click.ClickException(
-            f"Unknown repo `{repo_name}` in {pr_url}. Known repos: {known}"
+            f"Unknown monolith review target `{owner}/{repo_name}` in {pr_url}. "
+            f"Known repo owners: {known}"
         )
 
-    alias, submodule_path = REPO_MAP[repo_name]
+    alias, submodule_path = REPO_MAP[repo_key]
     pr_number = int(match.group("number"))
     return {
-        "owner": match.group("owner"),
+        "owner": owner,
         "repo": repo_name,
         "pr_number": pr_number,
         "alias": alias,
@@ -128,6 +175,40 @@ def parse_pr_url(pr_url: str) -> PullRequestTarget:
         "pr_url": pr_url,
         "entry_key": f"{alias}{pr_number}",
     }
+
+
+def parse_authoritative_pr(
+    raw_value: str, items: list[PullRequestTarget]
+) -> BatchPrIdentity:
+    allowed = {(item["repo"], item["pr_number"]) for item in items}
+
+    if raw_value.startswith("http://") or raw_value.startswith("https://"):
+        parsed_target = parse_pr_url(raw_value)
+        identity = (parsed_target["repo"], parsed_target["pr_number"])
+    else:
+        if ":" not in raw_value:
+            raise click.ClickException(
+                "Invalid `--authoritative-pr` value. Use repo:number or one of the "
+                "batch PR URLs."
+            )
+        repo, pr_number_text = raw_value.split(":", 1)
+        try:
+            pr_number = int(pr_number_text)
+        except ValueError as exc:
+            raise click.ClickException(
+                "Invalid `--authoritative-pr` value. PR number must be an integer."
+            ) from exc
+        identity = (repo, pr_number)
+
+    if identity not in allowed:
+        allowed_text = ", ".join(
+            f"{repo}:{pr_number}" for repo, pr_number in sorted(allowed)
+        )
+        raise click.ClickException(
+            "`--authoritative-pr` must point at one of the batch PRs. "
+            f"Allowed values: {allowed_text}."
+        )
+    return {"repo": identity[0], "pr_number": identity[1]}
 
 
 def reviews_root(worktree_root: Path) -> Path:
@@ -149,13 +230,42 @@ def reviews_root(worktree_root: Path) -> Path:
     required=True,
     help="One or more GitHub PR URLs.",
 )
-def main(monolith_root: Path, pr_urls: tuple[str, ...]) -> None:
+@click.option(
+    "--mode",
+    type=click.Choice(sorted(ALLOWED_MODES), case_sensitive=False),
+    required=True,
+    help="Resolved execution mode for this batch.",
+)
+@click.option(
+    "--linked-pair-reason",
+    default=None,
+    help="Required for linked cross-repo pairs; explains why the PRs must be reviewed together.",
+)
+@click.option(
+    "--cross-repo-dependency-summary",
+    default=None,
+    help="Optional machine-readable summary of the cross-repo dependency.",
+)
+@click.option(
+    "--authoritative-pr",
+    default=None,
+    help="Required for linked pairs; use repo:number or one of the batch PR URLs.",
+)
+def main(
+    monolith_root: Path,
+    pr_urls: tuple[str, ...],
+    mode: str,
+    linked_pair_reason: str | None,
+    cross_repo_dependency_summary: str | None,
+    authoritative_pr: str | None,
+) -> None:
     """Resolve one deterministic review batch and print JSON."""
 
     if monolith_root is None:
         root = discover_monolith_root(Path.cwd())
     else:
         root = validate_monolith_root(monolith_root.expanduser().resolve())
+    normalized_mode = mode.lower()
     items = [parse_pr_url(pr_url) for pr_url in pr_urls]
     seen_identities: set[tuple[str, int]] = set()
     for item in items:
@@ -176,6 +286,39 @@ def main(monolith_root: Path, pr_urls: tuple[str, ...]) -> None:
             "V1 linked pairs must be cross-repo. Use a single PR batch for same-repo review."
         )
 
+    link_type = "single_pr"
+    is_explicitly_linked = False
+    normalized_link_reason: str | None = None
+    normalized_dependency_summary: str | None = None
+    authoritative_identity: BatchPrIdentity | None = None
+    if len(items) == 2:
+        normalized_link_reason = (linked_pair_reason or "").strip()
+        if not normalized_link_reason:
+            raise click.ClickException(
+                "Linked cross-repo review batches require `--linked-pair-reason`."
+            )
+        normalized_dependency_summary = (
+            (cross_repo_dependency_summary or "").strip() or normalized_link_reason
+        )
+        if authoritative_pr is None or not authoritative_pr.strip():
+            raise click.ClickException(
+                "Linked cross-repo review batches require `--authoritative-pr`."
+            )
+        authoritative_identity = parse_authoritative_pr(authoritative_pr.strip(), items)
+        link_type = "explicit_cross_repo_pair"
+        is_explicitly_linked = True
+    elif any(
+        value
+        for value in (
+            linked_pair_reason,
+            cross_repo_dependency_summary,
+            authoritative_pr,
+        )
+    ):
+        raise click.ClickException(
+            "Linked-pair metadata is only valid when the batch contains two cross-repo PRs."
+        )
+
     batch_key = "-".join(str(item["entry_key"]) for item in items)
     worktree_path = root.parent / f"monolith-review-{batch_key}"
     review_dir = reviews_root(worktree_path)
@@ -186,12 +329,18 @@ def main(monolith_root: Path, pr_urls: tuple[str, ...]) -> None:
 
     payload: ReviewBatchPayload = {
         "batch_key": batch_key,
+        "mode": normalized_mode,
         "monolith_root": str(root),
         "worktree_path": str(worktree_path),
         "review_dir": str(review_dir),
         "artifact_path": str(artifact_path),
         "reassess_artifact_path": str(reassess_artifact_path),
         "state_path": str(state_path),
+        "link_type": link_type,
+        "is_explicitly_linked": is_explicitly_linked,
+        "linked_pair_reason": normalized_link_reason,
+        "cross_repo_dependency_summary": normalized_dependency_summary,
+        "authoritative_pr": authoritative_identity,
         "prs": items,
     }
     click.echo(json.dumps(payload, indent=2, sort_keys=True))

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
@@ -35,6 +35,12 @@ from uuid import uuid4
 
 import click
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from review_targets import KNOWN_V1_REPOS
+
 
 SCHEMA_VERSION = 3
 SUPPORTED_SCHEMA_VERSIONS: set[int] = {1, 2, SCHEMA_VERSION}
@@ -49,14 +55,6 @@ ALLOWED_POSTING_STATUSES: set[str] = {
     "posted_approved",
 }
 LIVE_VALIDATION_TTL = timedelta(minutes=10)
-KNOWN_V1_REPOS: set[str] = {
-    "Django4Lyfe",
-    "Diversio-Frontend",
-    "Optimo-Frontend",
-    "diversio-ds",
-    "infrastructure",
-    "diversio-serverless",
-}
 CONTEXT_LIST_FIELDS: tuple[str, ...] = (
     "still_legit",
     "moot_or_no_longer_applicable",

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
@@ -24,24 +24,46 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Literal, TypedDict
+from urllib.parse import urlparse
+from uuid import uuid4
 
 import click
 
 
-SCHEMA_VERSION = 2
-SUPPORTED_SCHEMA_VERSIONS: set[int] = {1, SCHEMA_VERSION}
-ALLOWED_MODES: set[str] = {"status", "review", "reassess", "post"}
+SCHEMA_VERSION = 3
+SUPPORTED_SCHEMA_VERSIONS: set[int] = {1, 2, SCHEMA_VERSION}
+PUBLIC_MODES: set[str] = {"status", "review", "reassess", "post"}
+COMPATIBILITY_MODE = "compatibility_recovery"
+ALLOWED_PERSISTED_MODES: set[str] = {*PUBLIC_MODES, COMPATIBILITY_MODE}
+ALLOWED_RECOMMENDATIONS: set[str] = {"approve", "comment", "request_changes"}
+ALLOWED_POSTING_STATUSES: set[str] = {
+    "not_posted",
+    "posted_comment",
+    "posted_request_changes",
+    "posted_approved",
+}
+LIVE_VALIDATION_TTL = timedelta(minutes=10)
+KNOWN_V1_REPOS: set[str] = {
+    "Django4Lyfe",
+    "Diversio-Frontend",
+    "Optimo-Frontend",
+    "diversio-ds",
+    "infrastructure",
+    "diversio-serverless",
+}
 CONTEXT_LIST_FIELDS: tuple[str, ...] = (
     "still_legit",
-    "moot_or_resolved",
+    "moot_or_no_longer_applicable",
     "resolved_for_context",
     "follow_up",
 )
+LEGACY_CONTEXT_LIST_FIELDS: tuple[str, ...] = ("moot_or_resolved",)
 
 FINDING_BUCKETS: tuple[str, ...] = ("new", "carried_forward", "resolved", "moot")
 ReviewThreadStatus = Literal["open", "resolved", "moot"]
@@ -52,12 +74,30 @@ class ReviewBatchIdentity(TypedDict):
     pr_number: int
 
 
+class LinkedBatchMetadata(TypedDict, total=False):
+    link_type: str
+    is_explicitly_linked: bool
+    linked_pair_reason: str
+    cross_repo_dependency_summary: str
+    authoritative_pr: ReviewBatchIdentity
+
+
 class ReviewPassEntry(TypedDict):
     repo: str
     pr_number: int
     base_branch: str
     head_sha: str
     merge_base: str
+    pr_state: str
+    is_draft: bool
+
+
+class LiveValidationRecord(TypedDict):
+    token: str
+    validated_at_utc: str
+    validated_against_pass_number: int
+    entries: list[ReviewPassEntry]
+    source_artifact_path: str
 
 
 class ReviewFinding(TypedDict, total=False):
@@ -107,7 +147,7 @@ class CommentContext(TypedDict, total=False):
     summary: str
     threads: list[ReviewThreadContext]
     still_legit: list[str]
-    moot_or_resolved: list[str]
+    moot_or_no_longer_applicable: list[str]
     resolved_for_context: list[str]
     follow_up: list[str]
 
@@ -121,6 +161,17 @@ class InlineCommentTarget(TypedDict, total=False):
     summary: str
 
 
+class BackendHandoff(TypedDict, total=False):
+    repo: str
+    pr_number: int
+    worktree_path: str
+    pr_url: str
+    head_sha: str
+    prior_open_finding_ids: list[str]
+    thread_context_summary: str
+    allowed_posting_action: str
+
+
 class ReviewPassRecord(TypedDict, total=False):
     review_pass_number: int
     recorded_at_utc: str
@@ -132,7 +183,10 @@ class ReviewPassRecord(TypedDict, total=False):
     scope_summary: str
     business_logic_summary: str
     cross_repo_summary: str
+    no_author_claims: bool
+    no_findings_after_full_review: bool
     author_claims_checked: list[AuthorClaimCheck]
+    backend_handoff: BackendHandoff
     comment_context: CommentContext
     findings: ReviewFindings
     teaching_points: list[str]
@@ -149,6 +203,8 @@ class ReviewStateRecord(TypedDict, total=False):
     review_pass_number: int
     posting_status: str
     prs: list[ReviewBatchIdentity]
+    linked_batch: LinkedBatchMetadata
+    pending_live_validation: LiveValidationRecord
     passes: list[ReviewPassRecord]
 
 
@@ -157,10 +213,14 @@ class ReviewPayloadInput(TypedDict, total=False):
     artifact_path: str
     posting_status: str
     recommendation: str
+    validation_token: str
     scope_summary: str
     business_logic_summary: str
     cross_repo_summary: str
+    no_author_claims: bool
+    no_findings_after_full_review: bool
     author_claims_checked: list[AuthorClaimCheck]
+    backend_handoff: BackendHandoff
     comment_context: CommentContext
     findings: ReviewFindings
     teaching_points: list[str]
@@ -183,12 +243,23 @@ class ReviewContextSummary(TypedDict, total=False):
     review_pass_number: int
     posting_status: str
     prs: list[ReviewBatchIdentity]
+    linked_batch: LinkedBatchMetadata
     pass_history: list[PassHistoryEntry]
     latest_context: ReviewPassRecord
     open_finding_count: int
     open_findings: list[ReviewFinding]
     latest_resolved_findings: list[ReviewFinding]
     latest_moot_findings: list[ReviewFinding]
+
+
+class LivePullRequestMetadata(TypedDict):
+    repo: str
+    pr_number: int
+    pr_url: str
+    base_branch: str
+    head_sha: str
+    pr_state: str
+    is_draft: bool
 
 
 def utc_now() -> str:
@@ -198,6 +269,155 @@ def utc_now() -> str:
         .isoformat()
         .replace("+00:00", "Z")
     )
+
+
+def parse_utc_timestamp(value: str, field_name: str) -> datetime:
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise click.ClickException(
+            f"Review payload field `{field_name}` must be a valid ISO-8601 timestamp."
+        ) from exc
+    if parsed.tzinfo is None:
+        raise click.ClickException(
+            f"Review payload field `{field_name}` must include timezone information."
+        )
+    return parsed.astimezone(timezone.utc)
+
+
+def validate_backend_handoff_pr_url(pr_url: str, repo: str, pr_number: int) -> None:
+    parsed = urlparse(pr_url)
+    if parsed.scheme not in {"http", "https"} or parsed.netloc != "github.com":
+        raise click.ClickException(
+            "Review payload field `backend_handoff.pr_url` must be a GitHub pull request URL."
+        )
+    parts = [part for part in parsed.path.split("/") if part]
+    expected_parts = ["DiversioTeam", repo, "pull", str(pr_number)]
+    if parts[:4] != expected_parts:
+        raise click.ClickException(
+            "Review payload field `backend_handoff.pr_url` must match the backend "
+            f"batch entry `{repo}#{pr_number}`."
+        )
+
+
+def parse_live_pr_context_payload(
+    payload: object,
+    known_prs: set[tuple[str, int]],
+    source_label: str,
+) -> dict[tuple[str, int], LivePullRequestMetadata]:
+    if not isinstance(payload, dict):
+        raise click.ClickException(
+            f"Live PR context artifact `{source_label}` must contain a JSON object."
+        )
+    source = require_non_empty_string(payload.get("source"), "source")
+    if source != "gh_graphql_review_threads":
+        raise click.ClickException(
+            f"Live PR context artifact `{source_label}` must come from "
+            "`fetch_review_threads.py`."
+        )
+    raw_pull_requests = payload.get("pull_requests")
+    if not isinstance(raw_pull_requests, list):
+        raise click.ClickException(
+            f"Live PR context artifact `{source_label}` is missing a valid `pull_requests` list."
+        )
+
+    parsed: dict[tuple[str, int], LivePullRequestMetadata] = {}
+    for index, item in enumerate(raw_pull_requests):
+        if not isinstance(item, dict):
+            raise click.ClickException(
+                f"Live PR context artifact `{source_label}` has a non-object `pull_requests[{index}]` entry."
+            )
+        pull_request = item.get("pull_request")
+        if not isinstance(pull_request, dict):
+            raise click.ClickException(
+                f"Live PR context artifact `{source_label}` is missing `pull_requests[{index}].pull_request`."
+            )
+        repo = require_non_empty_string(
+            pull_request.get("repo"), f"pull_requests[{index}].pull_request.repo"
+        )
+        pr_number = require_non_boolean_int(
+            pull_request.get("pr_number"),
+            f"pull_requests[{index}].pull_request.pr_number",
+        )
+        identity = (repo, pr_number)
+        if identity not in known_prs:
+            raise click.ClickException(
+                f"Live PR context artifact `{source_label}` includes `{repo}:{pr_number}`, "
+                "which is not part of this review batch."
+            )
+        if identity in parsed:
+            raise click.ClickException(
+                f"Live PR context artifact `{source_label}` contains duplicate PR metadata for `{repo}:{pr_number}`."
+            )
+        parsed[identity] = {
+            "repo": repo,
+            "pr_number": pr_number,
+            "pr_url": require_non_empty_string(
+                pull_request.get("url"),
+                f"pull_requests[{index}].pull_request.url",
+            ),
+            "base_branch": require_non_empty_string(
+                pull_request.get("base_ref_name"),
+                f"pull_requests[{index}].pull_request.base_ref_name",
+            ),
+            "head_sha": require_non_empty_string(
+                pull_request.get("head_ref_oid"),
+                f"pull_requests[{index}].pull_request.head_ref_oid",
+            ),
+            "pr_state": require_non_empty_string(
+                pull_request.get("state"),
+                f"pull_requests[{index}].pull_request.state",
+            ),
+            "is_draft": optional_bool(
+                pull_request.get("is_draft"),
+                f"pull_requests[{index}].pull_request.is_draft",
+            )
+            if pull_request.get("is_draft") is not None
+            else False,
+        }
+
+    ensure_full_batch_coverage(set(parsed), known_prs, "Live PR context artifact")
+    return parsed
+
+
+def parse_live_pr_context_artifact(
+    artifact_path: Path, known_prs: set[tuple[str, int]]
+) -> dict[tuple[str, int], LivePullRequestMetadata]:
+    with artifact_path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return parse_live_pr_context_payload(payload, known_prs, str(artifact_path))
+
+
+def fetch_live_pr_context_from_github(
+    pr_urls: list[str],
+    known_prs: set[tuple[str, int]],
+) -> dict[tuple[str, int], LivePullRequestMetadata]:
+    script_path = Path(__file__).with_name("fetch_review_threads.py")
+    command = ["uv", "run", "--script", str(script_path)]
+    for pr_url in pr_urls:
+        command.extend(["--pr-url", pr_url])
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise click.ClickException(
+            result.stderr.strip()
+            or "Failed to fetch live PR context via `fetch_review_threads.py`."
+        )
+    temp_path = Path("<live-fetch>")
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(
+            "`fetch_review_threads.py` returned invalid JSON during live validation."
+        ) from exc
+    return parse_live_pr_context_payload(payload, known_prs, "<live-fetch>")
 
 
 def ensure_dir(path: Path) -> None:
@@ -276,6 +496,12 @@ def normalize_state_record(payload: object) -> ReviewStateRecord:
         if raw_value is None:
             continue
         normalized[key] = require_non_empty_string(raw_value, key)
+    if "posting_status" in normalized:
+        normalized["posting_status"] = require_allowed_value(
+            normalized["posting_status"],
+            ALLOWED_POSTING_STATUSES,
+            "posting_status",
+        )
 
     raw_review_pass_number = payload.get("review_pass_number")
     if raw_review_pass_number is not None:
@@ -286,15 +512,34 @@ def normalize_state_record(payload: object) -> ReviewStateRecord:
     prs = normalize_review_batch_identities(payload.get("prs"))
     normalized["prs"] = prs
     known_prs = {(entry["repo"], entry["pr_number"]) for entry in prs}
+    linked_batch = normalize_linked_batch_metadata(payload.get("linked_batch"), prs)
+    if linked_batch is not None:
+        normalized["linked_batch"] = linked_batch
 
     raw_passes = payload.get("passes")
     if raw_passes is not None:
         if not isinstance(raw_passes, list):
             raise click.ClickException("State file has non-list `passes` field.")
-        normalized["passes"] = [
-            normalize_persisted_review_pass(item, index, known_prs)
-            for index, item in enumerate(raw_passes)
-        ]
+        normalized_passes: list[ReviewPassRecord] = []
+        for index, item in enumerate(raw_passes):
+            normalized_passes.append(
+                normalize_persisted_review_pass(
+                    item,
+                    index,
+                    known_prs,
+                    normalized_passes,
+                    normalized.get("worktree_path"),
+                )
+            )
+        normalized["passes"] = normalized_passes
+
+    pending_live_validation = normalize_live_validation_record(
+        payload.get("pending_live_validation"),
+        known_prs,
+        "pending_live_validation",
+    )
+    if pending_live_validation is not None:
+        normalized["pending_live_validation"] = pending_live_validation
 
     return normalized
 
@@ -350,7 +595,159 @@ def normalize_review_batch_identities(value: object) -> list[ReviewBatchIdentity
             )
         seen.add(identity)
         normalized.append({"repo": repo, "pr_number": pr_number})
+    validate_v1_batch_scope(normalized, "State file `prs`")
     return normalized
+
+
+def validate_v1_batch_scope(
+    identities: list[ReviewBatchIdentity], context_label: str
+) -> None:
+    if not identities:
+        raise click.ClickException(f"{context_label} must contain at least one PR.")
+    if len(identities) > 2:
+        raise click.ClickException(
+            f"{context_label} exceeds v1 scope. Only one PR or one linked cross-repo pair is supported."
+        )
+    unknown_repos = sorted(
+        identity["repo"]
+        for identity in identities
+        if identity["repo"] not in KNOWN_V1_REPOS
+    )
+    if unknown_repos:
+        allowed = ", ".join(sorted(KNOWN_V1_REPOS))
+        raise click.ClickException(
+            f"{context_label} contains unknown repo(s): {', '.join(unknown_repos)}. "
+            f"Known repos: {allowed}."
+        )
+    if len(identities) == 2 and identities[0]["repo"] == identities[1]["repo"]:
+        raise click.ClickException(
+            f"{context_label} must be cross-repo when it contains two PRs."
+        )
+
+
+def normalize_live_validation_record(
+    value: object,
+    known_prs: set[tuple[str, int]],
+    field_name: str,
+) -> LiveValidationRecord | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise click.ClickException(f"State file field `{field_name}` must be an object.")
+
+    return {
+        "token": require_non_empty_string(value.get("token"), f"{field_name}.token"),
+        "validated_at_utc": require_non_empty_string(
+            value.get("validated_at_utc"), f"{field_name}.validated_at_utc"
+        ),
+        "validated_against_pass_number": require_non_boolean_int(
+            value.get("validated_against_pass_number"),
+            f"{field_name}.validated_against_pass_number",
+        ),
+        "entries": normalize_persisted_review_entries(
+            value.get("entries"), known_prs, f"{field_name}.entries"
+        ),
+        "source_artifact_path": require_non_empty_string(
+            value.get("source_artifact_path"), f"{field_name}.source_artifact_path"
+        ),
+    }
+
+
+def normalize_linked_batch_metadata(
+    value: object, prs: list[ReviewBatchIdentity]
+) -> LinkedBatchMetadata | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise click.ClickException("State file field `linked_batch` must be an object.")
+
+    normalized: LinkedBatchMetadata = {}
+    link_type = optional_non_empty_string(value.get("link_type"), "linked_batch.link_type")
+    if link_type is not None:
+        if link_type not in {"single_pr", "explicit_cross_repo_pair"}:
+            raise click.ClickException(
+                "State file field `linked_batch.link_type` must be one of: "
+                "single_pr, explicit_cross_repo_pair."
+            )
+        normalized["link_type"] = link_type
+
+    raw_is_explicitly_linked = value.get("is_explicitly_linked")
+    if raw_is_explicitly_linked is not None:
+        if not isinstance(raw_is_explicitly_linked, bool):
+            raise click.ClickException(
+                "State file field `linked_batch.is_explicitly_linked` must be a boolean."
+            )
+        normalized["is_explicitly_linked"] = raw_is_explicitly_linked
+
+    linked_pair_reason = optional_non_empty_string(
+        value.get("linked_pair_reason"), "linked_batch.linked_pair_reason"
+    )
+    if linked_pair_reason is not None:
+        normalized["linked_pair_reason"] = linked_pair_reason
+
+    dependency_summary = optional_non_empty_string(
+        value.get("cross_repo_dependency_summary"),
+        "linked_batch.cross_repo_dependency_summary",
+    )
+    if dependency_summary is not None:
+        normalized["cross_repo_dependency_summary"] = dependency_summary
+
+    raw_authoritative_pr = value.get("authoritative_pr")
+    if raw_authoritative_pr is not None:
+        if not isinstance(raw_authoritative_pr, dict):
+            raise click.ClickException(
+                "State file field `linked_batch.authoritative_pr` must be an object."
+            )
+        known_prs = {(entry["repo"], entry["pr_number"]) for entry in prs}
+        repo, pr_number = resolve_repo_pr_scope(
+            raw_authoritative_pr.get("repo"),
+            raw_authoritative_pr.get("pr_number"),
+            known_prs,
+            "linked_batch.authoritative_pr",
+        )
+        normalized["authoritative_pr"] = {"repo": repo, "pr_number": pr_number}
+
+    if len(prs) == 2:
+        if normalized.get("link_type") != "explicit_cross_repo_pair":
+            raise click.ClickException(
+                "State file field `linked_batch.link_type` must be "
+                "`explicit_cross_repo_pair` for linked review batches."
+            )
+        if not normalized.get("is_explicitly_linked"):
+            raise click.ClickException(
+                "State file field `linked_batch.is_explicitly_linked` must be true "
+                "for linked review batches."
+            )
+        if "linked_pair_reason" not in normalized:
+            raise click.ClickException(
+                "State file field `linked_batch.linked_pair_reason` is required "
+                "for linked review batches."
+            )
+        if "authoritative_pr" not in normalized:
+            raise click.ClickException(
+                "State file field `linked_batch.authoritative_pr` is required "
+                "for linked review batches."
+            )
+    elif normalized:
+        if normalized.get("link_type") not in {None, "single_pr"}:
+            raise click.ClickException(
+                "Single-PR state cannot carry linked-pair metadata."
+            )
+        disallowed_single_pr_fields = {
+            key
+            for key in (
+                "linked_pair_reason",
+                "cross_repo_dependency_summary",
+                "authoritative_pr",
+            )
+            if key in normalized
+        }
+        if normalized.get("is_explicitly_linked") or disallowed_single_pr_fields:
+            raise click.ClickException(
+                "Single-PR state cannot carry linked-pair metadata."
+            )
+
+    return normalized or None
 
 
 def next_review_pass_number(payload: ReviewStateRecord, path: Path) -> int:
@@ -432,6 +829,25 @@ def optional_non_empty_string(value: object, field_name: str) -> str | None:
     return value.strip()
 
 
+def optional_bool(value: object, field_name: str) -> bool | None:
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise click.ClickException(
+            f"Review payload field `{field_name}` must be a boolean when set."
+        )
+    return value
+
+
+def require_allowed_value(value: str, allowed: set[str], field_name: str) -> str:
+    if value not in allowed:
+        allowed_values = ", ".join(sorted(allowed))
+        raise click.ClickException(
+            f"Review payload field `{field_name}` must be one of: {allowed_values}."
+        )
+    return value
+
+
 def normalize_string_list(value: object, field_name: str) -> list[str]:
     if value is None:
         return []
@@ -510,7 +926,7 @@ def parse_review_entry_payload(item: object, field_name: str) -> ReviewPassEntry
             f"Review payload field `{field_name}.pr_number` must be a non-boolean integer."
         )
 
-    return {
+    normalized: ReviewPassEntry = {
         "repo": repo,
         "pr_number": raw_pr_number,
         "base_branch": require_non_empty_string(
@@ -523,6 +939,13 @@ def parse_review_entry_payload(item: object, field_name: str) -> ReviewPassEntry
             item.get("merge_base"), f"{field_name}.merge_base"
         ),
     }
+    pr_state = optional_non_empty_string(item.get("pr_state"), f"{field_name}.pr_state")
+    if pr_state is not None:
+        normalized["pr_state"] = pr_state
+    is_draft = optional_bool(item.get("is_draft"), f"{field_name}.is_draft")
+    if is_draft is not None:
+        normalized["is_draft"] = is_draft
+    return normalized
 
 
 def normalize_review_entries(
@@ -679,6 +1102,11 @@ def normalize_review_threads(
                     f"Review payload field `{field_name}[{index}]` cannot mark a thread "
                     "as both `status=open` and `is_resolved=true`."
                 )
+            if not raw_is_resolved and status == "resolved":
+                raise click.ClickException(
+                    f"Review payload field `{field_name}[{index}]` cannot mark a thread "
+                    "as both `status=resolved` and `is_resolved=false`."
+                )
             thread["is_resolved"] = raw_is_resolved
 
         raw_is_outdated = item.get("is_outdated")
@@ -753,6 +1181,15 @@ def normalize_comment_context(
         if entries:
             normalized[key] = entries
 
+    legacy_moot_entries = normalize_string_list(
+        value.get("moot_or_resolved"), "comment_context.moot_or_resolved"
+    )
+    if legacy_moot_entries:
+        normalized["moot_or_no_longer_applicable"] = merge_unique_strings(
+            normalized.get("moot_or_no_longer_applicable", []),
+            legacy_moot_entries,
+        )
+
     return normalized or None
 
 
@@ -801,10 +1238,12 @@ def normalize_findings(
                 "repo": repo,
                 "pr_number": pr_number,
                 "id": finding_id,
+                "summary": require_non_empty_string(
+                    item.get("summary"), f"findings.{bucket}[{index}].summary"
+                ),
             }
             for key in (
                 "severity",
-                "summary",
                 "path",
                 "symbol",
                 "risk",
@@ -882,6 +1321,127 @@ def normalize_inline_comment_targets(
     return normalized
 
 
+def normalize_backend_handoff(
+    value: object,
+    known_prs: set[tuple[str, int]],
+    allowed_open_finding_ids: set[str],
+    entry_map: dict[tuple[str, int], ReviewPassEntry],
+    recommendation: str,
+    state_worktree_path: str | None,
+) -> BackendHandoff | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise click.ClickException("Review payload field `backend_handoff` must be an object.")
+
+    repo, pr_number = resolve_repo_pr_scope(
+        value.get("repo"),
+        value.get("pr_number"),
+        known_prs,
+        "backend_handoff",
+    )
+    if repo != "Django4Lyfe":
+        raise click.ClickException(
+            "Review payload field `backend_handoff` is only valid for "
+            "`Django4Lyfe` review entries."
+        )
+
+    handoff: BackendHandoff = {
+        "repo": repo,
+        "pr_number": pr_number,
+        "worktree_path": str(
+            Path(
+                require_non_empty_string(
+                    value.get("worktree_path"), "backend_handoff.worktree_path"
+                )
+            ).expanduser().resolve()
+        ),
+        "pr_url": require_non_empty_string(value.get("pr_url"), "backend_handoff.pr_url"),
+        "head_sha": require_non_empty_string(
+            value.get("head_sha"), "backend_handoff.head_sha"
+        ),
+        "thread_context_summary": require_non_empty_string(
+            value.get("thread_context_summary"),
+            "backend_handoff.thread_context_summary",
+        ),
+    }
+    validate_backend_handoff_pr_url(handoff["pr_url"], repo, pr_number)
+
+    backend_entry = entry_map[(repo, pr_number)]
+    if handoff["head_sha"] != backend_entry["head_sha"]:
+        raise click.ClickException(
+            "Review payload field `backend_handoff.head_sha` must match the "
+            "backend batch entry head SHA."
+        )
+    if state_worktree_path is not None and handoff["worktree_path"] != str(
+        Path(state_worktree_path).expanduser().resolve()
+    ):
+        raise click.ClickException(
+            "Review payload field `backend_handoff.worktree_path` must match the "
+            "recorded review state worktree path."
+        )
+
+    allowed_posting_action = optional_non_empty_string(
+        value.get("allowed_posting_action"), "backend_handoff.allowed_posting_action"
+    )
+    if allowed_posting_action is not None:
+        handoff["allowed_posting_action"] = require_allowed_value(
+            allowed_posting_action,
+            ALLOWED_RECOMMENDATIONS,
+            "backend_handoff.allowed_posting_action",
+        )
+        if handoff["allowed_posting_action"] != recommendation:
+            raise click.ClickException(
+                "Review payload field `backend_handoff.allowed_posting_action` must "
+                "match the current review recommendation."
+            )
+
+    prior_open_finding_ids = normalize_string_list(
+        value.get("prior_open_finding_ids"), "backend_handoff.prior_open_finding_ids"
+    )
+    scoped_prior_open_finding_ids: list[str] = []
+    for finding_id in prior_open_finding_ids:
+        scoped_id = scoped_identity_key(repo, pr_number, finding_id)
+        if scoped_id not in allowed_open_finding_ids:
+            raise click.ClickException(
+                "Review payload field `backend_handoff.prior_open_finding_ids` "
+                f"references unknown active finding `{scoped_id}`."
+            )
+        scoped_prior_open_finding_ids.append(finding_id)
+    handoff["prior_open_finding_ids"] = scoped_prior_open_finding_ids
+    return handoff
+
+
+def total_finding_count(findings: ReviewFindings, buckets: tuple[str, ...] = FINDING_BUCKETS) -> int:
+    return sum(len(findings.get(bucket, [])) for bucket in buckets)
+
+
+def has_comment_context_evidence(comment_context: CommentContext | None) -> bool:
+    if comment_context is None:
+        return False
+    if comment_context.get("summary"):
+        return True
+    if comment_context.get("threads"):
+        return True
+    return any(comment_context.get(key) for key in CONTEXT_LIST_FIELDS)
+
+
+def has_status_assessment(comment_context: CommentContext | None) -> bool:
+    if comment_context is None:
+        return False
+    assessment_keys = (
+        "still_legit",
+        "moot_or_no_longer_applicable",
+        "resolved_for_context",
+        "follow_up",
+    )
+    return any(comment_context.get(key) for key in assessment_keys)
+
+
+def batch_has_backend(known_prs: set[tuple[str, int]]) -> bool:
+    return any(repo == "Django4Lyfe" for repo, _ in known_prs)
+
+
 def normalize_persisted_review_entries(
     value: object,
     known_prs: set[tuple[str, int]],
@@ -915,6 +1475,8 @@ def normalize_persisted_review_pass(
     value: object,
     index: int,
     known_prs: set[tuple[str, int]],
+    existing_passes: list[ReviewPassRecord],
+    state_worktree_path: str | None,
 ) -> ReviewPassRecord:
     if not isinstance(value, dict):
         raise click.ClickException(
@@ -927,6 +1489,9 @@ def normalize_persisted_review_pass(
     posting_status = require_non_empty_string(
         value.get("posting_status"), f"passes[{index}].posting_status"
     )
+    posting_status = require_allowed_value(
+        posting_status, ALLOWED_POSTING_STATUSES, f"passes[{index}].posting_status"
+    )
     recorded_at_utc = require_non_empty_string(
         value.get("recorded_at_utc"), f"passes[{index}].recorded_at_utc"
     )
@@ -936,6 +1501,7 @@ def normalize_persisted_review_pass(
     entries = normalize_persisted_review_entries(
         value.get("entries"), known_prs, f"passes[{index}].entries"
     )
+    entry_map = entry_identity_map(entries)
 
     normalized: ReviewPassRecord = {
         "artifact_path": artifact_path,
@@ -946,19 +1512,22 @@ def normalize_persisted_review_pass(
     }
 
     mode = optional_non_empty_string(value.get("mode"), f"passes[{index}].mode")
-    if mode is not None:
-        if mode not in ALLOWED_MODES:
-            allowed_modes = ", ".join(sorted(ALLOWED_MODES))
-            raise click.ClickException(
-                f"State file field `passes[{index}].mode` must be one of: {allowed_modes}."
-            )
-        normalized["mode"] = mode
+    if mode is None:
+        normalized["mode"] = COMPATIBILITY_MODE
+    else:
+        normalized["mode"] = require_allowed_value(
+            mode, ALLOWED_PERSISTED_MODES, f"passes[{index}].mode"
+        )
 
     recommendation = optional_non_empty_string(
         value.get("recommendation"), f"passes[{index}].recommendation"
     )
     if recommendation is not None:
-        normalized["recommendation"] = recommendation
+        normalized["recommendation"] = require_allowed_value(
+            recommendation,
+            ALLOWED_RECOMMENDATIONS,
+            f"passes[{index}].recommendation",
+        )
 
     scope_summary = optional_non_empty_string(
         value.get("scope_summary"), f"passes[{index}].scope_summary"
@@ -994,11 +1563,35 @@ def normalize_persisted_review_pass(
         if "id" in finding and "repo" in finding and "pr_number" in finding
     }
 
+    no_author_claims = optional_bool(
+        value.get("no_author_claims"), f"passes[{index}].no_author_claims"
+    )
+    if no_author_claims is not None:
+        normalized["no_author_claims"] = no_author_claims
+
+    no_findings_after_full_review = optional_bool(
+        value.get("no_findings_after_full_review"),
+        f"passes[{index}].no_findings_after_full_review",
+    )
+    if no_findings_after_full_review is not None:
+        normalized["no_findings_after_full_review"] = no_findings_after_full_review
+
     author_claims_checked = normalize_author_claims(
         value.get("author_claims_checked"), known_prs
     )
     if author_claims_checked:
         normalized["author_claims_checked"] = author_claims_checked
+
+    backend_handoff = normalize_backend_handoff(
+        value.get("backend_handoff"),
+        known_prs,
+        open_finding_ids,
+        entry_map,
+        normalized.get("recommendation", ""),
+        state_worktree_path,
+    )
+    if backend_handoff is not None:
+        normalized["backend_handoff"] = backend_handoff
 
     comment_context = normalize_comment_context(
         value.get("comment_context"), known_prs, all_finding_ids
@@ -1017,6 +1610,29 @@ def normalize_persisted_review_pass(
     )
     if inline_comment_targets:
         normalized["inline_comment_targets"] = inline_comment_targets
+
+    persisted_mode = normalized.get("mode")
+    if persisted_mode in PUBLIC_MODES:
+        validate_review_requirements(
+            mode=persisted_mode,
+            posting_status=normalized["posting_status"],
+            recommendation=normalized.get("recommendation", ""),
+            artifact_path=Path(artifact_path),
+            entries=entries,
+            findings=findings,
+            no_findings_after_full_review=bool(
+                normalized.get("no_findings_after_full_review", False)
+            ),
+            author_claims_checked=author_claims_checked,
+            no_author_claims=bool(normalized.get("no_author_claims", False)),
+            comment_context=comment_context,
+            backend_handoff=backend_handoff,
+            known_prs=known_prs,
+            existing_passes=existing_passes,
+            enforce_artifact_existence=False,
+            require_post_validation_proof=False,
+            require_pr_lifecycle=False,
+        )
 
     return normalized
 
@@ -1230,6 +1846,306 @@ def merge_inline_targets_history(
     return [merged[key] for key in order[-max_items:]]
 
 
+def latest_substantive_pass(
+    passes: list[ReviewPassRecord],
+) -> ReviewPassRecord | None:
+    for pass_record in reversed(passes):
+        if pass_record.get("mode") in {"status", "review", "reassess"}:
+            return pass_record
+    return None
+
+
+def entry_identity_map(entries: list[ReviewPassEntry]) -> dict[tuple[str, int], ReviewPassEntry]:
+    return {(entry["repo"], entry["pr_number"]): entry for entry in entries}
+
+
+def entries_match_exactly(
+    left_entries: list[ReviewPassEntry], right_entries: list[ReviewPassEntry]
+) -> bool:
+    left_map = entry_identity_map(left_entries)
+    right_map = entry_identity_map(right_entries)
+    if left_map.keys() != right_map.keys():
+        return False
+    for identity, left_entry in left_map.items():
+        right_entry = right_map[identity]
+        for key in ("base_branch", "head_sha", "merge_base", "pr_state", "is_draft"):
+            if left_entry.get(key) != right_entry.get(key):
+                return False
+    return True
+
+
+def entries_match_live_validated_fields(
+    left_entries: list[ReviewPassEntry], right_entries: list[ReviewPassEntry]
+) -> bool:
+    left_map = entry_identity_map(left_entries)
+    right_map = entry_identity_map(right_entries)
+    if left_map.keys() != right_map.keys():
+        return False
+    for identity, left_entry in left_map.items():
+        right_entry = right_map[identity]
+        for key in ("base_branch", "head_sha", "pr_state", "is_draft"):
+            if left_entry.get(key) != right_entry.get(key):
+                return False
+    return True
+
+
+def ensure_entries_have_pr_lifecycle(
+    entries: list[ReviewPassEntry], context_label: str
+) -> None:
+    for entry in entries:
+        repo = entry["repo"]
+        pr_number = entry["pr_number"]
+        if "pr_state" not in entry:
+            raise click.ClickException(
+                f"{context_label} is missing `pr_state` for `{repo}:{pr_number}`."
+            )
+        if "is_draft" not in entry:
+            raise click.ClickException(
+                f"{context_label} is missing `is_draft` for `{repo}:{pr_number}`."
+            )
+
+
+def latest_matching_substantive_pass(
+    passes: list[ReviewPassRecord], entries: list[ReviewPassEntry]
+) -> ReviewPassRecord | None:
+    for pass_record in reversed(passes):
+        mode = pass_record.get("mode")
+        if mode not in {"status", "review", "reassess"}:
+            continue
+        raw_entries = pass_record.get("entries")
+        if not isinstance(raw_entries, list) or not raw_entries:
+            continue
+        persisted_entries = [
+            entry for entry in raw_entries if isinstance(entry, dict)
+        ]
+        if len(persisted_entries) != len(entries):
+            continue
+        if entries_match_exactly(persisted_entries, entries):
+            return pass_record
+    return None
+
+
+def ensure_artifact_exists(artifact_path: Path) -> None:
+    if not artifact_path.exists() or not artifact_path.is_file():
+        raise click.ClickException(
+            f"Review artifact `{artifact_path}` must exist before recording a pass."
+        )
+
+
+def active_findings_signature(
+    findings: ReviewFindings,
+) -> dict[str, tuple[str, str, str | None, str | None, str | None, str | None, str | None]]:
+    signature: dict[
+        str, tuple[str, str, str | None, str | None, str | None, str | None, str | None]
+    ] = {}
+    for bucket in ("new", "carried_forward"):
+        for finding in findings.get(bucket, []):
+            key = scoped_identity_key(finding["repo"], finding["pr_number"], finding["id"])
+            signature[key] = (
+                bucket,
+                finding.get("summary", ""),
+                finding.get("severity"),
+                finding.get("path"),
+                finding.get("symbol"),
+                finding.get("risk"),
+                finding.get("suggested_fix"),
+            )
+    return signature
+
+
+def validate_review_requirements(
+    *,
+    mode: str,
+    posting_status: str,
+    recommendation: str,
+    artifact_path: Path,
+    entries: list[ReviewPassEntry],
+    findings: ReviewFindings,
+    no_findings_after_full_review: bool,
+    author_claims_checked: list[AuthorClaimCheck],
+    no_author_claims: bool,
+    comment_context: CommentContext | None,
+    backend_handoff: BackendHandoff | None,
+    known_prs: set[tuple[str, int]],
+    existing_passes: list[ReviewPassRecord],
+    pending_live_validation: LiveValidationRecord | None = None,
+    validation_token: str | None = None,
+    enforce_artifact_existence: bool = True,
+    require_post_validation_proof: bool = True,
+    require_pr_lifecycle: bool = True,
+) -> None:
+    if enforce_artifact_existence:
+        ensure_artifact_exists(artifact_path)
+    if require_pr_lifecycle and mode in PUBLIC_MODES:
+        ensure_entries_have_pr_lifecycle(entries, "Review payload `entries`")
+
+    active_finding_count = total_finding_count(findings, ("new", "carried_forward"))
+    total_findings = total_finding_count(findings)
+
+    if recommendation == "approve" and active_finding_count > 0:
+        raise click.ClickException(
+            "Review payload cannot recommend `approve` while active findings remain."
+        )
+    if posting_status == "posted_approved" and active_finding_count > 0:
+        raise click.ClickException(
+            "Review payload cannot record `posted_approved` while active findings remain."
+        )
+
+    if no_author_claims and author_claims_checked:
+        raise click.ClickException(
+            "Review payload cannot set `no_author_claims=true` while also "
+            "recording `author_claims_checked`."
+        )
+    if no_findings_after_full_review and total_findings > 0:
+        raise click.ClickException(
+            "Review payload cannot set `no_findings_after_full_review=true` while "
+            "also recording findings."
+        )
+
+    if mode == "status":
+        if not has_comment_context_evidence(comment_context):
+            raise click.ClickException(
+                "`status` review payloads must include non-empty `comment_context` evidence."
+            )
+        if not has_status_assessment(comment_context):
+            raise click.ClickException(
+                "`status` review payloads must classify current state via "
+                "`still_legit`, `moot_or_no_longer_applicable`, "
+                "`resolved_for_context`, or `follow_up`."
+            )
+
+    if mode in {"review", "reassess"}:
+        if not has_comment_context_evidence(comment_context):
+            raise click.ClickException(
+                f"`{mode}` review payloads must include non-empty `comment_context` evidence."
+            )
+        if not author_claims_checked and not no_author_claims:
+            raise click.ClickException(
+                f"`{mode}` review payloads must record `author_claims_checked` "
+                "or set `no_author_claims=true`."
+            )
+        if total_findings == 0 and not no_findings_after_full_review:
+            raise click.ClickException(
+                f"`{mode}` review payloads with zero findings must set "
+                "`no_findings_after_full_review=true`."
+            )
+
+    if mode == "post":
+        prior_validated_pass = latest_matching_substantive_pass(existing_passes, entries)
+        if prior_validated_pass is None:
+            raise click.ClickException(
+                "`post` review payloads require a prior `status`, `review`, or "
+                "`reassess` pass recorded on the exact same batch heads."
+            )
+        if posting_status == "not_posted":
+            raise click.ClickException(
+                "`post` review payloads must record a concrete posted status."
+            )
+        expected_posting_status = {
+            "approve": "posted_approved",
+            "comment": "posted_comment",
+            "request_changes": "posted_request_changes",
+        }[recommendation]
+        if posting_status != expected_posting_status:
+            raise click.ClickException(
+                "`post` review payloads must align `posting_status` with "
+                f"`recommendation={recommendation}`."
+            )
+        prior_recommendation = prior_validated_pass.get("recommendation")
+        if prior_recommendation != recommendation:
+            raise click.ClickException(
+                "`post` review payloads must reuse the latest validated substantive "
+                f"recommendation. Expected `{prior_recommendation}`, got `{recommendation}`."
+            )
+        prior_findings = prior_validated_pass.get("findings")
+        if not isinstance(prior_findings, dict):
+            raise click.ClickException(
+                "The latest validated substantive pass is missing findings; record "
+                "a new substantive pass before posting."
+            )
+        if active_findings_signature(prior_findings) != active_findings_signature(findings):
+            raise click.ClickException(
+                "`post` review payloads must reuse the latest validated active "
+                "finding set. Record a new substantive pass before changing the verdict."
+            )
+        if require_post_validation_proof:
+            if validation_token is None:
+                raise click.ClickException(
+                    "`post` review payloads must include `validation_token` from "
+                    "the latest successful `validate-live-state` run."
+                )
+            if pending_live_validation is None:
+                raise click.ClickException(
+                    "`post` review payloads require a pending live-state validation "
+                    "proof in the state file."
+                )
+            if pending_live_validation["token"] != validation_token:
+                raise click.ClickException(
+                    "`post` review payloads supplied an invalid `validation_token`."
+                )
+            if pending_live_validation["validated_against_pass_number"] != prior_validated_pass.get(
+                "review_pass_number"
+            ):
+                raise click.ClickException(
+                    "`post` review payloads must use a live-state validation proof "
+                    "generated against the current latest substantive pass."
+                )
+            if not entries_match_live_validated_fields(
+                pending_live_validation["entries"], entries
+            ):
+                raise click.ClickException(
+                    "`post` review payloads must use a live-state validation proof "
+                    "for the exact live-validated batch fields being posted."
+                )
+            validated_at = parse_utc_timestamp(
+                pending_live_validation["validated_at_utc"],
+                "pending_live_validation.validated_at_utc",
+            )
+            now = datetime.now(timezone.utc)
+            if validated_at > now + timedelta(minutes=1):
+                raise click.ClickException(
+                    "The stored live-state validation proof has an invalid future "
+                    "timestamp."
+                )
+            if now - validated_at > LIVE_VALIDATION_TTL:
+                raise click.ClickException(
+                    "The stored live-state validation proof is stale. Re-run "
+                    "`validate-live-state` immediately before posting."
+                )
+            prior_recorded_at = optional_non_empty_string(
+                prior_validated_pass.get("recorded_at_utc"),
+                "prior_validated_pass.recorded_at_utc",
+            )
+            if prior_recorded_at is not None:
+                prior_recorded_at_dt = parse_utc_timestamp(
+                    prior_recorded_at, "prior_validated_pass.recorded_at_utc"
+                )
+                if validated_at < prior_recorded_at_dt:
+                    raise click.ClickException(
+                        "The stored live-state validation proof predates the "
+                        "latest substantive pass. Re-run `validate-live-state`."
+                    )
+            for entry in entries:
+                pr_state = str(entry["pr_state"]).upper()
+                if pr_state != "OPEN":
+                    raise click.ClickException(
+                        "`post` review payloads require the live PR state to be "
+                        f"`OPEN`; got `{pr_state}` for `{entry['repo']}:{entry['pr_number']}`."
+                    )
+                if entry["is_draft"]:
+                    raise click.ClickException(
+                        "`post` review payloads require non-draft PRs. Re-run after "
+                        f"`{entry['repo']}:{entry['pr_number']}` is ready for review."
+                    )
+
+    if batch_has_backend(known_prs) and mode in {"review", "reassess", "post"}:
+        if backend_handoff is None:
+            raise click.ClickException(
+                f"`{mode}` review payloads that include `Django4Lyfe` must persist "
+                "`backend_handoff` before recording the pass."
+            )
+
+
 @click.group()
 def cli() -> None:
     """Manage structured local review state."""
@@ -1244,6 +2160,19 @@ def cli() -> None:
 @click.option(
     "--pr", "prs", multiple=True, required=True, help="Repeat as repo:number."
 )
+@click.option(
+    "--link-type",
+    type=click.Choice(["single_pr", "explicit_cross_repo_pair"], case_sensitive=False),
+    default=None,
+    help="Optional linked-batch metadata for the initialized state.",
+)
+@click.option("--linked-pair-reason", default=None)
+@click.option("--cross-repo-dependency-summary", default=None)
+@click.option(
+    "--authoritative-pr",
+    default=None,
+    help="Use repo:number for the PR whose verdict wins if linked PRs diverge.",
+)
 def init_state(
     state_path: Path,
     batch_key: str,
@@ -1251,6 +2180,10 @@ def init_state(
     artifact_path: Path,
     force: bool,
     prs: tuple[str, ...],
+    link_type: str | None,
+    linked_pair_reason: str | None,
+    cross_repo_dependency_summary: str | None,
+    authoritative_pr: str | None,
 ) -> None:
     """Initialize one structured review-state file.
 
@@ -1276,6 +2209,66 @@ def init_state(
             raise click.ClickException(f"Duplicate --pr entry: {repo}:{number_text}")
         seen.add(identity)
         entries.append({"repo": repo, "pr_number": pr_number})
+    validate_v1_batch_scope(entries, "`init --pr`")
+
+    linked_batch: LinkedBatchMetadata | None = None
+    if len(entries) == 2:
+        resolved_link_type = (link_type or "explicit_cross_repo_pair").lower()
+        if resolved_link_type != "explicit_cross_repo_pair":
+            raise click.ClickException(
+                "Linked review batches must use `--link-type explicit_cross_repo_pair`."
+            )
+        if linked_pair_reason is None or not linked_pair_reason.strip():
+            raise click.ClickException(
+                "Linked review batches require `--linked-pair-reason`."
+            )
+        if authoritative_pr is None or not authoritative_pr.strip():
+            raise click.ClickException(
+                "Linked review batches require `--authoritative-pr`."
+            )
+        if ":" not in authoritative_pr:
+            raise click.ClickException(
+                "Invalid `--authoritative-pr` value. Use repo:number."
+            )
+        authoritative_repo, authoritative_pr_number_text = authoritative_pr.split(":", 1)
+        try:
+            authoritative_pr_number = int(authoritative_pr_number_text)
+        except ValueError as exc:
+            raise click.ClickException(
+                "Invalid `--authoritative-pr` value. PR number must be an integer."
+            ) from exc
+        authoritative_identity = (authoritative_repo, authoritative_pr_number)
+        if authoritative_identity not in seen:
+            raise click.ClickException(
+                "`--authoritative-pr` must point at one of the batch PRs."
+            )
+        linked_batch = {
+            "link_type": resolved_link_type,
+            "is_explicitly_linked": True,
+            "linked_pair_reason": linked_pair_reason.strip(),
+            "cross_repo_dependency_summary": (
+                cross_repo_dependency_summary.strip()
+                if isinstance(cross_repo_dependency_summary, str)
+                and cross_repo_dependency_summary.strip()
+                else linked_pair_reason.strip()
+            ),
+            "authoritative_pr": {
+                "repo": authoritative_identity[0],
+                "pr_number": authoritative_identity[1],
+            },
+        }
+    elif any(
+        value
+        for value in (
+            link_type,
+            linked_pair_reason,
+            cross_repo_dependency_summary,
+            authoritative_pr,
+        )
+    ):
+        raise click.ClickException(
+            "Linked-batch metadata is only valid when initializing a two-PR linked batch."
+        )
 
     resolved_state_path = Path(state_path).expanduser().resolve()
     if resolved_state_path.exists() and not force:
@@ -1296,6 +2289,8 @@ def init_state(
         "posting_status": "not_posted",
         "prs": entries,
     }
+    if linked_batch is not None:
+        payload["linked_batch"] = linked_batch
     atomic_write_json(resolved_state_path, payload)
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
 
@@ -1381,7 +2376,7 @@ def summarize_context(
                             key for key in open_finding_order if key != finding_key
                         ]
 
-    latest = passes[-1] if passes else {}
+    latest = latest_substantive_pass(passes) or (passes[-1] if passes else {})
     latest_resolved = []
     latest_moot = []
     latest_findings = latest.get("findings")
@@ -1412,32 +2407,35 @@ def summarize_context(
         "scope_summary",
         "business_logic_summary",
         "cross_repo_summary",
+        "no_author_claims",
+        "no_findings_after_full_review",
+        "backend_handoff",
         "entries",
     ):
         value = latest.get(key)
         if value:
             latest_context[key] = value
     merged_author_claims = merge_author_claim_history(
-        recent_passes, max_items=open_findings_limit
+        passes, max_items=open_findings_limit
     )
     if merged_author_claims:
         latest_context["author_claims_checked"] = merged_author_claims
     merged_comment_context = merge_comment_context_history(
-        recent_passes,
+        passes,
         max_threads=open_findings_limit,
         max_items_per_bucket=open_findings_limit,
     )
     if merged_comment_context is not None:
         latest_context["comment_context"] = merged_comment_context
     merged_teaching_points = merge_teaching_points_history(
-        recent_passes, max_items=open_findings_limit
+        passes, max_items=open_findings_limit
     )
     if merged_teaching_points:
         latest_context["teaching_points"] = merged_teaching_points
     merged_inline_targets = [
         target
         for target in merge_inline_targets_history(
-            recent_passes, max_items=open_findings_limit
+            passes, max_items=open_findings_limit
         )
         if scoped_identity_key(
             target["repo"], target["pr_number"], target["finding_id"]
@@ -1463,6 +2461,7 @@ def summarize_context(
         "review_pass_number": payload.get("review_pass_number", 0),
         "posting_status": payload.get("posting_status", "not_posted"),
         "prs": payload.get("prs", []),
+        "linked_batch": payload.get("linked_batch"),
         "pass_history": pass_history,
         "latest_context": latest_context,
         "open_finding_count": len(open_findings),
@@ -1481,6 +2480,130 @@ def summarize_context(
     click.echo(json.dumps(summary, indent=2, sort_keys=True))
 
 
+@cli.command("validate-live-state")
+@click.option(
+    "--state-path", type=click.Path(path_type=Path, exists=True), required=True
+)
+@click.option(
+    "--pr-context-path",
+    type=click.Path(path_type=Path, exists=True),
+    required=True,
+    help="Structured output from fetch_review_threads.py for the current live PR state.",
+)
+def validate_live_state(state_path: Path, pr_context_path: Path) -> None:
+    """Fail closed if live PR refs drifted from the latest recorded batch state."""
+
+    path = state_path.expanduser().resolve()
+    payload = read_json(path)
+    known_prs = parse_prs_from_state(payload)
+
+    raw_passes = payload.get("passes", [])
+    if not isinstance(raw_passes, list):
+        raise click.ClickException("Existing state has non-list `passes` field.")
+    passes = [item for item in raw_passes if isinstance(item, dict)]
+    latest_pass = latest_substantive_pass(passes)
+    if latest_pass is None:
+        raise click.ClickException(
+            "Cannot validate live state before at least one substantive review pass is recorded."
+        )
+    latest_entries = latest_pass.get("entries")
+    if not isinstance(latest_entries, list) or not latest_entries:
+        raise click.ClickException(
+            "Latest recorded pass does not contain valid `entries`."
+        )
+    normalized_latest_entries = normalize_persisted_review_entries(
+        latest_entries, known_prs, "latest_pass.entries"
+    )
+    ensure_entries_have_pr_lifecycle(
+        normalized_latest_entries,
+        "Latest substantive pass entries",
+    )
+    supplied_artifact = parse_live_pr_context_artifact(pr_context_path, known_prs)
+    pr_urls = [supplied_artifact[identity]["pr_url"] for identity in sorted(supplied_artifact)]
+    live_metadata_map = fetch_live_pr_context_from_github(pr_urls, known_prs)
+
+    latest_map = entry_identity_map(normalized_latest_entries)
+    live_map: dict[tuple[str, int], ReviewPassEntry] = {}
+    for identity, latest_entry in latest_map.items():
+        live_metadata = live_metadata_map[identity]
+        live_map[identity] = {
+            "repo": identity[0],
+            "pr_number": identity[1],
+            "base_branch": live_metadata["base_branch"],
+            "head_sha": live_metadata["head_sha"],
+            "merge_base": latest_entry["merge_base"],
+            "pr_state": live_metadata["pr_state"],
+            "is_draft": live_metadata["is_draft"],
+        }
+    mismatches: list[dict[str, object]] = []
+    for identity in sorted(latest_map):
+        latest_entry = latest_map[identity]
+        live_entry = live_map[identity]
+        drift: dict[str, object] = {
+            "repo": identity[0],
+            "pr_number": identity[1],
+            "expected_head_sha": latest_entry["head_sha"],
+            "actual_head_sha": live_entry["head_sha"],
+            "expected_base_branch": latest_entry["base_branch"],
+            "actual_base_branch": live_entry["base_branch"],
+            "expected_pr_state": latest_entry["pr_state"],
+            "actual_pr_state": live_entry["pr_state"],
+            "expected_is_draft": latest_entry["is_draft"],
+            "actual_is_draft": live_entry["is_draft"],
+        }
+        if latest_entry["head_sha"] != live_entry["head_sha"]:
+            drift["status"] = "head_sha_mismatch"
+            mismatches.append(drift)
+            continue
+        if latest_entry["base_branch"] != live_entry["base_branch"]:
+            drift["status"] = "base_branch_mismatch"
+            mismatches.append(drift)
+            continue
+        if latest_entry["pr_state"] != live_entry["pr_state"]:
+            drift["status"] = "pr_state_mismatch"
+            mismatches.append(drift)
+            continue
+        if latest_entry["is_draft"] != live_entry["is_draft"]:
+            drift["status"] = "draft_state_mismatch"
+            mismatches.append(drift)
+
+    if mismatches:
+        mismatch_json = json.dumps(mismatches, indent=2, sort_keys=True)
+        raise click.ClickException(
+            "Live PR state drifted from the latest recorded batch identity. "
+            "Record a new substantive pass before reassessment or posting.\n"
+            f"{mismatch_json}"
+        )
+
+    validation_record: LiveValidationRecord = {
+        "token": uuid4().hex,
+        "validated_at_utc": utc_now(),
+        "validated_against_pass_number": require_non_boolean_int(
+            latest_pass.get("review_pass_number"), "latest_pass.review_pass_number"
+        ),
+        "entries": [live_map[identity] for identity in sorted(live_map)],
+        "source_artifact_path": str(pr_context_path.expanduser().resolve()),
+    }
+    payload["pending_live_validation"] = validation_record
+    payload["updated_at_utc"] = utc_now()
+    atomic_write_json(path, payload)
+
+    click.echo(
+        json.dumps(
+            {
+                "status": "matched",
+                "token": validation_record["token"],
+                "validated_against_pass_number": validation_record[
+                    "validated_against_pass_number"
+                ],
+                "entries": validation_record["entries"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
 @cli.command("record-pass")
 @click.option(
     "--state-path", type=click.Path(path_type=Path, exists=True), required=True
@@ -1494,11 +2617,24 @@ def summarize_context(
 )
 @click.option("--artifact-path", type=click.Path(path_type=Path), required=True)
 @click.option("--posting-status", default="not_posted", show_default=True)
+@click.option(
+    "--compatibility-only",
+    is_flag=True,
+    default=False,
+    help="Allow this legacy compatibility write path for migration or recovery only.",
+)
+@click.option(
+    "--justification",
+    default=None,
+    help="Required when using `--compatibility-only`; explains why `record-review` cannot be used.",
+)
 def record_pass(
     state_path: Path,
     review_targets: tuple[str, ...],
     artifact_path: Path,
     posting_status: str,
+    compatibility_only: bool,
+    justification: str | None,
 ) -> None:
     """Record one completed review pass into structured local state.
 
@@ -1506,10 +2642,21 @@ def record_pass(
     part of the batch. That keeps reassessment history attached to the right
     review target.
 
-    Prefer `record-review` for normal usage because it can also persist compact
-    review context, stable finding IDs, comment-legitimacy notes, and inline
-    comment plans.
+    `record-pass` is compatibility-only. Normal review runs must use
+    `record-review`, which persists evidence and the structured context needed
+    for reassessment/posting.
     """
+
+    if not compatibility_only:
+        raise click.ClickException(
+            "`record-pass` is disabled for normal review runs. Use "
+            "`record-review`, or rerun with `--compatibility-only --justification ...` "
+            "for a migration/recovery case."
+        )
+    if justification is None or not justification.strip():
+        raise click.ClickException(
+            "`record-pass --compatibility-only` requires a non-empty `--justification`."
+        )
 
     path = state_path.expanduser().resolve()
     payload = read_json(path)
@@ -1530,15 +2677,21 @@ def record_pass(
         seen_targets.add(identity)
         entries.append(entry)
     ensure_full_batch_coverage(seen_targets, known_prs, "`record-pass`")
+    artifact_path = Path(artifact_path).expanduser().resolve()
+    ensure_artifact_exists(artifact_path)
+    posting_status = require_allowed_value(
+        posting_status, ALLOWED_POSTING_STATUSES, "posting_status"
+    )
     review_pass_number = next_review_pass_number(payload, path)
     now = utc_now()
 
     pass_record: ReviewPassRecord = {
         "review_pass_number": review_pass_number,
         "recorded_at_utc": now,
-        "artifact_path": str(Path(artifact_path).expanduser().resolve()),
+        "artifact_path": str(artifact_path),
         "posting_status": posting_status,
         "entries": entries,
+        "mode": COMPATIBILITY_MODE,
     }
 
     passes = payload.setdefault("passes", [])
@@ -1547,8 +2700,9 @@ def record_pass(
     passes.append(pass_record)
     payload["review_pass_number"] = review_pass_number
     payload["updated_at_utc"] = now
-    payload["artifact_path"] = str(Path(artifact_path).expanduser().resolve())
+    payload["artifact_path"] = str(artifact_path)
     payload["posting_status"] = posting_status
+    payload.pop("pending_live_validation", None)
 
     atomic_write_json(path, payload)
     click.echo(json.dumps(pass_record, indent=2, sort_keys=True))
@@ -1571,14 +2725,14 @@ def record_review(state_path: Path) -> None:
     known_prs = parse_prs_from_state(payload)
     review_payload = load_review_payload_from_stdin()
 
-    mode = require_non_empty_string(review_payload.get("mode"), "mode")
-    if mode not in ALLOWED_MODES:
-        allowed_modes = ", ".join(sorted(ALLOWED_MODES))
-        raise click.ClickException(
-            f"Review payload field `mode` must be one of: {allowed_modes}."
-        )
+    mode = require_allowed_value(
+        require_non_empty_string(review_payload.get("mode"), "mode"),
+        PUBLIC_MODES,
+        "mode",
+    )
 
     entries = normalize_review_entries(review_payload.get("entries"), known_prs)
+    entry_map = entry_identity_map(entries)
     artifact_path = (
         Path(
             require_non_empty_string(
@@ -1588,11 +2742,18 @@ def record_review(state_path: Path) -> None:
         .expanduser()
         .resolve()
     )
-    posting_status = require_non_empty_string(
-        review_payload.get("posting_status"), "posting_status"
+    posting_status = require_allowed_value(
+        require_non_empty_string(review_payload.get("posting_status"), "posting_status"),
+        ALLOWED_POSTING_STATUSES,
+        "posting_status",
     )
-    recommendation = require_non_empty_string(
-        review_payload.get("recommendation"), "recommendation"
+    recommendation = require_allowed_value(
+        require_non_empty_string(review_payload.get("recommendation"), "recommendation"),
+        ALLOWED_RECOMMENDATIONS,
+        "recommendation",
+    )
+    validation_token = optional_non_empty_string(
+        review_payload.get("validation_token"), "validation_token"
     )
     scope_summary = require_non_empty_string(
         review_payload.get("scope_summary"), "scope_summary"
@@ -1602,6 +2763,17 @@ def record_review(state_path: Path) -> None:
     )
     cross_repo_summary = optional_non_empty_string(
         review_payload.get("cross_repo_summary"), "cross_repo_summary"
+    )
+    no_author_claims = bool(
+        optional_bool(review_payload.get("no_author_claims"), "no_author_claims")
+        or False
+    )
+    no_findings_after_full_review = bool(
+        optional_bool(
+            review_payload.get("no_findings_after_full_review"),
+            "no_findings_after_full_review",
+        )
+        or False
     )
     findings = normalize_findings(review_payload.get("findings"), known_prs)
     all_finding_ids = {
@@ -1619,6 +2791,14 @@ def record_review(state_path: Path) -> None:
     author_claims_checked = normalize_author_claims(
         review_payload.get("author_claims_checked"), known_prs
     )
+    backend_handoff = normalize_backend_handoff(
+        review_payload.get("backend_handoff"),
+        known_prs,
+        open_finding_ids,
+        entry_map,
+        recommendation,
+        payload.get("worktree_path"),
+    )
     comment_context = normalize_comment_context(
         review_payload.get("comment_context"), known_prs, all_finding_ids
     )
@@ -1627,6 +2807,37 @@ def record_review(state_path: Path) -> None:
     )
     inline_comment_targets = normalize_inline_comment_targets(
         review_payload.get("inline_comment_targets"), known_prs, open_finding_ids
+    )
+    existing_passes = payload.get("passes", [])
+    if not isinstance(existing_passes, list):
+        raise click.ClickException("Existing state has non-list `passes` field.")
+    persisted_passes = [
+        item for item in existing_passes if isinstance(item, dict)
+    ]
+    pending_live_validation = payload.get("pending_live_validation")
+    if pending_live_validation is not None and not isinstance(
+        pending_live_validation, dict
+    ):
+        raise click.ClickException(
+            "Existing state has invalid `pending_live_validation` field."
+        )
+
+    validate_review_requirements(
+        mode=mode,
+        posting_status=posting_status,
+        recommendation=recommendation,
+        artifact_path=artifact_path,
+        entries=entries,
+        findings=findings,
+        no_findings_after_full_review=no_findings_after_full_review,
+        author_claims_checked=author_claims_checked,
+        no_author_claims=no_author_claims,
+        comment_context=comment_context,
+        backend_handoff=backend_handoff,
+        known_prs=known_prs,
+        existing_passes=persisted_passes,
+        pending_live_validation=pending_live_validation,
+        validation_token=validation_token,
     )
 
     review_pass_number = next_review_pass_number(payload, path)
@@ -1647,8 +2858,14 @@ def record_review(state_path: Path) -> None:
         pass_record["business_logic_summary"] = business_logic_summary
     if cross_repo_summary is not None:
         pass_record["cross_repo_summary"] = cross_repo_summary
+    if no_author_claims:
+        pass_record["no_author_claims"] = True
+    if no_findings_after_full_review:
+        pass_record["no_findings_after_full_review"] = True
     if author_claims_checked:
         pass_record["author_claims_checked"] = author_claims_checked
+    if backend_handoff is not None:
+        pass_record["backend_handoff"] = backend_handoff
     if comment_context is not None:
         pass_record["comment_context"] = comment_context
     if teaching_points:
@@ -1664,6 +2881,7 @@ def record_review(state_path: Path) -> None:
     payload["updated_at_utc"] = now
     payload["artifact_path"] = str(artifact_path)
     payload["posting_status"] = posting_status
+    payload.pop("pending_live_validation", None)
 
     atomic_write_json(path, payload)
     click.echo(json.dumps(pass_record, indent=2, sort_keys=True))

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
@@ -62,6 +62,12 @@ CONTEXT_LIST_FIELDS: tuple[str, ...] = (
     "follow_up",
 )
 LEGACY_CONTEXT_LIST_FIELDS: tuple[str, ...] = ("moot_or_resolved",)
+CURRENT_STATUS_CONTEXT_FIELDS: tuple[str, ...] = (
+    "still_legit",
+    "moot_or_no_longer_applicable",
+    "follow_up",
+)
+DURABLE_CONTEXT_LIST_FIELDS: tuple[str, ...] = ("resolved_for_context",)
 
 FINDING_BUCKETS: tuple[str, ...] = ("new", "carried_forward", "resolved", "moot")
 ReviewThreadStatus = Literal["open", "resolved", "moot"]
@@ -563,6 +569,10 @@ def normalize_state_record(
                     normalized_passes,
                     normalized.get("worktree_path"),
                     allow_legacy_missing_finding_summary=bool(
+                        source_schema_version is not None
+                        and source_schema_version < SCHEMA_VERSION
+                    ),
+                    allow_legacy_public_mode_contract_gaps=bool(
                         source_schema_version is not None
                         and source_schema_version < SCHEMA_VERSION
                     ),
@@ -1647,6 +1657,7 @@ def normalize_persisted_review_pass(
     state_worktree_path: str | None,
     *,
     allow_legacy_missing_finding_summary: bool = False,
+    allow_legacy_public_mode_contract_gaps: bool = False,
 ) -> ReviewPassRecord:
     if not isinstance(value, dict):
         raise click.ClickException(
@@ -1786,6 +1797,18 @@ def normalize_persisted_review_pass(
         normalized["inline_comment_targets"] = inline_comment_targets
 
     persisted_mode = normalized.get("mode")
+    legacy_read_compat = bool(
+        allow_legacy_public_mode_contract_gaps
+        and persisted_mode in {"status", "review", "reassess"}
+    )
+    if legacy_read_compat and persisted_mode in {"review", "reassess"}:
+        if (
+            "no_findings_after_full_review" not in normalized
+            and total_finding_count(findings) == 0
+        ):
+            normalized["no_findings_after_full_review"] = True
+        if "no_author_claims" not in normalized and not author_claims_checked:
+            normalized["no_author_claims"] = True
     if persisted_mode in PUBLIC_MODES:
         validate_review_requirements(
             mode=persisted_mode,
@@ -1806,6 +1829,7 @@ def normalize_persisted_review_pass(
             enforce_artifact_existence=False,
             require_post_validation_proof=False,
             require_pr_lifecycle=False,
+            require_comment_context_evidence=not legacy_read_compat,
         )
 
     return normalized
@@ -1917,11 +1941,13 @@ def merge_comment_context_history(
     merged: CommentContext = {}
     merged_threads: dict[str, ReviewThreadContext] = {}
     thread_order: list[str] = []
+    latest_context: CommentContext | None = None
 
     for pass_record in passes:
         context = pass_record.get("comment_context")
         if not isinstance(context, dict):
             continue
+        latest_context = context
 
         thread_source = context.get("thread_source")
         if isinstance(thread_source, str) and thread_source.strip():
@@ -1943,7 +1969,7 @@ def merge_comment_context_history(
                     thread_order.append(thread_key)
                 merged_threads[thread_key] = thread
 
-        for key in CONTEXT_LIST_FIELDS:
+        for key in DURABLE_CONTEXT_LIST_FIELDS:
             raw_items = context.get(key, [])
             if not isinstance(raw_items, list):
                 continue
@@ -1953,6 +1979,17 @@ def merge_comment_context_history(
             if not valid_items:
                 continue
             merged[key] = merge_unique_strings(merged.get(key, []), valid_items)
+
+    if isinstance(latest_context, dict):
+        for key in CURRENT_STATUS_CONTEXT_FIELDS:
+            raw_items = latest_context.get(key, [])
+            if not isinstance(raw_items, list):
+                continue
+            valid_items = [
+                item for item in raw_items if isinstance(item, str) and item.strip()
+            ]
+            if valid_items:
+                merged[key] = valid_items
 
     if thread_order:
         selected_thread_keys = (
@@ -2147,6 +2184,7 @@ def validate_review_requirements(
     enforce_artifact_existence: bool = True,
     require_post_validation_proof: bool = True,
     require_pr_lifecycle: bool = True,
+    require_comment_context_evidence: bool = True,
 ) -> None:
     if enforce_artifact_existence:
         ensure_artifact_exists(artifact_path)
@@ -2177,7 +2215,9 @@ def validate_review_requirements(
         )
 
     if mode == "status":
-        if not has_comment_context_evidence(comment_context):
+        if require_comment_context_evidence and not has_comment_context_evidence(
+            comment_context
+        ):
             raise click.ClickException(
                 "`status` review payloads must include non-empty `comment_context` evidence."
             )
@@ -2189,7 +2229,9 @@ def validate_review_requirements(
             )
 
     if mode in {"review", "reassess"}:
-        if not has_comment_context_evidence(comment_context):
+        if require_comment_context_evidence and not has_comment_context_evidence(
+            comment_context
+        ):
             raise click.ClickException(
                 f"`{mode}` review payloads must include non-empty `comment_context` evidence."
             )
@@ -2654,19 +2696,9 @@ def summarize_context(
     click.echo(json.dumps(summary, indent=2, sort_keys=True))
 
 
-@cli.command("validate-live-state")
-@click.option(
-    "--state-path", type=click.Path(path_type=Path, exists=True), required=True
-)
-@click.option(
-    "--pr-context-path",
-    type=click.Path(path_type=Path, exists=True),
-    required=True,
-    help="Structured output from fetch_review_threads.py for the current live PR state.",
-)
-def validate_live_state(state_path: Path, pr_context_path: Path) -> None:
-    """Fail closed if live PR refs drifted from the latest recorded batch state."""
-
+def build_live_state_comparison(
+    state_path: Path, pr_context_path: Path
+) -> tuple[ReviewStateRecord, ReviewPassRecord, list[ReviewPassEntry], list[dict[str, object]]]:
     path = state_path.expanduser().resolve()
     payload = read_json(path)
     known_prs = parse_prs_from_state(payload)
@@ -2678,7 +2710,7 @@ def validate_live_state(state_path: Path, pr_context_path: Path) -> None:
     latest_pass = latest_substantive_pass(passes)
     if latest_pass is None:
         raise click.ClickException(
-            "Cannot validate live state before at least one substantive review pass is recorded."
+            "Cannot compare live state before at least one substantive review pass is recorded."
         )
     latest_entries = latest_pass.get("entries")
     if not isinstance(latest_entries, list) or not latest_entries:
@@ -2693,7 +2725,9 @@ def validate_live_state(state_path: Path, pr_context_path: Path) -> None:
         "Latest substantive pass entries",
     )
     supplied_artifact = parse_live_pr_context_artifact(pr_context_path, known_prs)
-    pr_urls = [supplied_artifact[identity]["pr_url"] for identity in sorted(supplied_artifact)]
+    pr_urls = [
+        supplied_artifact[identity]["pr_url"] for identity in sorted(supplied_artifact)
+    ]
     live_metadata_map = fetch_live_pr_context_from_github(pr_urls, known_prs)
 
     latest_map = entry_identity_map(normalized_latest_entries)
@@ -2741,6 +2775,65 @@ def validate_live_state(state_path: Path, pr_context_path: Path) -> None:
             drift["status"] = "draft_state_mismatch"
             mismatches.append(drift)
 
+    return (
+        payload,
+        latest_pass,
+        [live_map[identity] for identity in sorted(live_map)],
+        mismatches,
+    )
+
+
+@cli.command("report-live-drift")
+@click.option(
+    "--state-path", type=click.Path(path_type=Path, exists=True), required=True
+)
+@click.option(
+    "--pr-context-path",
+    type=click.Path(path_type=Path, exists=True),
+    required=True,
+    help="Structured output from fetch_review_threads.py for the current live PR state.",
+)
+def report_live_drift(state_path: Path, pr_context_path: Path) -> None:
+    """Report live PR drift for reassessment without writing a validation token."""
+
+    _payload, latest_pass, live_entries, mismatches = build_live_state_comparison(
+        state_path, pr_context_path
+    )
+    click.echo(
+        json.dumps(
+            {
+                "status": "drifted" if mismatches else "matched",
+                "validated_against_pass_number": require_non_boolean_int(
+                    latest_pass.get("review_pass_number"),
+                    "latest_pass.review_pass_number",
+                ),
+                "entries": live_entries,
+                "mismatches": mismatches,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+@cli.command("validate-live-state")
+@click.option(
+    "--state-path", type=click.Path(path_type=Path, exists=True), required=True
+)
+@click.option(
+    "--pr-context-path",
+    type=click.Path(path_type=Path, exists=True),
+    required=True,
+    help="Structured output from fetch_review_threads.py for the current live PR state.",
+)
+def validate_live_state(state_path: Path, pr_context_path: Path) -> None:
+    """Fail closed if live PR refs drifted from the latest recorded batch state."""
+
+    path = state_path.expanduser().resolve()
+    payload, latest_pass, live_entries, mismatches = build_live_state_comparison(
+        path, pr_context_path
+    )
+
     if mismatches:
         mismatch_json = json.dumps(mismatches, indent=2, sort_keys=True)
         raise click.ClickException(
@@ -2755,7 +2848,7 @@ def validate_live_state(state_path: Path, pr_context_path: Path) -> None:
         "validated_against_pass_number": require_non_boolean_int(
             latest_pass.get("review_pass_number"), "latest_pass.review_pass_number"
         ),
-        "entries": [live_map[identity] for identity in sorted(live_map)],
+        "entries": live_entries,
         "source_artifact_path": str(pr_context_path.expanduser().resolve()),
     }
     payload["pending_live_validation"] = validation_record

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
@@ -1830,6 +1830,7 @@ def normalize_persisted_review_pass(
             require_post_validation_proof=False,
             require_pr_lifecycle=False,
             require_comment_context_evidence=not legacy_read_compat,
+            require_status_assessment=not legacy_read_compat,
         )
 
     return normalized
@@ -2185,6 +2186,7 @@ def validate_review_requirements(
     require_post_validation_proof: bool = True,
     require_pr_lifecycle: bool = True,
     require_comment_context_evidence: bool = True,
+    require_status_assessment: bool = True,
 ) -> None:
     if enforce_artifact_existence:
         ensure_artifact_exists(artifact_path)
@@ -2221,7 +2223,7 @@ def validate_review_requirements(
             raise click.ClickException(
                 "`status` review payloads must include non-empty `comment_context` evidence."
             )
-        if not has_status_assessment(comment_context):
+        if require_status_assessment and not has_status_assessment(comment_context):
             raise click.ClickException(
                 "`status` review payloads must classify current state via "
                 "`still_legit`, `moot_or_no_longer_applicable`, "

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
@@ -491,12 +491,16 @@ def read_json(path: Path) -> ReviewStateRecord:
             f"found {raw_schema_version}, supported versions are {supported_versions}. "
             f"Upgrade/migrate the state file or remove {path} and rerun the command."
         )
-    normalized = normalize_state_record(data)
+    normalized = normalize_state_record(
+        data, source_schema_version=raw_schema_version
+    )
     parse_prs_from_state(normalized)
     return normalized
 
 
-def normalize_state_record(payload: object) -> ReviewStateRecord:
+def normalize_state_record(
+    payload: object, *, source_schema_version: int | None = None
+) -> ReviewStateRecord:
     """Normalize older on-disk state into the current in-memory shape.
 
     First principle:
@@ -558,6 +562,10 @@ def normalize_state_record(payload: object) -> ReviewStateRecord:
                     known_prs,
                     normalized_passes,
                     normalized.get("worktree_path"),
+                    allow_legacy_missing_finding_summary=bool(
+                        source_schema_version is not None
+                        and source_schema_version < SCHEMA_VERSION
+                    ),
                 )
             )
         normalized["passes"] = normalized_passes
@@ -1239,8 +1247,25 @@ def normalize_comment_context(
     return normalized or None
 
 
+def synthesize_legacy_finding_summary(finding: ReviewFinding) -> str:
+    location_parts = [
+        part
+        for part in (finding.get("path"), finding.get("symbol"))
+        if isinstance(part, str) and part
+    ]
+    if location_parts:
+        return f"Legacy finding `{finding['id']}` ({', '.join(location_parts)})"
+    severity = finding.get("severity")
+    if isinstance(severity, str) and severity:
+        return f"Legacy {severity} finding `{finding['id']}`"
+    return f"Legacy finding `{finding['id']}`"
+
+
 def normalize_findings(
-    value: object, known_prs: set[tuple[str, int]]
+    value: object,
+    known_prs: set[tuple[str, int]],
+    *,
+    allow_legacy_missing_summary: bool = False,
 ) -> ReviewFindings:
     if value is None:
         return {bucket: [] for bucket in FINDING_BUCKETS}
@@ -1284,9 +1309,6 @@ def normalize_findings(
                 "repo": repo,
                 "pr_number": pr_number,
                 "id": finding_id,
-                "summary": require_non_empty_string(
-                    item.get("summary"), f"findings.{bucket}[{index}].summary"
-                ),
             }
             for key in (
                 "severity",
@@ -1300,6 +1322,18 @@ def normalize_findings(
                 )
                 if normalized_value is not None:
                     finding[key] = normalized_value
+            summary = optional_non_empty_string(
+                item.get("summary"), f"findings.{bucket}[{index}].summary"
+            )
+            if summary is None:
+                if allow_legacy_missing_summary:
+                    summary = synthesize_legacy_finding_summary(finding)
+                else:
+                    raise click.ClickException(
+                        "Review payload is missing non-empty string "
+                        f"`findings.{bucket}[{index}].summary`."
+                    )
+            finding["summary"] = summary
             bucket_entries.append(finding)
         normalized[bucket] = bucket_entries
     return normalized
@@ -1611,6 +1645,8 @@ def normalize_persisted_review_pass(
     known_prs: set[tuple[str, int]],
     existing_passes: list[ReviewPassRecord],
     state_worktree_path: str | None,
+    *,
+    allow_legacy_missing_finding_summary: bool = False,
 ) -> ReviewPassRecord:
     if not isinstance(value, dict):
         raise click.ClickException(
@@ -1681,7 +1717,11 @@ def normalize_persisted_review_pass(
     if cross_repo_summary is not None:
         normalized["cross_repo_summary"] = cross_repo_summary
 
-    findings = normalize_findings(value.get("findings"), known_prs)
+    findings = normalize_findings(
+        value.get("findings"),
+        known_prs,
+        allow_legacy_missing_summary=allow_legacy_missing_finding_summary,
+    )
     normalized["findings"] = findings
 
     all_finding_ids = {

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_targets.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_targets.py
@@ -1,0 +1,56 @@
+"""Shared review-target metadata for monolith review orchestration helpers."""
+
+from __future__ import annotations
+
+from typing import Final, TypedDict
+
+
+class ReviewTargetConfig(TypedDict):
+    alias: str
+    submodule_path: str | None
+
+
+REVIEW_TARGETS: Final[dict[tuple[str, str], ReviewTargetConfig]] = {
+    ("DiversioTeam", "monolith"): {
+        "alias": "mono",
+        "submodule_path": None,
+    },
+    ("DiversioTeam", "Django4Lyfe"): {
+        "alias": "bk",
+        "submodule_path": "backend",
+    },
+    ("DiversioTeam", "Diversio-Frontend"): {
+        "alias": "fe",
+        "submodule_path": "frontend",
+    },
+    ("DiversioTeam", "Optimo-Frontend"): {
+        "alias": "of",
+        "submodule_path": "optimo-frontend",
+    },
+    ("DiversioTeam", "diversio-ds"): {
+        "alias": "ds",
+        "submodule_path": "design-system",
+    },
+    ("DiversioTeam", "infrastructure"): {
+        "alias": "infra",
+        "submodule_path": "infrastructure",
+    },
+    ("DiversioTeam", "diversio-serverless"): {
+        "alias": "sls",
+        "submodule_path": "diversio-serverless",
+    },
+    ("DiversioTeam", "agent-skills-marketplace"): {
+        "alias": "asm",
+        "submodule_path": "agent-skills-marketplace",
+    },
+}
+
+KNOWN_V1_REPOS: Final[frozenset[str]] = frozenset(
+    repo for _owner, repo in REVIEW_TARGETS
+)
+
+
+def format_known_review_targets() -> str:
+    return ", ".join(
+        f"{owner}/{repo}" for owner, repo in sorted(REVIEW_TARGETS)
+    )

--- a/tests/test_fetch_review_threads.py
+++ b/tests/test_fetch_review_threads.py
@@ -87,6 +87,7 @@ class FetchReviewThreadsTests(unittest.TestCase):
                         "url": "https://github.com/DiversioTeam/agent-skills-marketplace/pull/50",
                         "title": "Thread helper test",
                         "state": "OPEN",
+                        "isDraft": False,
                         "body": "body",
                         "baseRefName": "main",
                         "headRefName": "branch",

--- a/tests/test_fetch_review_threads.py
+++ b/tests/test_fetch_review_threads.py
@@ -66,6 +66,17 @@ FETCH_REVIEW_THREADS = load_module_under_test()
 
 
 class FetchReviewThreadsTests(unittest.TestCase):
+    def test_parse_pr_url_supports_agent_skills_marketplace(self) -> None:
+        pr_ref = FETCH_REVIEW_THREADS.parse_pr_url(
+            "https://github.com/DiversioTeam/agent-skills-marketplace/pull/50"
+        )
+
+        self.assertEqual(pr_ref.owner, "DiversioTeam")
+        self.assertEqual(pr_ref.repo, "agent-skills-marketplace")
+        self.assertEqual(pr_ref.pr_number, 50)
+        self.assertEqual(pr_ref.alias, "asm")
+        self.assertEqual(pr_ref.submodule_path, "agent-skills-marketplace")
+
     def make_response(
         self,
         *,

--- a/tests/test_monolith_review_orchestrator_contracts.py
+++ b/tests/test_monolith_review_orchestrator_contracts.py
@@ -207,6 +207,56 @@ class ReviewStateContractTests(unittest.TestCase):
         self.assertTrue(review_pass["no_findings_after_full_review"])
         self.assertTrue(review_pass["no_author_claims"])
 
+    def test_read_json_accepts_legacy_schema_two_status_pass_without_comment_context(
+        self,
+    ) -> None:
+        payload = {
+            "schema_version": 2,
+            "batch_key": "asm-59",
+            "created_at_utc": "2026-04-27T00:00:00Z",
+            "updated_at_utc": "2026-04-27T00:00:00Z",
+            "worktree_path": "/tmp/monolith-review-asm-59",
+            "artifact_path": "/tmp/monolith-review-asm-59/review.md",
+            "posting_status": "not_posted",
+            "prs": [{"repo": "agent-skills-marketplace", "pr_number": 59}],
+            "passes": [
+                {
+                    "artifact_path": "/tmp/monolith-review-asm-59/review.md",
+                    "posting_status": "not_posted",
+                    "recorded_at_utc": "2026-04-27T00:00:00Z",
+                    "review_pass_number": 1,
+                    "mode": "status",
+                    "recommendation": "comment",
+                    "scope_summary": "Legacy schema-2 status pass.",
+                    "entries": [
+                        {
+                            "repo": "agent-skills-marketplace",
+                            "pr_number": 59,
+                            "base_branch": "main",
+                            "head_sha": "b8c36a1",
+                            "merge_base": "6557e6c",
+                        }
+                    ],
+                    "findings": {
+                        "new": [],
+                        "carried_forward": [],
+                        "resolved": [],
+                        "moot": [],
+                    },
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_path = Path(temp_dir) / "state.json"
+            state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+            normalized = REVIEW_STATE.read_json(state_path)
+
+        review_pass = normalized["passes"][0]
+        self.assertEqual(review_pass["mode"], "status")
+        self.assertNotIn("comment_context", review_pass)
+
     def test_normalize_findings_still_requires_summary_for_current_writes(self) -> None:
         with self.assertRaises(REVIEW_STATE.click.ClickException) as exc_info:
             REVIEW_STATE.normalize_findings(
@@ -215,6 +265,42 @@ class ReviewStateContractTests(unittest.TestCase):
             )
 
         self.assertIn("findings.new[0].summary", str(exc_info.exception))
+
+    def test_current_status_payloads_still_require_status_assessment(self) -> None:
+        with self.assertRaises(REVIEW_STATE.click.ClickException) as exc_info:
+            REVIEW_STATE.validate_review_requirements(
+                mode="status",
+                posting_status="not_posted",
+                recommendation="comment",
+                artifact_path=Path("/tmp/review.md"),
+                entries=[
+                    {
+                        "repo": "agent-skills-marketplace",
+                        "pr_number": 59,
+                        "base_branch": "main",
+                        "head_sha": "b8c36a1",
+                        "merge_base": "6557e6c",
+                        "pr_state": "OPEN",
+                        "is_draft": False,
+                    }
+                ],
+                findings={
+                    "new": [],
+                    "carried_forward": [],
+                    "resolved": [],
+                    "moot": [],
+                },
+                no_findings_after_full_review=False,
+                author_claims_checked=[],
+                no_author_claims=False,
+                comment_context={"summary": "Legacy-free current status payload."},
+                backend_handoff=None,
+                known_prs={("agent-skills-marketplace", 59)},
+                existing_passes=[],
+                enforce_artifact_existence=False,
+            )
+
+        self.assertIn("must classify current state", str(exc_info.exception))
 
     def test_merge_comment_context_history_uses_latest_current_status_buckets(self) -> None:
         merged = REVIEW_STATE.merge_comment_context_history(

--- a/tests/test_monolith_review_orchestrator_contracts.py
+++ b/tests/test_monolith_review_orchestrator_contracts.py
@@ -156,6 +156,57 @@ class ReviewStateContractTests(unittest.TestCase):
         )
         self.assertEqual(normalized["schema_version"], REVIEW_STATE.SCHEMA_VERSION)
 
+    def test_read_json_accepts_legacy_schema_two_review_pass_without_new_proof_fields(
+        self,
+    ) -> None:
+        payload = {
+            "schema_version": 2,
+            "batch_key": "asm-59",
+            "created_at_utc": "2026-04-24T00:00:00Z",
+            "updated_at_utc": "2026-04-24T00:00:00Z",
+            "worktree_path": "/tmp/monolith-review-asm-59",
+            "artifact_path": "/tmp/monolith-review-asm-59/review.md",
+            "posting_status": "not_posted",
+            "prs": [{"repo": "agent-skills-marketplace", "pr_number": 59}],
+            "passes": [
+                {
+                    "artifact_path": "/tmp/monolith-review-asm-59/review.md",
+                    "posting_status": "not_posted",
+                    "recorded_at_utc": "2026-04-24T00:00:00Z",
+                    "review_pass_number": 1,
+                    "mode": "review",
+                    "recommendation": "comment",
+                    "scope_summary": "Legacy schema-2 review pass.",
+                    "entries": [
+                        {
+                            "repo": "agent-skills-marketplace",
+                            "pr_number": 59,
+                            "base_branch": "main",
+                            "head_sha": "2769963",
+                            "merge_base": "6557e6c",
+                        }
+                    ],
+                    "findings": {
+                        "new": [],
+                        "carried_forward": [],
+                        "resolved": [],
+                        "moot": [],
+                    },
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_path = Path(temp_dir) / "state.json"
+            state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+            normalized = REVIEW_STATE.read_json(state_path)
+
+        review_pass = normalized["passes"][0]
+        self.assertEqual(review_pass["mode"], "review")
+        self.assertTrue(review_pass["no_findings_after_full_review"])
+        self.assertTrue(review_pass["no_author_claims"])
+
     def test_normalize_findings_still_requires_summary_for_current_writes(self) -> None:
         with self.assertRaises(REVIEW_STATE.click.ClickException) as exc_info:
             REVIEW_STATE.normalize_findings(
@@ -164,6 +215,156 @@ class ReviewStateContractTests(unittest.TestCase):
             )
 
         self.assertIn("findings.new[0].summary", str(exc_info.exception))
+
+    def test_merge_comment_context_history_uses_latest_current_status_buckets(self) -> None:
+        merged = REVIEW_STATE.merge_comment_context_history(
+            [
+                {
+                    "comment_context": {
+                        "thread_source": "gh_graphql",
+                        "summary": "Initial review",
+                        "still_legit": ["Old issue still looked open."],
+                        "resolved_for_context": ["Older durable context."],
+                    }
+                },
+                {
+                    "comment_context": {
+                        "thread_source": "gh_graphql",
+                        "summary": "Latest review",
+                        "moot_or_no_longer_applicable": [
+                            "The old issue is now fixed."
+                        ],
+                        "resolved_for_context": ["New durable context."],
+                    }
+                },
+            ]
+        )
+
+        assert merged is not None
+        self.assertNotIn("still_legit", merged)
+        self.assertEqual(
+            merged["moot_or_no_longer_applicable"],
+            ["The old issue is now fixed."],
+        )
+        self.assertEqual(
+            merged["resolved_for_context"],
+            ["Older durable context.", "New durable context."],
+        )
+        self.assertEqual(merged["summary"], "Latest review")
+
+    def test_merge_comment_context_history_drops_old_current_status_when_latest_has_none(
+        self,
+    ) -> None:
+        merged = REVIEW_STATE.merge_comment_context_history(
+            [
+                {
+                    "comment_context": {
+                        "still_legit": ["Old issue still looked open."],
+                        "resolved_for_context": ["Older durable context."],
+                    }
+                },
+                {
+                    "comment_context": {
+                        "resolved_for_context": ["Latest pass recorded the fix."],
+                    }
+                },
+            ]
+        )
+
+        assert merged is not None
+        self.assertNotIn("still_legit", merged)
+        self.assertEqual(
+            merged["resolved_for_context"],
+            ["Older durable context.", "Latest pass recorded the fix."],
+        )
+
+    def test_report_live_drift_returns_drift_payload_without_raising(self) -> None:
+        payload = {
+            "schema_version": 3,
+            "batch_key": "asm-59",
+            "created_at_utc": "2026-04-24T00:00:00Z",
+            "updated_at_utc": "2026-04-24T00:00:00Z",
+            "worktree_path": "/tmp/monolith-review-asm-59",
+            "artifact_path": "/tmp/monolith-review-asm-59/review.md",
+            "posting_status": "not_posted",
+            "review_pass_number": 1,
+            "prs": [{"repo": "agent-skills-marketplace", "pr_number": 59}],
+            "passes": [
+                {
+                    "artifact_path": "/tmp/monolith-review-asm-59/review.md",
+                    "posting_status": "not_posted",
+                    "recorded_at_utc": "2026-04-24T00:00:00Z",
+                    "review_pass_number": 1,
+                    "mode": "reassess",
+                    "recommendation": "request_changes",
+                    "scope_summary": "Latest reassessment",
+                    "entries": [
+                        {
+                            "repo": "agent-skills-marketplace",
+                            "pr_number": 59,
+                            "base_branch": "main",
+                            "head_sha": "expected-sha",
+                            "merge_base": "merge-base",
+                            "pr_state": "OPEN",
+                            "is_draft": False,
+                        }
+                    ],
+                    "no_author_claims": True,
+                    "comment_context": {
+                        "thread_source": "gh_graphql",
+                        "summary": "Reviewed thread history.",
+                        "still_legit": ["One finding is still open."],
+                    },
+                    "findings": {
+                        "new": [
+                            {
+                                "repo": "agent-skills-marketplace",
+                                "pr_number": 59,
+                                "id": "open-finding",
+                                "summary": "One finding is still open.",
+                            }
+                        ],
+                        "carried_forward": [],
+                        "resolved": [],
+                        "moot": [],
+                    },
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_path = Path(temp_dir) / "state.json"
+            pr_context_path = Path(temp_dir) / "pr-context.json"
+            state_path.write_text(json.dumps(payload), encoding="utf-8")
+            pr_context_path.write_text("{}", encoding="utf-8")
+            outputs: list[str] = []
+
+            with patch.object(
+                REVIEW_STATE,
+                "parse_live_pr_context_artifact",
+                return_value={
+                    ("agent-skills-marketplace", 59): {
+                        "pr_url": "https://github.com/DiversioTeam/agent-skills-marketplace/pull/59"
+                    }
+                },
+            ), patch.object(
+                REVIEW_STATE,
+                "fetch_live_pr_context_from_github",
+                return_value={
+                    ("agent-skills-marketplace", 59): {
+                        "base_branch": "main",
+                        "head_sha": "actual-sha",
+                        "pr_state": "OPEN",
+                        "is_draft": False,
+                    }
+                },
+            ), patch.object(REVIEW_STATE.click, "echo", side_effect=outputs.append):
+                REVIEW_STATE.report_live_drift(state_path, pr_context_path)
+
+        self.assertEqual(len(outputs), 1)
+        result = json.loads(outputs[0])
+        self.assertEqual(result["status"], "drifted")
+        self.assertEqual(result["mismatches"][0]["status"], "head_sha_mismatch")
 
     def test_backend_handoff_pr_url_requires_exact_pr_number(self) -> None:
         REVIEW_STATE.validate_backend_handoff_pr_url(

--- a/tests/test_monolith_review_orchestrator_contracts.py
+++ b/tests/test_monolith_review_orchestrator_contracts.py
@@ -103,6 +103,68 @@ class ReviewStateContractTests(unittest.TestCase):
             "test identities",
         )
 
+    def test_read_json_synthesizes_legacy_summary_for_schema_two_findings(self) -> None:
+        payload = {
+            "schema_version": 2,
+            "batch_key": "asm-59",
+            "created_at_utc": "2026-04-24T00:00:00Z",
+            "updated_at_utc": "2026-04-24T00:00:00Z",
+            "worktree_path": "/tmp/monolith-review-asm-59",
+            "artifact_path": "/tmp/monolith-review-asm-59/review.md",
+            "posting_status": "not_posted",
+            "prs": [{"repo": "agent-skills-marketplace", "pr_number": 59}],
+            "passes": [
+                {
+                    "artifact_path": "/tmp/monolith-review-asm-59/review.md",
+                    "posting_status": "not_posted",
+                    "recorded_at_utc": "2026-04-24T00:00:00Z",
+                    "review_pass_number": 1,
+                    "entries": [
+                        {
+                            "repo": "agent-skills-marketplace",
+                            "pr_number": 59,
+                            "base_branch": "main",
+                            "head_sha": "6557e6c",
+                            "merge_base": "9d1c6e1c",
+                        }
+                    ],
+                    "findings": {
+                        "new": [
+                            {
+                                "id": "legacy-finding-without-summary",
+                                "path": "plugins/example.py",
+                            }
+                        ],
+                        "carried_forward": [],
+                        "resolved": [],
+                        "moot": [],
+                    },
+                }
+            ],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_path = Path(temp_dir) / "state.json"
+            state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+            normalized = REVIEW_STATE.read_json(state_path)
+
+        finding = normalized["passes"][0]["findings"]["new"][0]
+        self.assertEqual(
+            finding["summary"],
+            "Legacy finding `legacy-finding-without-summary` (plugins/example.py)",
+        )
+        self.assertEqual(normalized["schema_version"], REVIEW_STATE.SCHEMA_VERSION)
+
+    def test_normalize_findings_still_requires_summary_for_current_writes(self) -> None:
+        with self.assertRaises(REVIEW_STATE.click.ClickException) as exc_info:
+            REVIEW_STATE.normalize_findings(
+                {"new": [{"id": "missing-summary"}]},
+                {("agent-skills-marketplace", 59)},
+            )
+
+        self.assertIn("findings.new[0].summary", str(exc_info.exception))
+
     def test_backend_handoff_pr_url_requires_exact_pr_number(self) -> None:
         REVIEW_STATE.validate_backend_handoff_pr_url(
             "https://github.com/DiversioTeam/Django4Lyfe/pull/1/files",

--- a/tests/test_monolith_review_orchestrator_contracts.py
+++ b/tests/test_monolith_review_orchestrator_contracts.py
@@ -97,6 +97,12 @@ PREPARE_WORKTREE = load_module("prepare_review_worktree", PREPARE_WORKTREE_PATH)
 
 
 class ReviewStateContractTests(unittest.TestCase):
+    def test_validate_v1_batch_scope_accepts_agent_skills_marketplace(self) -> None:
+        REVIEW_STATE.validate_v1_batch_scope(
+            [{"repo": "agent-skills-marketplace", "pr_number": 59}],
+            "test identities",
+        )
+
     def test_backend_handoff_pr_url_requires_exact_pr_number(self) -> None:
         REVIEW_STATE.validate_backend_handoff_pr_url(
             "https://github.com/DiversioTeam/Django4Lyfe/pull/1/files",
@@ -144,6 +150,78 @@ class ReviewStateContractTests(unittest.TestCase):
 
 
 class PrepareReviewWorktreeContractTests(unittest.TestCase):
+    def test_worktree_is_clean_when_only_review_target_sha_differs(self) -> None:
+        worktree_path = Path("/tmp/monolith-review-batch")
+
+        def fake_run_command(cmd: list[str], cwd: Path | None = None) -> object:
+            command_key = tuple(cmd)
+            if command_key == (
+                "git",
+                "status",
+                "--short",
+                "--ignore-submodules=none",
+            ) and cwd == worktree_path:
+                return PREPARE_WORKTREE.subprocess.CompletedProcess(
+                    cmd, 0, stdout=" M agent-skills-marketplace\n", stderr=""
+                )
+            if command_key == (
+                "git",
+                "status",
+                "--short",
+                "--ignore-submodules=none",
+            ) and cwd == worktree_path / "agent-skills-marketplace":
+                return PREPARE_WORKTREE.subprocess.CompletedProcess(
+                    cmd, 0, stdout="", stderr=""
+                )
+            raise AssertionError(f"Unexpected command: cmd={cmd!r} cwd={cwd!r}")
+
+        with patch.object(
+            PREPARE_WORKTREE,
+            "run_command",
+            side_effect=fake_run_command,
+        ):
+            dirty = PREPARE_WORKTREE.worktree_is_dirty(
+                worktree_path, {"agent-skills-marketplace"}
+            )
+
+        self.assertFalse(dirty)
+
+    def test_worktree_is_dirty_when_review_target_has_local_edits(self) -> None:
+        worktree_path = Path("/tmp/monolith-review-batch")
+
+        def fake_run_command(cmd: list[str], cwd: Path | None = None) -> object:
+            command_key = tuple(cmd)
+            if command_key == (
+                "git",
+                "status",
+                "--short",
+                "--ignore-submodules=none",
+            ) and cwd == worktree_path:
+                return PREPARE_WORKTREE.subprocess.CompletedProcess(
+                    cmd, 0, stdout=" M agent-skills-marketplace\n", stderr=""
+                )
+            if command_key == (
+                "git",
+                "status",
+                "--short",
+                "--ignore-submodules=none",
+            ) and cwd == worktree_path / "agent-skills-marketplace":
+                return PREPARE_WORKTREE.subprocess.CompletedProcess(
+                    cmd, 0, stdout=" M plugins/example.py\n", stderr=""
+                )
+            raise AssertionError(f"Unexpected command: cmd={cmd!r} cwd={cwd!r}")
+
+        with patch.object(
+            PREPARE_WORKTREE,
+            "run_command",
+            side_effect=fake_run_command,
+        ):
+            dirty = PREPARE_WORKTREE.worktree_is_dirty(
+                worktree_path, {"agent-skills-marketplace"}
+            )
+
+        self.assertTrue(dirty)
+
     def test_infer_pr_remote_name_does_not_treat_branch_prefix_as_remote(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_path = Path(temp_dir)

--- a/tests/test_monolith_review_orchestrator_contracts.py
+++ b/tests/test_monolith_review_orchestrator_contracts.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+from types import ModuleType
+import unittest
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REVIEW_STATE_PATH = (
+    REPO_ROOT
+    / "plugins"
+    / "monolith-review-orchestrator"
+    / "skills"
+    / "monolith-review-orchestrator"
+    / "scripts"
+    / "review_state.py"
+)
+PREPARE_WORKTREE_PATH = (
+    REPO_ROOT
+    / "plugins"
+    / "monolith-review-orchestrator"
+    / "skills"
+    / "monolith-review-orchestrator"
+    / "scripts"
+    / "prepare_review_worktree.py"
+)
+
+
+def build_fake_click() -> ModuleType:
+    fake_click = ModuleType("click")
+
+    class FakeClickException(Exception):
+        pass
+
+    def fake_command(*_args: object, **_kwargs: object):
+        def decorator(function: object) -> object:
+            return function
+
+        return decorator
+
+    def fake_option(*_args: object, **_kwargs: object):
+        def decorator(function: object) -> object:
+            return function
+
+        return decorator
+
+    def fake_group(*_args: object, **_kwargs: object):
+        def decorator(function: object) -> object:
+            function.command = fake_command  # type: ignore[attr-defined]
+            return function
+
+        return decorator
+
+    def fake_echo(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    class FakePath:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+    class FakeChoice:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+    fake_click.ClickException = FakeClickException
+    fake_click.command = fake_command
+    fake_click.option = fake_option
+    fake_click.group = fake_group
+    fake_click.echo = fake_echo
+    fake_click.Path = FakePath
+    fake_click.Choice = FakeChoice
+    return fake_click
+
+
+def load_module(name: str, path: Path) -> object:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module from {path}")
+
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(
+        sys.modules,
+        {"click": build_fake_click(), spec.name: module},
+        clear=False,
+    ):
+        spec.loader.exec_module(module)
+    return module
+
+
+REVIEW_STATE = load_module("review_state", REVIEW_STATE_PATH)
+PREPARE_WORKTREE = load_module("prepare_review_worktree", PREPARE_WORKTREE_PATH)
+
+
+class ReviewStateContractTests(unittest.TestCase):
+    def test_backend_handoff_pr_url_requires_exact_pr_number(self) -> None:
+        REVIEW_STATE.validate_backend_handoff_pr_url(
+            "https://github.com/DiversioTeam/Django4Lyfe/pull/1/files",
+            "Django4Lyfe",
+            1,
+        )
+
+        with self.assertRaises(REVIEW_STATE.click.ClickException) as exc_info:
+            REVIEW_STATE.validate_backend_handoff_pr_url(
+                "https://github.com/DiversioTeam/Django4Lyfe/pull/12",
+                "Django4Lyfe",
+                1,
+            )
+
+        self.assertIn("Django4Lyfe#1", str(exc_info.exception))
+
+    def test_parse_live_pr_context_artifact_rejects_wrong_source(self) -> None:
+        payload = {
+            "source": "hand_written_json",
+            "pull_requests": [
+                {
+                    "pull_request": {
+                        "repo": "Django4Lyfe",
+                        "pr_number": 1,
+                        "url": "https://github.com/DiversioTeam/Django4Lyfe/pull/1",
+                        "base_ref_name": "main",
+                        "head_ref_oid": "abc123",
+                        "state": "OPEN",
+                        "is_draft": False,
+                    }
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            artifact_path = Path(temp_dir) / "pr-context.json"
+            artifact_path.write_text(json.dumps(payload))
+
+            with self.assertRaises(REVIEW_STATE.click.ClickException) as exc_info:
+                REVIEW_STATE.parse_live_pr_context_artifact(
+                    artifact_path,
+                    {("Django4Lyfe", 1)},
+                )
+
+        self.assertIn("fetch_review_threads.py", str(exc_info.exception))
+
+
+class PrepareReviewWorktreeContractTests(unittest.TestCase):
+    def test_infer_pr_remote_name_does_not_treat_branch_prefix_as_remote(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir)
+            with patch.object(
+                PREPARE_WORKTREE,
+                "list_remotes",
+                return_value=["origin"],
+            ):
+                remote_name = PREPARE_WORKTREE.infer_pr_remote_name(
+                    repo_path,
+                    "feature/foo",
+                )
+
+        self.assertEqual(remote_name, "origin")
+
+    def test_infer_pr_remote_name_uses_actual_remote_prefix_when_present(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_path = Path(temp_dir)
+            with patch.object(
+                PREPARE_WORKTREE,
+                "list_remotes",
+                return_value=["origin", "upstream"],
+            ):
+                remote_name = PREPARE_WORKTREE.infer_pr_remote_name(
+                    repo_path,
+                    "upstream/feature/foo",
+                )
+
+        self.assertEqual(remote_name, "upstream")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_resolve_review_batch.py
+++ b/tests/test_resolve_review_batch.py
@@ -91,6 +91,14 @@ class ResolveReviewBatchTests(unittest.TestCase):
         self.assertEqual(payload["submodule_path"], "backend")
         self.assertEqual(payload["entry_key"], "bk2836")
 
+    def test_parse_pr_url_supports_agent_skills_marketplace(self) -> None:
+        payload = RESOLVE_REVIEW_BATCH.parse_pr_url(
+            "https://github.com/DiversioTeam/agent-skills-marketplace/pull/59"
+        )
+        self.assertEqual(payload["alias"], "asm")
+        self.assertEqual(payload["submodule_path"], "agent-skills-marketplace")
+        self.assertEqual(payload["entry_key"], "asm59")
+
     def test_review_and_worktree_roots_are_applied(self) -> None:
         monolith_root = Path("/tmp/monolith-root")
         review_root = Path("/tmp/review-root")


### PR DESCRIPTION
## Summary

This PR tightens the monolith-review-orchestrator review harness in five places that were breaking or misdocumenting the self-review flow on this branch:

1. it now supports `DiversioTeam/agent-skills-marketplace` anywhere the orchestrator constrains review targets, from one shared source of truth
2. it no longer treats the expected detached review-target submodule SHA divergence as generic dirty-reuse state
3. it now preserves durable context from supported legacy review-state files that omitted fields newer passes require, while keeping the stricter current write contract intact
4. it now separates reassessment drift reporting from the strict pre-post live-state validation gate
5. it now tolerates legacy schema-2 `mode=status` passes during persisted reads and aligns the top-level README reassessment example with that workflow split

## What Changed

- Added `review_targets.py` as the shared review-target mapping used by:
  - `resolve_review_batch.py`
  - `fetch_review_threads.py`
  - `review_state.py`
- Registered `agent-skills-marketplace` with alias `asm` and submodule path `agent-skills-marketplace`
- Updated worktree dirtiness detection in `prepare_review_worktree.py` so clean detached review-target submodules do not block deterministic reuse
- Updated `review_state.py` so schema-1/2 persisted findings can be normalized without a stored `summary`
- Updated persisted-pass normalization so supported legacy schema-2 `review`, `reassess`, and `status` passes can still be read even when they predate the newer comment-context, author-claim, zero-finding, or status-assessment proof fields
- Kept current write-time `status` validation strict while disabling the status-assessment gate only for supported legacy persisted reads
- Switched `summarize-context` comment-context merging so current-status buckets (`still_legit`, `moot_or_no_longer_applicable`, `follow_up`) come from the latest pass while durable context such as `resolved_for_context` still merges across history
- Added `report-live-drift` as the non-mutating reassessment helper and kept `validate-live-state` as the one-time token-minting pre-post gate
- Updated reassessment guidance in `SKILL.md`, `review-context-protocol.md`, `workflow-helpers.md`, `reassess-prs.md`, and the repo-root `README.md` to route reassessment through drift reporting instead of failing closed on expected head movement
- Added regression coverage for:
  - schema-2 legacy finding summary synthesis
  - schema-2 legacy public-mode pass compatibility
  - schema-2 legacy `mode=status` compatibility without `comment_context`
  - strict current-write `status` assessment enforcement
  - latest-pass semantics for current-status comment-context buckets
  - non-mutating drift reporting on head mismatch
- Bumped `monolith-review-orchestrator` from `0.3.6` to `0.3.7` in both plugin metadata locations

## Why

The earlier PR heads failed two active review findings, and the next head still had three remaining workflow/state-contract gaps. On the latest review pass, two final issues remained:

- supported legacy schema-2 `mode=status` passes could still fail normalization before `summarize-context` recovered history
- the top-level README still told reviewers to use `validate-live-state` during reassessment, even though expected head drift should now flow through `report-live-drift`

This patch closes those final gaps without weakening the stricter current `record-review` or `post` contracts.

## Validation

```bash
python3 -m unittest tests.test_fetch_review_threads tests.test_resolve_review_batch tests.test_prepare_review_worktree tests.test_monolith_review_orchestrator_contracts
python3 -m py_compile \
  plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
bash scripts/validate-skills.sh
jq -e . .claude-plugin/marketplace.json >/dev/null
jq -e . plugins/monolith-review-orchestrator/.claude-plugin/plugin.json >/dev/null
```

Also replayed the reported failure paths locally:
- `summarize-context` now succeeds on schema-2 `mode=review` and `mode=status` states that omit the newer proof fields
- `summarize-context` no longer carries forward an older `still_legit` bucket after a later pass records the concern as resolved
- `report-live-drift` now returns structured head-drift output for reassessment without minting a post token or failing closed
