### PR TITLE
Align monolith-review-orchestrator with worker-owned inline publishing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "monolith-review-orchestrator",
       "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "author": {
         "name": "Diversio Devs"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "monolith-review-orchestrator",
       "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
-      "version": "0.2.2",
+      "version": "0.2.5",
       "author": {
         "name": "Diversio Devs"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "monolith-review-orchestrator",
       "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
-      "version": "0.2.6",
+      "version": "0.2.3",
       "author": {
         "name": "Diversio Devs"
       },

--- a/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-review-orchestrator",
-  "version": "0.2.2",
+  "version": "0.2.5",
   "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-review-orchestrator",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-review-orchestrator",
-  "version": "0.2.6",
+  "version": "0.2.3",
   "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/monolith-review-orchestrator/README.md
+++ b/plugins/monolith-review-orchestrator/README.md
@@ -9,7 +9,8 @@ Use this plugin when the goal is not just to skim a diff, but to:
 - deeply understand the PR and the back-and-forth review history
 - treat resolved comments as important context, not noise
 - reassess incrementally after new commits
-- post clearer, more instructive GitHub reviews and inline comments
+- post clearer, more instructive GitHub reviews through the worker-owned
+  publish path, with inline comments when anchors are stable
 
 ## What It Figures Out For You
 
@@ -32,6 +33,25 @@ the plugin figures out:
 
 That is why the example prompts below focus on the review ask, not the setup
 mechanics.
+
+## First Principles
+
+The plugin intentionally splits review work into two different jobs:
+
+```text
+Codex / agent
+  -> understand the PR
+  -> draft the review
+
+worker
+  -> re-check live GitHub state
+  -> validate inline anchors
+  -> publish atomically through local `gh` / `gh api`
+```
+
+That split exists because analysis and publication fail in different ways. A
+good review draft can still become stale before publish. Keeping the worker in
+charge of the final mutation makes that last safety check explicit.
 
 ## Best Inputs
 
@@ -88,7 +108,11 @@ Please reassess it using the existing review context. Focus on deltas, re-check 
 ```text
 Now post the final GitHub review for https://github.com/DiversioTeam/Django4Lyfe/pull/2779.
 
-Keep one authoritative top-level review and use inline comments where they help. Teach the author: explain the problem, why it matters, and the next step. Approve only if there are no legitimate blocking issues left.
+Keep one authoritative top-level review. Use inline comments only when the
+exact diff anchor is genuinely stable; otherwise fold the point into the
+top-level review. When inline comments are present, let the worker publish
+them together with the top-level review through the worker-owned path. Approve
+only if there are no legitimate blocking issues left.
 ```
 
 ### 6. Status-Only Read
@@ -118,8 +142,11 @@ follows.
   available.
 - The cache is strongest when you reuse the same deterministic review worktree
   and batch state across passes.
-- This plugin is still intentionally narrow on generic non-backend posting and
-  broad multi-PR automation.
+- When posting is enabled, the worker revalidates the live PR and publishes the
+  top-level review plus any validated inline comments atomically through local
+  `gh` / `gh api`.
+- This plugin is still intentionally narrow on multi-PR publish automation and
+  replies to existing review threads.
 
 ## Why These Pieces Exist
 

--- a/plugins/monolith-review-orchestrator/commands/post-review.md
+++ b/plugins/monolith-review-orchestrator/commands/post-review.md
@@ -1,5 +1,5 @@
 ---
-description: Post a polished, teaching-oriented monolith review to GitHub, including inline comments when justified and an approval only when the final verdict is clean.
+description: Draft a polished, teaching-oriented monolith final review for worker-owned GitHub publication, with inline comments only when the diff anchor is stable.
 ---
 
 Use the `monolith-review-orchestrator` skill.
@@ -9,10 +9,16 @@ Operate in posting mode:
 - load the latest compact review context before drafting the final review
 - treat thread-resolution status as reliable when it came from the orchestrator's
   thread-aware `fetch_review_threads.py` helper
-- dedupe against existing comments conservatively
 - keep one authoritative top-level review per PR
-- add inline comments only for distinct root-cause findings
+- remember the Phase 2a split: Codex drafts, worker revalidates, worker
+  publishes
+- dedupe against existing comments conservatively
+- add inline comments only for distinct root-cause findings with genuinely
+  stable diff anchors
+- prefer simple single-line `RIGHT`-side anchors when possible
+- use multi-line anchors only when the location is unambiguous
+- if an inline anchor is uncertain or likely stale, fold that point into the
+  top-level review body instead
 - explain risk and concrete next step in every serious comment
 - approve only when no legitimate blocking issues remain
-- in v1, prefer backend posting paths that can reuse Monty posting/memory
-  machinery
+- do not imply support for thread replies or partial inline publication

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/SKILL.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/SKILL.md
@@ -14,16 +14,18 @@ Supported v1 scope:
 
 - single PR, or one explicitly linked cross-repo PR pair
 - monolith-local execution only
-- read-only `status`, `review`, and `reassess`
+- `status`, `review`, `reassess`, and worker-owned `post` mode
 - deterministic worktree reuse/bootstrap
 - persistent JSON-first review context plus markdown artifacts
-- backend GitHub posting only when reusing `monty-code-review` memory/posting
-  machinery
+- worker-owned final review publishing: Codex drafts, the worker revalidates,
+  and the worker publishes one top-level review plus zero or more inline
+  comments atomically when the anchors validate cleanly
 
 Explicitly out of scope for v1:
 
 - generic multi-PR batch posting
 - generic unresolved-thread automation without a dedicated helper
+- replies to existing review threads or partial inline publication
 - repo-agnostic marketplace-style usage outside the Diversio monolith
 - broad submodule branch normalization during review prep
 - claiming reliable "final status" from comment lists alone
@@ -91,8 +93,9 @@ Choose one mode early and state it explicitly to the user:
    - Re-review after new commits, focusing on deltas, prior findings, and still
      open concerns.
 4. `post`
-   - Publish the latest validated review to GitHub, including inline comments
-     when warranted and approval only if clean.
+   - Draft the latest validated review for worker-owned GitHub publication,
+     including inline comments only when the diff anchor is stable enough for
+     the worker to validate safely.
 
 If the prompt implies more than one mode, use this order:
 
@@ -269,8 +272,8 @@ Backend rule:
 
 - If a PR touches `backend/`, invoke `monty-code-review` for that slice.
 - Reuse its review memory protocol when doing a follow-up pass.
-- When posting to GitHub for backend findings, follow the monty GitHub posting
-  protocol instead of improvising.
+- Reuse Monty's backend review taste and memory context when it helps, but keep
+  the final GitHub publish step on this orchestrator's worker-owned path.
 
 Non-backend rule:
 
@@ -287,8 +290,8 @@ delegation, or multiple agents.
 
 Ownership model:
 
-- main agent owns intake, local state management, final synthesis, and GitHub
-  posting
+- main agent owns intake, local state management, final synthesis, and the
+  final drafted review bundle
 - sidecar agents own bounded analysis tasks only
 
 Good parallel splits:
@@ -300,7 +303,7 @@ Good parallel splits:
 
 Bad parallel splits:
 
-- two agents posting to the same PR
+- two agents preparing competing final review drafts for the same PR
 - two agents editing the same review artifact
 - delegating the immediate blocker when the main agent needs the answer next
 
@@ -371,17 +374,28 @@ it from the combined artifact instead of duplicating it line for line.
 
 Only post when the user asked or explicitly confirmed posting.
 
-V1 posting boundary:
+Phase 2a posting contract:
 
-- backend posting may proceed only through `monty-code-review` posting/memory
-  machinery
-- generic multi-PR or non-backend posting should be treated as not yet
-  productized unless dedicated helpers exist
+- Codex drafts one authoritative top-level review body and zero or more inline
+  comments.
+- Codex does not post the final review to GitHub directly.
+- The worker re-checks the live PR summary, unresolved-thread state, and
+  top-level review/comment activity immediately before publish.
+- The worker validates inline anchors against the current diff.
+- The worker publishes one atomic review through local `gh` / `gh api`, or
+  publishes nothing if the stale-input or anchor checks fail.
+- Replies to existing review threads and partial inline publication are still
+  out of scope.
 
-Posting rules:
+Drafting rules for `post` mode:
 
 - one authoritative top-level review per PR
-- inline comments only for distinct root-cause findings
+- inline comments only for distinct root-cause findings with genuinely stable
+  diff anchors
+- prefer single-line `RIGHT`-side anchors when possible
+- use multi-line anchors only when the diff location is unambiguous
+- if an anchor is uncertain or likely to drift, fold that point into the
+  top-level review body instead
 - avoid duplicate comments against already-open reviewer threads
 - explain why a prior unresolved comment is still valid, or why it is now moot
 - explain when a resolved comment shaped the current assessment or fix

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/review-context-protocol.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/review-context-protocol.md
@@ -109,6 +109,66 @@ Guardrails:
 Keep the markdown artifact for humans, but treat the JSON state as canonical for
 follow-up passes.
 
+## Inline Comment Target Shape
+
+Persist `inline_comment_targets` only when the point has a stable current-diff
+anchor and the finding is still active.
+
+Why this shape exists:
+
+```text
+finding_id
+  -> explains why the comment exists
+
+path + line + side
+  -> names one concrete diff anchor
+
+expected_line_text
+  -> helps the worker notice drift before publish
+```
+
+This is intentionally small. The state file should capture only the parts a
+later pass or worker can check reliably, not a blob of prose that needs to be
+reinterpreted each time.
+
+Required shape for each target:
+
+- `finding_id`
+- `path`
+- `line`
+- `side`
+- optional `start_line`
+- optional `start_side`
+- optional `expected_line_text`
+
+Scope fields for persisted batch state:
+
+- include `repo` and `pr_number` when the batch contains more than one PR
+- those scope fields are batch identity, not part of the worker's diff-anchor
+  contract itself
+
+Rules:
+
+- `finding_id` must reference an active `new` or `carried_forward` finding in
+  the same recorded pass.
+- `side` should be `RIGHT` or `LEFT`; prefer single-line `RIGHT`-side anchors
+  when possible.
+- `expected_line_text` should capture the visible diff text when you know it,
+  so the worker can fail closed if the anchor drifts before publish.
+- If you cannot name a stable diff anchor, do not persist an inline target for
+  that point. Fold it into the top-level review body instead.
+- Do not rely on prose-only location hints instead of anchor fields.
+
+Practical writing rule:
+
+```text
+if you can point to one exact diff line
+  -> persist an inline target
+
+if you cannot point to one exact diff line
+  -> keep the point in the top-level review body
+```
+
 ## Stable Finding IDs
 
 Use a repo-scoped finding identity:
@@ -218,7 +278,9 @@ cat <<'EOF' | uv run --script plugins/monolith-review-orchestrator/skills/monoli
       "pr_number": 389,
       "finding_id": "of389|empty-state-contract|src/cards/RiskCard.tsx|render_body",
       "path": "src/cards/RiskCard.tsx",
-      "summary": "Anchor the empty-body root cause here."
+      "line": 77,
+      "side": "RIGHT",
+      "expected_line_text": "return <RiskCardBody body={body} />;"
     }
   ]
 }
