### PR TITLE
docs: clean up install instructions, DRY README content, add pi-package contributor sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # VS Code workspace config
 *.code-workspace
 __pycache__/
+.pi/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,11 @@ possible (for example, `app.message.followUp`) so custom user bindings still
 make sense. Bump the package version when publishing an update rather than only
 editing source files.
 
+For local extension smoke tests, prefer `pi -e ./pi-packages/<package>` so the
+package loads for the current run without mutating user or project settings.
+Use `pi install -l` only when testing project-local install, `/reload`, or
+settings persistence behavior.
+
 ## Validation
 
 Run the guardrails that match your change:
@@ -102,6 +107,7 @@ bash scripts/validate-skills.sh --all
 jq -e . .claude-plugin/marketplace.json >/dev/null
 jq -e . plugins/<plugin>/.claude-plugin/plugin.json >/dev/null
 jq -e . pi-packages/<package>/package.json >/dev/null
+(cd pi-packages/<package> && npm pack --dry-run --json >/tmp/<package>-pack.json)
 printf '{"id":"cmds","type":"get_commands"}\n' | PI_OFFLINE=1 pi --mode rpc --no-session --no-context-files --no-extensions -e ./pi-packages/<package> --no-prompt-templates --no-skills
 ```
 

--- a/README.md
+++ b/README.md
@@ -266,253 +266,8 @@ agent-skills-marketplace/
 
 | Package | Description | Install |
 |---------|-------------|---------|
-| `ci-status` | Pi-native CI status extension with `/ci`, `/ci-detail`, `/ci-logs`, auto-watch after pushes, widget/status rendering, GitHub Actions + CircleCI support, and LLM CI tools | `pi install -l ./pi-packages/ci-status` |
-| `dev-workflow` | Pi-native daily developer workflow with 15 core workflow prompts, `/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`, XDG/project prompt config, CI analysis, PR review feedback, release PR prep, local skills, and optional pi-subagents chain | `pi install -l ./pi-packages/dev-workflow` |
-
-## Monolith Review Orchestrator
-
-This plugin exists because deep PR review in the Diversio monolith has a few
-failure-prone steps that should not be re-derived from scratch every run:
-
-- deciding whether the machine is even in a valid monolith environment
-- turning one PR or one linked cross-repo PR pair into one stable review identity
-- creating or reusing the right detached review worktree
-- fetching thread-aware review history, including resolved and outdated threads
-- remembering durable review context across multiple passes, including prior
-  findings and resolved-comment history
-
-The basic shape is:
-
-```text
-preflight -> resolve batch -> prepare worktree -> fetch review threads -> persist review context -> write review artifact
-```
-
-Recent helper-layer additions:
-
-- monolith PRs can resolve without a submodule path
-- batch resolution can place review artifacts and deterministic worktrees under
-  external roots
-- worker-owned dirty deterministic worktrees can be repaired by recreate-and-reuse
-  instead of wedging the automation loop
-
-Why we added helper scripts:
-
-- prose is good for policy, but bad for deterministic naming and state
-- reassessment needs structured identity, not just markdown files
-- thread-aware GitHub review history should come from one deterministic helper,
-  not ad hoc GraphQL commands
-- resolved comments and prior findings need a compact local memory, not a fresh
-  reconstruction every pass
-- review prep should stay narrow and avoid monolith-wide mutation helpers
-
-Where to read more:
-
-- plugin README: `plugins/monolith-review-orchestrator/README.md`
-- skill: `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/SKILL.md`
-- worktree protocol:
-  `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/intake-and-worktree-protocol.md`
-- review context protocol:
-  `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/review-context-protocol.md`
-- helper explainer:
-  `plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/references/workflow-helpers.md`
-
-Example helper usage:
-
-```bash
-uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/preflight_review_env.py
-
-uv run --script plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py \
-  --pr-url https://github.com/DiversioTeam/Django4Lyfe/pull/2779 \
-  --pr-url https://github.com/DiversioTeam/Optimo-Frontend/pull/389
-```
-
-### Copy-Paste Workflow
-
-Use this when you want the deterministic local workflow without re-reading the
-full skill docs.
-
-#### 1. Preflight the machine and checkout
-
-Why:
-- fail early if this is not a real monolith checkout
-- avoid discovering missing tools after worktree or review state steps
-- allow an explicit `--monolith-root` override when you are invoking the helper
-  from outside the monolith checkout
-
-```bash
-export MONOLITH_ROOT="/path/to/monolith"
-cd "$MONOLITH_ROOT"
-
-uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/preflight_review_env.py
-```
-
-#### 2. Resolve one stable review batch identity
-
-Why:
-- one PR or one linked cross-repo PR pair should always map to the same batch key,
-  worktree path, markdown artifact path, and state path
-
-```bash
-cd "$MONOLITH_ROOT"
-
-uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py \
-  --pr-url https://github.com/DiversioTeam/Django4Lyfe/pull/2779 \
-  --pr-url https://github.com/DiversioTeam/Optimo-Frontend/pull/389
-```
-
-Expected shape:
-
-This is a partial excerpt of the JSON you should expect. The actual command
-also includes keys such as `monolith_root`, `review_dir`,
-`reassess_artifact_path`, and `prs`.
-
-```json
-{
-  "batch_key": "bk2779-of389",
-  "worktree_path": "/path/to/monolith-review-bk2779-of389",
-  "artifact_path": "/path/to/monolith-review-bk2779-of389/reviews/review-bk2779-of389.md",
-  "state_path": "/path/to/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json"
-}
-```
-
-#### 3. Create or reuse the detached review worktree
-
-Why:
-- keep the review run isolated
-- avoid attached-branch worktree lock pain
-- initialize only this worktree instead of broad monolith mutation
-
-```bash
-cd "$MONOLITH_ROOT"
-
-uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/prepare_review_worktree.py \
-  --monolith-root "$MONOLITH_ROOT" \
-  --worktree-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389" \
-  --submodule-path backend \
-  --submodule-path optimo-frontend \
-  --start-ref HEAD
-```
-
-Important:
-- this helper intentionally does **not** run `scripts/update_submodules.py`
-- review prep should stay narrow and not normalize unrelated submodules
-
-#### 4. Fetch thread-aware GitHub review history
-
-Why:
-- resolved and outdated threads carry important review context
-- the orchestrator now owns a first-class GraphQL acquisition path for thread
-  state and thread comments
-
-```bash
-cd "$MONOLITH_ROOT"
-
-uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/fetch_review_threads.py \
-  --pr-url https://github.com/DiversioTeam/Django4Lyfe/pull/2779 \
-  --pr-url https://github.com/DiversioTeam/Optimo-Frontend/pull/389
-```
-
-#### 5. Initialize structured review state
-
-Why:
-- markdown is for humans
-- JSON state is for reassessment identity and compact review context
-- follow-up passes should update the same batch state, not invent a new one
-
-```bash
-cd "$MONOLITH_ROOT"
-
-uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py init \
-  --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json" \
-  --batch-key bk2779-of389 \
-  --worktree-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389" \
-  --artifact-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/review-bk2779-of389.md" \
-  --pr Django4Lyfe:2779 \
-  --pr Optimo-Frontend:389
-```
-
-If the state file already exists and you intentionally want to replace it, add
-`--force`. The default behavior is to refuse overwrite so reassessment history
-is not destroyed accidentally.
-
-#### 6. Reassessment and context reuse
-
-Why:
-- load the durable local identity first
-- reuse prior findings, comment-history notes, and teaching points before
-  comparing deltas
-- preserve repo-scoped findings and thread context across passes instead of
-  replacing them with the latest pass only
-- prefer recent active findings in the compact summary instead of surfacing the
-  oldest still-open issues first
-- compare deltas against stored state instead of guessing from the latest
-  markdown file alone
-
-```bash
-cd "$MONOLITH_ROOT"
-
-uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py summarize-context \
-  --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json"
-```
-
-Then record the new pass after reviewing:
-
-```bash
-cd "$MONOLITH_ROOT"
-
-cat <<EOF | uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py \
-  record-review \
-  --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json"
-{
-  "mode": "reassess",
-  "artifact_path": "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/review-bk2779-of389.md",
-  "posting_status": "not_posted",
-  "recommendation": "request_changes",
-  "scope_summary": "Reassessed the linked backend and Optimo frontend PRs after follow-up commits.",
-  "entries": [
-    {
-      "repo": "Django4Lyfe",
-      "pr_number": 2779,
-      "base_branch": "main",
-      "head_sha": "<backend-head-sha>",
-      "merge_base": "<backend-merge-base-sha>"
-    },
-    {
-      "repo": "Optimo-Frontend",
-      "pr_number": 389,
-      "base_branch": "main",
-      "head_sha": "<optimo-head-sha>",
-      "merge_base": "<optimo-merge-base-sha>"
-    }
-  ],
-  "comment_context": {
-    "thread_source": "gh_graphql",
-    "summary": "Read existing review threads, including resolved ones, before reassessing."
-  },
-  "findings": {
-    "new": [],
-    "carried_forward": [],
-    "resolved": [],
-    "moot": []
-  }
-}
-EOF
-```
-
-Important:
-- `entries` must include every PR in the batch
-- findings and inline targets should stay repo-scoped inside linked PR batches
-- inline comment targets should reference active findings, not free-form IDs
-- `summarize-context` is intentionally compact and should prioritize recent-pass
-  context instead of replaying every historical note forever
-
-#### Visual summary
-
-There is also a presentation-style explainer at:
-
-```text
-~/.agent/diagrams/monolith-review-orchestrator-visual-explainer.html
-```
+| `ci-status` | Pi-native CI status extension with `/ci`, `/ci-detail`, `/ci-logs`, auto-watch after pushes, widget/status rendering, GitHub Actions + CircleCI support, and LLM CI tools | `pi install "$PWD/pi-packages/ci-status"` |
+| `dev-workflow` | Pi-native daily developer workflow with 15 core workflow prompts, `/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`, XDG/project prompt config, CI analysis, PR review feedback, release PR prep, local skills, and optional pi-subagents chain | `pi install "$PWD/pi-packages/dev-workflow"` |
 
 ## Installation
 
@@ -538,28 +293,34 @@ Project-scope plugins don't persist across worktrees.
 ### Pi-native packages
 
 Pi-native packages live under `pi-packages/` and install with the pi CLI instead
-of the Claude Code marketplace. From this repo checkout:
+of the Claude Code marketplace. For normal use, install them globally from an
+absolute local path:
 
 ```bash
