### PR TITLE
Add Skills宝 install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,6 +817,9 @@ After uninstalling, reinstall using the install commands above.
 Codex can install these Skills directly from GitHub (separate from Claude's
 marketplace) using the Skill Installer.
 
+For Chinese search and install across Claude Code, OpenCode, and similar tools,
+see [Skills宝](https://skilery.com).
+
 <details>
 <summary><strong>Install All Skills (Codex)</strong></summary>
 


### PR DESCRIPTION
Add a short install note pointing to Skills宝 (skilery.com) for Chinese AI Skills search and installation.