@@ -230,7 +292,8 @@ EOF
 When posting or drafting the final review:
 
 - keep one authoritative top-level review
-- keep one inline anchor per root-cause cluster
+- keep one inline anchor per root-cause cluster only when the diff anchor is
+  genuinely stable
 - avoid duplicating already-open reviewer threads
 - tie each serious comment to risk or broken behavior
 - give the author a concrete next step
@@ -248,6 +311,8 @@ Inline comments should be compact but complete:
 - what is wrong
 - why it matters
 - what change would fix it
+- prefer single-line `RIGHT`-side anchors and fold uncertain anchors into the
+  top-level review
 
 If a prior resolved comment still matters, mention that briefly so the author
 can see the continuity without having to reconstruct the whole history.

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md
@@ -249,6 +249,30 @@ What it does:
 - keeps markdown as the human artifact and JSON as the machine identity
 - refuses to overwrite existing state unless `--force` is explicit
 
+Why the inline target fields matter now:
+
+```text
+old habit
+  -> "leave an inline note around here"
+
+problem
+  -> future passes cannot tell whether "here" still exists in the diff
+
+current contract
+  -> finding_id
+  -> path
+  -> line + side
+  -> optional start_line + start_side
+  -> optional expected_line_text
+
+benefit
+  -> later passes can understand the intent
+  -> the worker can re-check the anchor safely before publish
+```
+
+Think of `review_state.py` as the place where we turn fuzzy review intent into
+small, durable, machine-checkable review memory.
+
 Example:
 
 ```bash
@@ -323,6 +347,69 @@ cat <<EOF | uv run --script plugins/monolith-review-orchestrator/skills/monolith
 }
 EOF
 ```