-pi install -l ./pi-packages/ci-status
-pi install -l ./pi-packages/dev-workflow
+pi install "$PWD/pi-packages/ci-status"
+pi install "$PWD/pi-packages/dev-workflow"
 ```
 
+Plain `pi install` writes to global user settings. Use `pi -e ./pi-packages/<package>`
+for one-off extension testing without changing settings. Use `pi install -l`
+only when you need to test project-local install, reload, or persistence
+behavior.
+
+Install each pi package in one scope at a time. If `ci-status` is installed
+globally and also from a different project-local path, Pi can load both copies
+and duplicate `get_ci_status` / `ci_fetch_job_logs` tool registration. Remove
+the duplicate project package entry from `.pi/settings.json` or uninstall the
+global copy before reloading.
+
 Run `/reload` in pi after installation. See `pi-packages/ci-status/README.md`
-and `pi-packages/dev-workflow/README.md` for command inventory and CI integration details.
+and `pi-packages/dev-workflow/README.md` for command inventory, contribution
+workflow, and local testing commands.
 
-### Monolith-Only Prerequisites
+### Monolith Review Orchestrator
 
-`monolith-review-orchestrator` is not a generic marketplace-style review plugin.
-It assumes:
-
-- a Diversio monolith checkout or sibling monolith review worktree
-- the monolith `scripts/` helpers and docs are present
-- `uv`, `git`, and `git worktree` are installed
-- GitHub auth is available if PR metadata or posting is required
-- local permission to create sibling worktrees
-
-Treat it as a harness-local workflow plugin.
+`monolith-review-orchestrator` is a harness-local workflow for Diversio
+monolith review work. Read `plugins/monolith-review-orchestrator/README.md`
+for prerequisites, helper commands, and usage examples.
 
 If you already use the upstream `visual-explainer` plugin, uninstall it before
 installing this marketplace version:

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -11,7 +11,7 @@ when command files change.
     status discovery, auto-watch after pushes, widget/status rendering,
     notifications, CI-provider/workflow-cycle TUI job details, failed-job reruns,
     guided fix prompts, and log access.
-  - Pi install from repo checkout: `pi install -l ./pi-packages/ci-status`
+  - Pi install from repo checkout: `pi install "$PWD/pi-packages/ci-status"`
   - Package path: `pi-packages/ci-status`
   - Extension path: `pi-packages/ci-status/extensions/ci-status`
   - Slash commands: `/ci`, `/ci-detail`, `/ci-logs`, `/ci-refresh`,
@@ -27,7 +27,7 @@ when command files change.
     interactive TUI help panel, CI analysis, PR review feedback handling,
     release PR prep prompts, local skills, and optional pi-subagents chain.
   - Pi install from repo checkout:
-    `pi install -l ./pi-packages/dev-workflow`
+    `pi install "$PWD/pi-packages/dev-workflow"`
   - Package path: `pi-packages/dev-workflow`
   - Extension path:
     `pi-packages/dev-workflow/extensions/dev-workflow`

--- a/docs/quality/gates.md
+++ b/docs/quality/gates.md
@@ -10,6 +10,7 @@ bash scripts/validate-skills.sh --all
 jq -e . .claude-plugin/marketplace.json >/dev/null
 jq -e . plugins/<plugin>/.claude-plugin/plugin.json >/dev/null
 jq -e . pi-packages/<package>/package.json >/dev/null
+(cd pi-packages/<package> && npm pack --dry-run --json >/tmp/<package>-pack.json)
 printf '{"id":"cmds","type":"get_commands"}\n' | PI_OFFLINE=1 pi --mode rpc --no-session --no-context-files --no-extensions -e ./pi-packages/<package> --no-prompt-templates --no-skills
 ```
 

