### PR TITLE
Fix historical batch review state reads

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
     {
       "name": "monolith-review-orchestrator",
       "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "author": {
         "name": "Diversio Devs"
       },

--- a/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
+++ b/plugins/monolith-review-orchestrator/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "monolith-review-orchestrator",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Monolith-local PR review harness for the Diversio monolith: deep PR understanding, thread-aware GitHub review acquisition, deterministic worktree reuse/bootstrap, persistent review context across passes, resolved-comment-aware reassessment, backend monty-review handoff, and author-guiding review output.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
+++ b/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py
@@ -1025,6 +1025,15 @@ def normalize_persisted_review_entries(
     known_prs: set[tuple[str, int]],
     field_name: str,
 ) -> list[ReviewPassEntry]:
+    """Normalize already-persisted pass entries.
+
+    Some historical worker-owned state stores a batch-level `prs` list but has
+    older pass rows whose `entries` only name the PR reviewed in that pass. For
+    reads, keep the useful context when every listed entry is valid. The write
+    paths (`record-pass` and `record-review`) still enforce complete
+    batch-scoped entries for every new pass.
+    """
+
     if not isinstance(value, list) or not value:
         raise click.ClickException(
             f"State file field `{field_name}` must be a non-empty list."
@@ -1045,7 +1054,6 @@ def normalize_persisted_review_entries(
             )
         seen_targets.add(identity)
         normalized.append(entry)
-    ensure_full_batch_coverage(seen_targets, known_prs, field_name)
     return normalized
 
 

--- a/tests/test_review_state.py
+++ b/tests/test_review_state.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = (
+    REPO_ROOT
+    / "plugins"
+    / "monolith-review-orchestrator"
+    / "skills"
+    / "monolith-review-orchestrator"
+    / "scripts"
+    / "review_state.py"
+)
+BATCH_ARTIFACT_PATH = "/tmp/reviews/bk2912-mono291/review-bk2912-mono291.md"
+BATCH_WORKTREE_PATH = "/tmp/worktrees/bk2912-mono291"
+
+
+def write_json_payload(path: Path, payload: object) -> None:
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def summarize_review_state(state_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "uv",
+            "run",
+            "--quiet",
+            "--script",
+            str(SCRIPT_PATH),
+            "summarize-context",
+            "--state-path",
+            str(state_path),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def record_review_state(
+    state_path: Path, payload: object
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "uv",
+            "run",
+            "--quiet",
+            "--script",
+            str(SCRIPT_PATH),
+            "record-review",
+            "--state-path",
+            str(state_path),
+        ],
+        cwd=REPO_ROOT,
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def partial_batch_entry_review_state_payload() -> dict[str, object]:
+    return {
+        "schema_version": 2,
+        "batch_key": "bk2912-mono291",
+        "created_at_utc": "2026-04-28T00:00:00Z",
+        "updated_at_utc": "2026-04-28T00:00:00Z",
+        "worktree_path": BATCH_WORKTREE_PATH,
+        "artifact_path": BATCH_ARTIFACT_PATH,
+        "review_pass_number": 1,
+        "posting_status": "posted_review_comment",
+        "prs": [
+            {"repo": "Django4Lyfe", "pr_number": 2912},
+            {"repo": "monolith", "pr_number": 291},
+        ],
+        "passes": [
+            {
+                "review_pass_number": 1,
+                "recorded_at_utc": "2026-04-28T00:00:00Z",
+                "artifact_path": BATCH_ARTIFACT_PATH,
+                "posting_status": "posted_review_comment",
+                "entries": [
+                    {
+                        "repo": "monolith",
+                        "pr_number": 291,
+                        "base_branch": "main",
+                        "head_sha": "31865ba84716",
+                        "merge_base": "merge-base-mono291",
+                    }
+                ],
+                "mode": "review",
+                "recommendation": "comment",
+                "scope_summary": (
+                    "Historical pass only covered the monolith side before the "
+                    "current batch identity included the linked backend PR."
+                ),
+                "findings": {
+                    "new": [],
+                    "carried_forward": [],
+                    "resolved": [],
+                    "moot": [],
+                },
+            }
+        ],
+    }
+
+
+class ReviewStateTests(unittest.TestCase):
+    def test_summarize_allows_historical_pass_with_partial_batch_entries(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_path = Path(temp_dir) / "review-bk2912-mono291.json"
+            write_json_payload(state_path, partial_batch_entry_review_state_payload())
+
+            result = summarize_review_state(state_path)
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual(
+                payload["prs"],
+                [
+                    {"repo": "Django4Lyfe", "pr_number": 2912},
+                    {"repo": "monolith", "pr_number": 291},
+                ],
+            )
+            self.assertEqual(
+                payload["latest_context"]["entries"],
+                [
+                    {
+                        "repo": "monolith",
+                        "pr_number": 291,
+                        "base_branch": "main",
+                        "head_sha": "31865ba84716",
+                        "merge_base": "merge-base-mono291",
+                    }
+                ],
+            )
+
+    def test_record_review_still_rejects_partial_batch_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            state_path = Path(temp_dir) / "review-bk2912-mono291.json"
+            write_json_payload(
+                state_path,
+                {
+                    "schema_version": 2,
+                    "batch_key": "bk2912-mono291",
+                    "created_at_utc": "2026-04-28T00:00:00Z",
+                    "updated_at_utc": "2026-04-28T00:00:00Z",
+                    "worktree_path": BATCH_WORKTREE_PATH,
+                    "artifact_path": BATCH_ARTIFACT_PATH,
+                    "review_pass_number": 0,
+                    "posting_status": "not_posted",
+                    "prs": [
+                        {"repo": "Django4Lyfe", "pr_number": 2912},
+                        {"repo": "monolith", "pr_number": 291},
+                    ],
+                },
+            )
+
+            result = record_review_state(
+                state_path,
+                {
+                    "mode": "review",
+                    "artifact_path": BATCH_ARTIFACT_PATH,
+                    "posting_status": "not_posted",
+                    "recommendation": "comment",
+                    "scope_summary": "New writes still need every PR in the batch.",
+                    "entries": [
+                        {
+                            "repo": "monolith",
+                            "pr_number": 291,
+                            "base_branch": "main",
+                            "head_sha": "31865ba84716",
+                            "merge_base": "merge-base-mono291",
+                        }
+                    ],
+                    "findings": {
+                        "new": [],
+                        "carried_forward": [],
+                        "resolved": [],
+                        "moot": [],
+                    },
+                },
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "Review payload `entries` is missing batch PRs: Django4Lyfe:2912",
+                result.stderr,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR makes `review_state.py summarize-context` tolerate historical pass records whose `entries` only cover the PR reviewed in that older pass, while preserving full batch coverage enforcement for new `record-review` writes. It also bumps `monolith-review-orchestrator` to `0.2.4`.

### Key Changes

| Area | Description |
|------|-------------|
| Historical state reads | Persisted pass entries still validate shape, duplicates, and membership in the batch, but no longer require every batch PR to appear in every old pass. |
| Write contract | `record-review` / `record-pass` still require full batch-scoped entries for newly recorded passes. |
| Regression coverage | Adds marketplace-local tests for the partial historical pass read path and the write-path rejection. |
| Plugin metadata | Bumps `monolith-review-orchestrator` from `0.2.3` to `0.2.4` in both manifest locations. |

## Review Flow

```
Existing state file
  -> summarize-context
  -> persisted pass entries validate listed PRs only
  -> compact prior context loads successfully

New review payload
  -> record-review / record-pass
  -> entries must include every PR in the batch
  -> partial batch writes are rejected
```

## Files Changed

<details>
<summary>Core helper</summary>

- `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py` - Relaxes full-batch coverage only for persisted read normalization.

</details>

<details>
<summary>Tests</summary>

- `tests/test_review_state.py` - Covers historical partial-batch reads and confirms new partial-batch writes still fail.

</details>

<details>
<summary>Plugin metadata</summary>

- `.claude-plugin/marketplace.json` - Bumps marketplace version entry to `0.2.4`.
- `plugins/monolith-review-orchestrator/.claude-plugin/plugin.json` - Bumps plugin manifest version to `0.2.4`.

</details>

## How to Test

```bash
uv run python -m unittest tests.test_review_state
uv run python -m unittest discover tests
bash scripts/validate-skills.sh
bash scripts/validate-skills.sh --all
jq -e . .claude-plugin/marketplace.json >/dev/null
jq -e . plugins/monolith-review-orchestrator/.claude-plugin/plugin.json >/dev/null
```

Also ran the marketplace consistency check from `.github/workflows/validate-marketplace.yml` locally under `bash`; it passed.

Note: `bash scripts/validate-skills.sh --all` reports existing warning-threshold SKILL.md sizes for `monolith-review-orchestrator` and `monty-code-review`, but passes the hard limit.

## Risk

Low. The changed behavior is scoped to reading already-persisted state. New state writes still enforce full batch coverage, and the regression tests cover both sides of that contract.