+
+Rich review-context write example with an inline target:
+
+```bash
+cat <<EOF | uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py \
+  record-review \
+  --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json"
+{
+  "mode": "post",
+  "artifact_path": "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/review-bk2779-of389.md",
+  "posting_status": "not_posted",
+  "recommendation": "request_changes",
+  "scope_summary": "Prepared the final review draft and one stable inline anchor.",
+  "entries": [
+    {
+      "repo": "Django4Lyfe",
+      "pr_number": 2779,
+      "base_branch": "main",
+      "head_sha": "<backend-head-sha>",
+      "merge_base": "<backend-merge-base>"
+    },
+    {
+      "repo": "Optimo-Frontend",
+      "pr_number": 389,
+      "base_branch": "main",
+      "head_sha": "<optimo-head-sha>",
+      "merge_base": "<optimo-merge-base>"
+    }
+  ],
+  "findings": {
+    "new": [
+      {
+        "repo": "Optimo-Frontend",
+        "pr_number": 389,
+        "id": "of389|empty-state-contract|src/cards/RiskCard.tsx|render_body",
+        "severity": "blocking",
+        "summary": "The empty-body case is still not handled end-to-end."
+      }
+    ],
+    "carried_forward": [],
+    "resolved": [],
+    "moot": []
+  },
+  "inline_comment_targets": [
+    {
+      "repo": "Optimo-Frontend",
+      "pr_number": 389,
+      "finding_id": "of389|empty-state-contract|src/cards/RiskCard.tsx|render_body",
+      "path": "src/cards/RiskCard.tsx",
+      "line": 77,
+      "side": "RIGHT",
+      "expected_line_text": "return <RiskCardBody body={body} />;"
+    }
+  ]
+}
+EOF
+```
+
+Why `expected_line_text` is useful:
+
+- it gives the worker one more safety check before publish
+- it makes rebases or nearby edits fail closed instead of silently anchoring to
+  the wrong changed line
 
 Guardrails:
 

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
@@ -45,6 +45,9 @@ CONTEXT_LIST_FIELDS: tuple[str, ...] = (
 
 FINDING_BUCKETS: tuple[str, ...] = ("new", "carried_forward", "resolved", "moot")
 ReviewThreadStatus = Literal["open", "resolved", "moot"]
+# GitHub review anchors only support two sides in the current worker contract.
+# Keeping the alias explicit makes the validation logic below easier to read.
+ReviewCommentSide = Literal["RIGHT", "LEFT"]
 
 
 class ReviewBatchIdentity(TypedDict):
@@ -113,12 +116,41 @@ class CommentContext(TypedDict, total=False):
 
 
 class InlineCommentTarget(TypedDict, total=False):
+    """One persisted inline-comment plan tied to an active finding.
+
+    First principle:
+    this state file does not store arbitrary prose about "maybe comment here".
+    It stores the smallest anchor shape that later review passes and workers can
+    reason about safely.
+
+    Visual model:
+
+        finding_id
+          -> why this comment exists
+
+        path + line + side
+          -> where the worker should expect to anchor it
+
+        start_line + start_side
+          -> optional range start for the rare multiline case
+
+        expected_line_text
+          -> optional safety check so stale anchors fail closed
+
+    `summary` stays optional for backwards compatibility and human context, but
+    the current Phase 2a contract is the explicit anchor fields above.
+    """
+
     repo: str
     pr_number: int
     finding_id: str
     path: str
     line: int
     summary: str
+    side: ReviewCommentSide
+    start_line: int
+    start_side: ReviewCommentSide
+    expected_line_text: str
 
 
 class ReviewPassRecord(TypedDict, total=False):
@@ -430,6 +462,24 @@ def optional_non_empty_string(value: object, field_name: str) -> str | None:
             f"Review payload field `{field_name}` must be a non-empty string when set."
         )
     return value.strip()