--- a/docs/runbooks/distribution.md
+++ b/docs/runbooks/distribution.md
@@ -129,24 +129,40 @@ not the Claude Code marketplace.
 From a checkout of this repo:
 
 ```bash
-pi install -l ./pi-packages/ci-status
-pi install -l ./pi-packages/dev-workflow
+pi install "$PWD/pi-packages/ci-status"
+pi install "$PWD/pi-packages/dev-workflow"
 ```
 
 From the Diversio monolith root, include the submodule path:
 
 ```bash
-pi install -l ./agent-skills-marketplace/pi-packages/ci-status
-pi install -l ./agent-skills-marketplace/pi-packages/dev-workflow
+pi install "$PWD/agent-skills-marketplace/pi-packages/ci-status"
+pi install "$PWD/agent-skills-marketplace/pi-packages/dev-workflow"
 ```
 
-Use `-l` for project-local installs that write to `.pi/settings.json`. For a
-personal global install, pass an absolute path instead:
+Plain `pi install` writes to global user settings (`~/.pi/agent/settings.json`).
+For one-off extension testing, prefer `-e` so Pi loads the package for the
+current run without changing settings:
 
 ```bash
-pi install /path/to/agent-skills-marketplace/pi-packages/ci-status
-pi install /path/to/agent-skills-marketplace/pi-packages/dev-workflow
+pi -e ./pi-packages/ci-status
+pi -e ./pi-packages/dev-workflow
 ```
