### PR TITLE
Add marketplace and terraform repo mappings to monolith review helpers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "monolith-review-orchestrator",
       "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "author": {
         "name": "Diversio Devs"
       },

--- a/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-review-orchestrator",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/SKILL.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/SKILL.md
@@ -195,6 +195,8 @@ Map common Diversio repos to monolith paths:
 - `diversio-ds` -> `design-system`
 - `infrastructure` -> `infrastructure`
 - `diversio-serverless` -> `diversio-serverless`
+- `agent-skills-marketplace` -> `agent-skills-marketplace`
+- `terraform-modules` -> `terraform-modules`
 
 If a repo cannot be mapped confidently, ask once.
 

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/fetch_review_threads.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/fetch_review_threads.py
@@ -42,6 +42,8 @@ KNOWN_REPOS: dict[str, tuple[str, str | None]] = {
     "diversio-ds": ("ds", "design-system"),
     "infrastructure": ("infra", "infrastructure"),
     "diversio-serverless": ("sls", "diversio-serverless"),
+    "agent-skills-marketplace": ("asm", "agent-skills-marketplace"),
+    "terraform-modules": ("tfm", "terraform-modules"),
 }
 
 MAIN_QUERY = """\

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py
@@ -46,6 +46,8 @@ REPO_MAP: dict[str, tuple[str, str | None]] = {
     "diversio-ds": ("ds", "design-system"),
     "infrastructure": ("infra", "infrastructure"),
     "diversio-serverless": ("sls", "diversio-serverless"),
+    "agent-skills-marketplace": ("asm", "agent-skills-marketplace"),
+    "terraform-modules": ("tfm", "terraform-modules"),
 }
 PR_PATH_PATTERN = re.compile(
     r"^/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)(?:/.*)?$"

--- a/tests/test_fetch_review_threads.py
+++ b/tests/test_fetch_review_threads.py
@@ -218,6 +218,20 @@ class FetchReviewThreadsTests(unittest.TestCase):
             }
         }
 
+    def test_parse_pr_url_preserves_marketplace_mapping(self) -> None:
+        payload = FETCH_REVIEW_THREADS.parse_pr_url(
+            "https://github.com/DiversioTeam/agent-skills-marketplace/pull/50"
+        )
+        self.assertEqual(payload.alias, "asm")
+        self.assertEqual(payload.submodule_path, "agent-skills-marketplace")
+
+    def test_parse_pr_url_preserves_terraform_modules_mapping(self) -> None:
+        payload = FETCH_REVIEW_THREADS.parse_pr_url(
+            "https://github.com/DiversioTeam/terraform-modules/pull/42"
+        )
+        self.assertEqual(payload.alias, "tfm")
+        self.assertEqual(payload.submodule_path, "terraform-modules")
+
     def test_fetch_pull_request_context_dedupes_non_paginated_connections(self) -> None:
         responses = [
             self.make_response(

--- a/tests/test_resolve_review_batch.py
+++ b/tests/test_resolve_review_batch.py
@@ -86,6 +86,22 @@ class ResolveReviewBatchTests(unittest.TestCase):
         self.assertEqual(payload["submodule_path"], "backend")
         self.assertEqual(payload["entry_key"], "bk2836")
 
+    def test_parse_pr_url_supports_agent_skills_marketplace(self) -> None:
+        payload = RESOLVE_REVIEW_BATCH.parse_pr_url(
+            "https://github.com/DiversioTeam/agent-skills-marketplace/pull/59"
+        )
+        self.assertEqual(payload["alias"], "asm")
+        self.assertEqual(payload["submodule_path"], "agent-skills-marketplace")
+        self.assertEqual(payload["entry_key"], "asm59")
+
+    def test_parse_pr_url_supports_terraform_modules(self) -> None:
+        payload = RESOLVE_REVIEW_BATCH.parse_pr_url(
+            "https://github.com/DiversioTeam/terraform-modules/pull/42"
+        )
+        self.assertEqual(payload["alias"], "tfm")
+        self.assertEqual(payload["submodule_path"], "terraform-modules")
+        self.assertEqual(payload["entry_key"], "tfm42")
+
     def test_review_and_worktree_roots_are_applied(self) -> None:
         monolith_root = Path("/tmp/monolith-root")
         review_root = Path("/tmp/review-root")


### PR DESCRIPTION
Closes #60.

## Summary
This PR teaches the monolith-review-orchestrator helper scripts to recognize `agent-skills-marketplace` and `terraform-modules` as supported monolith submodule targets.

### Key Changes

| Area | Change |
| --- | --- |
| Batch resolution | add repo mappings for `agent-skills-marketplace` and `terraform-modules` in `resolve_review_batch.py` |
| Thread fetch metadata | keep `fetch_review_threads.py` aligned with the same alias/submodule mappings |
| Tests | add focused coverage for both new repo mappings |
| Skill docs | update the monolith-review-orchestrator repo-to-submodule map |

## Why

The monolith auto-reviewer can now poll PRs from these repos, but the helper layer was still operating with an older supported-repo map.

```text
candidate agent-skills-marketplace#59
   -> enters candidate evaluation
   -> resolve_review_batch.py rejects the repo as unknown
```

First principle:
- if the monolith review harness claims to support a repo, the helper scripts that normalize PR intake must recognize that repo explicitly
- the helper-layer repo map should stay consistent across batch resolution, thread fetching, tests, and skill docs

## What Changed

### 1. Expanded the helper repo maps
Both helper scripts now include:
- `agent-skills-marketplace` -> `agent-skills-marketplace`
- `terraform-modules` -> `terraform-modules`

### 2. Locked the new mappings down with focused tests
The tests now assert the alias and submodule path for both repos so this support does not silently regress.

### 3. Kept the skill docs aligned
The repo-to-submodule mapping list in the monolith-review-orchestrator skill now lists both new repos explicitly.

## Files Changed

- `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py`
- `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/fetch_review_threads.py`
- `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/SKILL.md`
- `tests/test_resolve_review_batch.py`
- `tests/test_fetch_review_threads.py`

## How to Test

```bash
uv tool run ruff check \
  plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py \
  plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/fetch_review_threads.py \
  tests/test_resolve_review_batch.py \
  tests/test_fetch_review_threads.py

uv tool run python -m unittest \
  tests.test_resolve_review_batch \
  tests.test_fetch_review_threads
```

## Notes
- Ready for review, following the marketplace branch/PR hygiene in `AGENTS.md`.
- This is the marketplace-side dependency for monolith PR `DiversioTeam/monolith#251`.