+
+
+def require_review_comment_side(value: object, field_name: str) -> ReviewCommentSide:
+    """Validate one GitHub review-comment side field.
+
+    We keep this as a tiny helper instead of repeating string checks inline so
+    later readers can see that `RIGHT` / `LEFT` is an intentional contract,
+    not an arbitrary string convention.
+    """
+
+    side = require_non_empty_string(value, field_name)
+    if side == "RIGHT":
+        return "RIGHT"
+    if side == "LEFT":
+        return "LEFT"
+    raise click.ClickException(
+        f"Review payload field `{field_name}` must be `RIGHT` or `LEFT`."
+    )
 
 
 def normalize_string_list(value: object, field_name: str) -> list[str]:
@@ -825,6 +875,33 @@ def normalize_inline_comment_targets(
     known_prs: set[tuple[str, int]],
     allowed_finding_ids: set[str],
 ) -> list[InlineCommentTarget]:
+    """Normalize persisted inline-comment plans for the current worker contract.
+
+    First principle:
+    inline comments are riskier than top-level review prose.
+
+    A top-level review can still be useful after lines move. An inline comment
+    becomes misleading if its diff anchor drifts. That is why this helper keeps
+    the anchor shape explicit and validates it early when review state is
+    written or re-read.
+
+    Visual model:
+
+        persisted state
+          -> finding_id
+          -> path
+          -> optional anchor fields
+
+        normalization
+          -> reject unknown findings
+          -> reject malformed anchors
+          -> preserve only fields later passes can trust
+
+    Backwards compatibility note:
+    older state may still carry a human-facing `summary`. We preserve it when
+    present, but new automation should rely on explicit anchor fields instead.
+    """
+
     if value is None:
         return []
     if not isinstance(value, list):