+
+Use `-l` only when you need to test project-local install, reload, or
+persistence behavior that writes to `.pi/settings.json`:
+
+```bash
+pi install -l ./pi-packages/ci-status
+pi install -l ./pi-packages/dev-workflow
+```
+
+Install a pi package in one scope at a time. Pi deduplicates the same package
+identity across user and project settings, but different local paths can still
+resolve as different packages. For `ci-status`, duplicate loads can produce
+tool registration conflicts for `get_ci_status` and `ci_fetch_job_logs`. Remove
+the duplicate project package entry or uninstall the global copy before
+restarting or running `/reload`.
 
 After install, restart pi or run `/reload`. The `ci-status` package provides
 `/ci`, `/ci-detail`, `/ci-logs`, CI auto-watch, UI widgets, notifications, and

--- a/pi-packages/ci-status/README.md
+++ b/pi-packages/ci-status/README.md
@@ -4,18 +4,63 @@ Pi extension for checking CI from inside pi. It currently fetches GitHub Actions
 
 ## Install
 
+For normal use, install globally from a checkout of this repo. Use `$PWD` so Pi
+registers the checkout you intend in user settings.
+
 ```bash
-# From the agent-skills-marketplace repo root, project-level (writes to .pi/settings.json)
-pi install -l ./pi-packages/ci-status
+# From the agent-skills-marketplace repo root
+pi install "$PWD/pi-packages/ci-status"
 
 # From the Diversio monolith root
-pi install -l ./agent-skills-marketplace/pi-packages/ci-status
-
-# Personal/global install from a local checkout
-pi install /path/to/agent-skills-marketplace/pi-packages/ci-status
+pi install "$PWD/agent-skills-marketplace/pi-packages/ci-status"
 ```
 
-Then restart pi or run `/reload` in an existing pi session.
+Plain `pi install` writes to global user settings. Then restart pi or run
+`/reload` in an existing pi session.
+
+Install `ci-status` in one scope at a time. If it is installed globally and
+also from a different project-local path, Pi can load both copies and duplicate
+`get_ci_status` / `ci_fetch_job_logs` tool registration. Remove the duplicate
+project package entry from `.pi/settings.json` or uninstall the global copy
+before `/reload`.
+
+## Contributing And Local Testing
+
+Use `-e` for one-off extension testing while actively editing this package. It
+loads the package for the current Pi run without changing global or project
+settings:
+
+```bash
+# From the agent-skills-marketplace repo root
+pi -e ./pi-packages/ci-status
+```
+
+Use a project-local install only when you need to test `.pi/settings.json`,
+`/reload`, or persistence behavior:
+
+```bash
+# From the agent-skills-marketplace repo root
+pi install -l ./pi-packages/ci-status
+```
+
+Run these checks before opening a PR:
+
+```bash
+jq -e . pi-packages/ci-status/package.json >/dev/null
+
+(cd pi-packages/ci-status && npm pack --dry-run --json >/tmp/ci-status-pack.json)
+
+printf '{"id":"cmds","type":"get_commands"}\n' | \
+  PI_OFFLINE=1 pi --mode rpc --no-session --no-context-files \
+    --no-extensions -e ./pi-packages/ci-status \
+    --no-prompt-templates --no-skills >/tmp/ci-status-commands.json
+
+jq -e '.success == true' /tmp/ci-status-commands.json >/dev/null
+```
+
+After changing commands, tools, shortcuts, or package resources, update this
+README plus the top-level `README.md`, `docs/runbooks/distribution.md`, and
+`docs/plugins/catalog.md`.
 
 ## Commands
 

--- a/pi-packages/dev-workflow/README.md
+++ b/pi-packages/dev-workflow/README.md
@@ -4,18 +4,22 @@ Daily developer workflow for pi: plan review, self-review, standards, CI, docume
 
 ## Install
 