@@ -850,10 +927,14 @@ def normalize_inline_comment_targets(
             "path": require_non_empty_string(
                 item.get("path"), f"inline_comment_targets[{index}].path"
             ),
-            "summary": require_non_empty_string(
-                item.get("summary"), f"inline_comment_targets[{index}].summary"
-            ),
         }
+        # `summary` is optional legacy/human context. The current worker-owned
+        # inline contract is the explicit anchor payload below.
+        summary = optional_non_empty_string(
+            item.get("summary"), f"inline_comment_targets[{index}].summary"
+        )
+        if summary is not None:
+            target["summary"] = summary
         finding_id = require_non_empty_string(
             item.get("finding_id"), f"inline_comment_targets[{index}].finding_id"
         )
@@ -878,6 +959,58 @@ def normalize_inline_comment_targets(
                     f"Review payload field `inline_comment_targets[{index}].line` must be a positive integer."
                 )
             target["line"] = raw_line
+        raw_side = item.get("side")
+        if raw_side is not None:
+            side = require_review_comment_side(
+                raw_side, f"inline_comment_targets[{index}].side"
+            )
+            if raw_line is None:
+                raise click.ClickException(
+                    f"Review payload field `inline_comment_targets[{index}].side` requires `line`."
+            )
+            target["side"] = side
+        # Multiline anchors are supported, but only when both start fields are
+        # present together so later readers do not have to guess the intended
+        # range shape.
+        raw_start_line = item.get("start_line")
+        if raw_start_line is not None:
+            if (
+                not isinstance(raw_start_line, int)
+                or isinstance(raw_start_line, bool)
+                or raw_start_line < 1
+            ):
+                raise click.ClickException(
+                    f"Review payload field `inline_comment_targets[{index}].start_line` must be a positive integer."
+                )
+            target["start_line"] = raw_start_line
+        raw_start_side = item.get("start_side")
+        if raw_start_side is not None:
+            target["start_side"] = require_review_comment_side(
+                raw_start_side, f"inline_comment_targets[{index}].start_side"
+            )
+        if (raw_start_line is None) != (raw_start_side is None):
+            raise click.ClickException(
+                "Review payload field "
+                f"`inline_comment_targets[{index}]` must provide `start_line` "
+                "and `start_side` together."
+            )
+        expected_line_text = optional_non_empty_string(
+            item.get("expected_line_text"),
+            f"inline_comment_targets[{index}].expected_line_text",
+        )
+        if expected_line_text is not None:
+            target["expected_line_text"] = expected_line_text
+        # Advanced anchor fields only make sense when the main anchor exists.
+        # That keeps the persisted shape first-principles-driven instead of
+        # allowing half-specified plans like "maybe this line, maybe that one".
+        if (
+            raw_start_line is not None or expected_line_text is not None
+        ) and (raw_line is None or raw_side is None):
+            raise click.ClickException(
+                "Review payload field "
+                f"`inline_comment_targets[{index}]` must provide both `line` "
+                "and `side` when using advanced anchor fields."
+            )
         normalized.append(target)
     return normalized
 

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
@@ -967,8 +967,13 @@ def normalize_inline_comment_targets(
             if raw_line is None:
                 raise click.ClickException(
                     f"Review payload field `inline_comment_targets[{index}].side` requires `line`."
-            )
+                )
             target["side"] = side