+For normal use, install globally from a checkout of this repo. Use `$PWD` so Pi
+registers the checkout you intend in user settings.
+
 ```bash
-# From the agent-skills-marketplace repo root, project-level (writes to .pi/settings.json)
-pi install -l ./pi-packages/dev-workflow
+# From the agent-skills-marketplace repo root
+pi install "$PWD/pi-packages/dev-workflow"
 
 # From the Diversio monolith root
-pi install -l ./agent-skills-marketplace/pi-packages/dev-workflow
-
-# Personal/global install from a local checkout
-pi install /path/to/agent-skills-marketplace/pi-packages/dev-workflow
+pi install "$PWD/agent-skills-marketplace/pi-packages/dev-workflow"
 ```
 
-Then `/reload` in any pi session.
+Plain `pi install` writes to global user settings. Then restart pi or run
+`/reload` in any pi session.
+
+Install `dev-workflow` in one scope at a time. Use `-l` only when testing the
+package project-locally as a developer.
 
 ## Commands
 
@@ -139,13 +143,55 @@ Run with:
 /run-chain workflow-pipeline -- <task>
 ```
 
+## Contributing And Local Testing
+
+Use `-e` for one-off extension testing while actively editing this package. It
+loads the package for the current Pi run without changing global or project
+settings:
+
+```bash
+# From the agent-skills-marketplace repo root
+pi -e ./pi-packages/dev-workflow
+```
+
+Use a project-local install only when you need to test `.pi/settings.json`,
+`/reload`, or persistence behavior:
+
+```bash
+# From the agent-skills-marketplace repo root
+pi install -l ./pi-packages/dev-workflow
+```
+
+Run these checks before opening a PR:
+
+```bash
+jq -e . pi-packages/dev-workflow/package.json >/dev/null
+
+(cd pi-packages/dev-workflow && npm pack --dry-run --json >/tmp/dev-workflow-pack.json)
+
+printf '{"id":"cmds","type":"get_commands"}\n' | \
+  PI_OFFLINE=1 pi --mode rpc --no-session --no-context-files \
+    --no-extensions -e ./pi-packages/dev-workflow \
+    --no-prompt-templates --no-skills >/tmp/dev-workflow-commands.json
+
+jq -e '.success == true' /tmp/dev-workflow-commands.json >/dev/null
+```
+
+After changing commands, tools, shortcuts, prompt inventory, skills, chain
+files, or package resources, update this README plus the top-level `README.md`,
+`docs/runbooks/distribution.md`, and `docs/plugins/catalog.md`.
+
 ## Requirements
 
 - pi >= 1.0.0
 - Recommended: install the separate `ci-status` package for `/ci`, `/ci-detail`, and `/ci-logs`:
 
   ```bash