+        if raw_line is not None and raw_side is None:
+            raise click.ClickException(
+                "Review payload field "
+                f"`inline_comment_targets[{index}].line` requires `side`."
+            )
         # Multiline anchors are supported, but only when both start fields are
         # present together so later readers do not have to guess the intended
         # range shape.


### PR DESCRIPTION
Closes #62
Refs DiversioTeam/monolith#258

## Summary

This PR aligns the `monolith-review-orchestrator` marketplace source of truth with the worker-owned inline review publishing model that now exists in `DiversioTeam/monolith`.

### Key Features

| Feature | Description |
|---------|-------------|
| Prompt-contract alignment | Updates the skill, command, and README so they explicitly teach `Codex drafts -> worker validates -> worker publishes`. |
| Inline target schema | Documents the Phase 2a inline anchor shape clearly, including when to persist an inline target versus when to fold the point into the top-level review. |
| Helper compatibility | Extends `review_state.py` so the persisted inline target shape matches the documented contract instead of rejecting newer anchor fields. |
| Reader-facing docs | Adds simpler, first-principles explanations and concrete examples so future readers can understand why these fields and rules exist. |

## Publish Flow

```text
Codex / agent
  -> reads the prepared worktree
  -> drafts one top-level review
  -> drafts inline comments only when the anchor is stable

worker
  -> re-checks live PR state
  -> validates inline anchors against the current diff
  -> publishes one atomic review through local gh / gh api
```