-  pi install -l ./pi-packages/ci-status
+  pi install "$PWD/pi-packages/ci-status"
   ```
+
+  Use the same install scope you use for other pi packages. Do not install
+  `ci-status` both globally and from a different project-local path; duplicated
+  CI tools can conflict.
 
 Subagent commands require [pi-subagents](https://github.com/nicobailon/pi-subagents) for true agent isolation; they fall back to inline execution without it. CI prompts prefer the `ci-status` package when installed and only fall back to `get_ci_status` / `ci_fetch_job_logs` when the current harness exposes those tools.

--- a/plugins/monolith-review-orchestrator/README.md
+++ b/plugins/monolith-review-orchestrator/README.md
@@ -136,6 +136,209 @@ If you prefer slash commands:
 Then provide the same concrete PR URLs and review intent in the prompt that
 follows.
 
+## Prerequisites
+
+This is a harness-local workflow plugin. It assumes:
+
+- a Diversio monolith checkout or sibling monolith review worktree
+- the monolith `scripts/` helpers and docs are present
+- `uv`, `git`, and `git worktree` are installed
+- GitHub auth is available if PR metadata or posting is required
+- local permission to create sibling worktrees
+
+## Helper Workflow
+
+Use this when you want the deterministic local workflow without re-reading the
+full skill docs.
+
+The helper flow is:
+
+```text
+preflight -> resolve batch -> prepare worktree -> fetch review threads -> persist review context -> write review artifact
+```
+
+### 1. Preflight The Machine And Checkout
+
+Why:
+- fail early if this is not a real monolith checkout
+- avoid discovering missing tools after worktree or review state steps
+- allow an explicit `--monolith-root` override when invoking the helper from
+  outside the monolith checkout
+
+```bash
+export MONOLITH_ROOT="/path/to/monolith"
+cd "$MONOLITH_ROOT"
+
+uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/preflight_review_env.py
+```
+
+### 2. Resolve One Stable Review Batch Identity
+
+Why:
+- one PR or one linked cross-repo PR pair should always map to the same batch
+  key, worktree path, markdown artifact path, and state path
+
+```bash
+cd "$MONOLITH_ROOT"
+
+uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/resolve_review_batch.py \
+  --pr-url https://github.com/DiversioTeam/Django4Lyfe/pull/2779 \
+  --pr-url https://github.com/DiversioTeam/Optimo-Frontend/pull/389
+```
+
+Expected shape:
+
+```json
+{
+  "batch_key": "bk2779-of389",
+  "worktree_path": "/path/to/monolith-review-bk2779-of389",
+  "artifact_path": "/path/to/monolith-review-bk2779-of389/reviews/review-bk2779-of389.md",
+  "state_path": "/path/to/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json"
+}
+```
+
+The actual command also includes keys such as `monolith_root`, `review_dir`,
+`reassess_artifact_path`, and `prs`.
+
+### 3. Create Or Reuse The Detached Review Worktree
+
+Why:
+- keep the review run isolated
+- avoid attached-branch worktree lock pain
+- initialize only this worktree instead of broad monolith mutation
+
+```bash
+cd "$MONOLITH_ROOT"
+
+uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/prepare_review_worktree.py \
+  --monolith-root "$MONOLITH_ROOT" \
+  --worktree-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389" \
+  --submodule-path backend \
+  --submodule-path optimo-frontend \
+  --start-ref HEAD
+```
+
+Important:
+- this helper intentionally does **not** run `scripts/update_submodules.py`
+- review prep should stay narrow and not normalize unrelated submodules
+
+### 4. Fetch Thread-Aware GitHub Review History
+
+Why:
+- resolved and outdated threads carry important review context
+- the orchestrator owns a first-class GraphQL acquisition path for thread state
+  and thread comments
+
+```bash
+cd "$MONOLITH_ROOT"
+
+uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/fetch_review_threads.py \
+  --pr-url https://github.com/DiversioTeam/Django4Lyfe/pull/2779 \
+  --pr-url https://github.com/DiversioTeam/Optimo-Frontend/pull/389
+```
+
+### 5. Initialize Structured Review State
+
+Why:
+- markdown is for humans
+- JSON state is for reassessment identity and compact review context
+- follow-up passes should update the same batch state, not invent a new one
+
+```bash
+cd "$MONOLITH_ROOT"
+
+uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py init \
+  --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json" \
+  --batch-key bk2779-of389 \
+  --worktree-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389" \
+  --artifact-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/review-bk2779-of389.md" \
+  --pr Django4Lyfe:2779 \
+  --pr Optimo-Frontend:389
+```
+
+If the state file already exists and you intentionally want to replace it, add
+`--force`. The default behavior refuses overwrites so reassessment history is
+not destroyed accidentally.
+
+### 6. Reassessment And Context Reuse
+
+Why:
+- load the durable local identity first
+- reuse prior findings, comment-history notes, and teaching points before
+  comparing deltas
+- preserve repo-scoped findings and thread context across passes instead of
+  replacing them with the latest pass only
+- prefer recent active findings in the compact summary instead of surfacing the
+  oldest still-open issues first
+- compare deltas against stored state instead of guessing from the latest
+  markdown file alone
+
+```bash
+cd "$MONOLITH_ROOT"
+
+uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py summarize-context \
+  --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json"
+```
+
+Then record the new pass after reviewing:
+
+```bash
+cd "$MONOLITH_ROOT"
+
+cat <<EOF | uv run --script agent-skills-marketplace/plugins/monolith-review-orchestrator/skills/monolith-review-orchestrator/scripts/review_state.py \
+  record-review \
+  --state-path "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/.state/review-bk2779-of389.json"
+{
+  "mode": "reassess",
+  "artifact_path": "${MONOLITH_ROOT%/*}/monolith-review-bk2779-of389/reviews/review-bk2779-of389.md",
+  "posting_status": "not_posted",
+  "recommendation": "request_changes",
+  "scope_summary": "Reassessed the linked backend and Optimo frontend PRs after follow-up commits.",
+  "entries": [
+    {
+      "repo": "Django4Lyfe",
+      "pr_number": 2779,
+      "base_branch": "main",
+      "head_sha": "<backend-head-sha>",
+      "merge_base": "<backend-merge-base-sha>"
+    },
+    {
+      "repo": "Optimo-Frontend",
+      "pr_number": 389,
+      "base_branch": "main",
+      "head_sha": "<optimo-head-sha>",
+      "merge_base": "<optimo-merge-base-sha>"
+    }
+  ],
+  "comment_context": {
+    "thread_source": "gh_graphql",
+    "summary": "Read existing review threads, including resolved ones, before reassessing."
+  },
+  "findings": {
+    "new": [],
+    "carried_forward": [],
+    "resolved": [],
+    "moot": []
+  }
+}
+EOF
+```
+
+Important:
+- `entries` must include every PR in the batch
+- findings and inline targets should stay repo-scoped inside linked PR batches
+- inline comment targets should reference active findings, not free-form IDs
+- `summarize-context` is intentionally compact and should prioritize recent-pass
+  context instead of replaying every historical note forever
+
+### Visual Summary
+
+There is also a presentation-style explainer at:
+
+```text
+~/.agent/diagrams/monolith-review-orchestrator-visual-explainer.html
+```
+
 ## Notes
 
 - The plugin uses a thread-aware GitHub acquisition helper when GitHub auth is


### PR DESCRIPTION
## Summary

Documentation and install-instruction cleanup across the marketplace repo.

## What changed

### Install instructions (correctness fix)
- Changed pi-package install instructions from `pi install -l ./pi-packages/<name>` to `pi install "$PWD/pi-packages/<name>"` — the `-l` flag writes to project-local `.pi/settings.json` which causes duplicate-package conflicts when a user also has the package installed globally. Affected files: `README.md`, `docs/runbooks/distribution.md`, `docs/plugins/catalog.md`.

### README consolidation (DRY)
- Moved ~250 lines of monolith-review-orchestrator workflow docs from top-level `README.md` into `plugins/monolith-review-orchestrator/README.md` (where they already existed in a slightly different form). The top-level README now points to the plugin README instead of duplicating.

### Contributing & local testing guidance (new)
- Added "Contributing And Local Testing" sections to `pi-packages/ci-status/README.md` and `pi-packages/dev-workflow/README.md`, covering `-e` vs `-l` usage, and pre-PR validation commands (`jq`, `npm pack --dry-run`, pi RPC command check).

### Quality gates (validation hardening)
- Added `npm pack --dry-run --json` validation step to `docs/quality/gates.md` and `CONTRIBUTING.md`.

### Housekeeping
- Added `.pi/` to `.gitignore`.
- Added single-scope install advice and duplicate-package warnings throughout distribution docs.
- Updated `CONTRIBUTING.md` with pi extension smoke-test guidance (`-e` vs `-l`).

## Validation

- [x] `bash scripts/validate-skills.sh --all` — passes
- [x] `jq -e . .claude-plugin/marketplace.json` — passes
- [x] `jq -e . plugins/*/.claude-plugin/plugin.json` — passes
- [x] `jq -e . pi-packages/*/package.json` — passes
- [x] `npm pack --dry-run` for ci-status and dev-workflow — passes
- [x] pi RPC `get_commands` check for both packages — passes