The important design point is that review analysis and GitHub mutation fail in different ways. A good draft can still become stale before publish, so the worker keeps the last safety check and the final mutation.

## Detailed Changes

---

## 1. Align The Prompt Contract

The plugin docs previously described an older posting model and were too vague about inline comments. This PR updates the prompt layer so it now teaches the current Phase 2a rules explicitly:

- Codex drafts but does not post directly.
- The worker revalidates live PR state before publish.
- Inline comments are only appropriate when the diff anchor is genuinely stable.
- Uncertain inline points should be folded into the top-level review body.
- Replies to existing threads and partial inline publication are still out of scope.

This updates the user-facing and skill-facing guidance in:

- `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/SKILL.md`
- `plugins/monolith-review-orchestrator/commands/post-review.md`
- `plugins/monolith-review-orchestrator/README.md`

---

## 2. Define The Inline Target Shape Clearly

The review-context protocol now explains the inline target shape from first principles instead of only hinting at it.

```text
finding_id
  -> why this comment exists

path + line + side
  -> where the worker expects to anchor it

expected_line_text
  -> how the worker can detect anchor drift before publish
```

The reference also explains the practical rule of use:

- if you can point to one exact diff line, persist an inline target
- if you cannot point to one exact diff line, keep the point in the top-level review body

---

## 3. Keep `review_state.py` Compatible With The Documented Contract

While aligning the docs, I found that the helper still validated the older persisted shape for `inline_comment_targets`. That meant the new documented example would not actually round-trip through the helper.

This PR fixes that mismatch by teaching `review_state.py` to accept and preserve:

- `side`
- `start_line`
- `start_side`
- `expected_line_text`

It also keeps legacy `summary` optional instead of required, validates anchor-side values explicitly, rejects malformed partial anchor shapes, and now enforces the required anchor pair in both directions so `line` cannot be persisted without `side`.

This keeps the persisted review memory first-principles-driven: small, explicit, machine-checkable fields instead of fuzzy prose about where an inline comment might go.

---

## 4. Add More Reader-Focused Documentation

The new and changed docs are intentionally more visual and explanatory.

Highlights:

- README now includes a short first-principles section showing the split between agent analysis and worker publication.
- `workflow-helpers.md` now explains why inline anchor fields matter and includes a concrete `record-review` example with the newer anchor fields.
- `review_state.py` now has simpler inline documentation around the anchor contract so future readers can understand why those validations exist.

## Files Changed

<details>
<summary>Plugin metadata</summary>

- `.claude-plugin/marketplace.json`
- `plugins/monolith-review-orchestrator/.claude-plugin/plugin.json`

</details>

<details>
<summary>Skill and command docs</summary>

- `plugins/monolith-review-orchestrator/README.md`
- `plugins/monolith-review-orchestrator/commands/post-review.md`
- `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/SKILL.md`
- `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/review-context-protocol.md`
- `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md`

</details>

<details>
<summary>Helper script</summary>

- `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py`

</details>

## How To Test

```bash
ruff check plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
python3 -m py_compile plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
bash scripts/validate-skills.sh --all
jq -e . .claude-plugin/marketplace.json >/dev/null
jq -e . plugins/monolith-review-orchestrator/.claude-plugin/plugin.json >/dev/null
```

### Manual / Functional Validation

- Ran a local `review_state.py` smoke test that initialized state and recorded a review payload using `line`, `side`, and `expected_line_text`.
- Confirmed the newer inline target fields persisted correctly in the recorded pass output.
- Ran a negative contract test confirming that `line` without `side` now fails early.

## Notes

- This repo remains configuration/docs-first; no runtime application behavior was added here.
- The plugin version is bumped to `0.2.3`, representing the final branch delta from `main` for this PR.
- The existing `SKILL.md` warning-threshold notice remains non-blocking: the changed skill stays below the 500-line hard limit.
- If a local install is using a copied skill from `~/.codex/skills/...`, distribution/sync may still be needed after this merges.
