### PR TITLE
feat: add skills-bridge pi package to bridge 21 plugin skills into pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ agent-skills-marketplace/
 |---------|-------------|---------|
 | `ci-status` | Pi-native CI status extension with `/ci`, `/ci-detail`, `/ci-logs`, auto-watch after pushes, widget/status rendering, GitHub Actions + CircleCI support, and LLM CI tools | `pi install "$PWD/pi-packages/ci-status"` |
 | `dev-workflow` | Pi-native daily developer workflow with 15 core workflow prompts, `/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`, XDG/project prompt config, CI analysis, PR review feedback, release PR prep, local skills, and optional pi-subagents chain | `pi install "$PWD/pi-packages/dev-workflow"` |
+| `skills-bridge` | Auto-discovers all 21 Claude Code plugin skills from plugins/*/skills/ and registers them as pi skills. One install bridges the gap between the plugin ecosystem and pi | `pi install "$PWD/pi-packages/skills-bridge"` |
 
 ## Installation
 
@@ -311,6 +312,7 @@ absolute local path:
 ```bash
 pi install "$PWD/pi-packages/ci-status"
 pi install "$PWD/pi-packages/dev-workflow"
+pi install "$PWD/pi-packages/skills-bridge"
 ```
 
 Plain `pi install` writes to global user settings. Use `pi -e ./pi-packages/<package>`

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -67,7 +67,9 @@ when command files change.
   - Extension path:
     `pi-packages/skills-bridge/extensions/skills-bridge`
   - Discovery: three-tier resolution — `PI_SKILLS_PATH` env var,
-    `~/.config/pi/skills-bridge.json` config file, cwd walk-up.
+    `~/.config/pi/skills-bridge.json` config file, cwd walk-up
+    (repo-agnostic: checks for `plugins/` at each ancestor, plus
+    `agent-skills-marketplace/plugins/` for the monolith submodule).
   - Skills bridged: `release-manager`, `monty-code-review`,
     `backend-atomic-commit`, `backend-pr-workflow`, `plan-directory`,
     `backend-ralph-plan`, `pr-description-writer`, `process-code-review`,

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -55,6 +55,29 @@ when command files change.
   - Recommended companion package: `ci-status` for `/ci`, `/ci-detail`, and
     `/ci-logs`; workflow prompts fall back to `get_ci_status` /
     `ci_fetch_job_logs` only when the current harness exposes those tools.
+- `skills-bridge` (pi package)
+  - Purpose: auto-discovers Claude Code plugin skills from
+    `plugins/*/skills/` directories and registers them as pi
+    skills via the `resources_discover` extension hook. One install makes all
+    21 plugin skills available in pi without restructuring the
+    repo.
+  - Pi install from repo checkout:
+    `pi install "$PWD/pi-packages/skills-bridge"`
+  - Package path: `pi-packages/skills-bridge`
+  - Extension path:
+    `pi-packages/skills-bridge/extensions/skills-bridge`
+  - Discovery: three-tier resolution — `PI_SKILLS_PATH` env var,
+    `~/.config/pi/skills-bridge.json` config file, cwd walk-up.
+  - Skills bridged: `release-manager`, `monty-code-review`,
+    `backend-atomic-commit`, `backend-pr-workflow`, `plan-directory`,
+    `backend-ralph-plan`, `pr-description-writer`, `process-code-review`,
+    `bruno-api`, `code-review-digest-writer`, `mixpanel-analytics`,
+    `clickup-ticket`, `github-ticket`, `repo-docs-generator`,
+    `visual-explainer`, `dependabot-remediation`, `terraform-atomic-commit`,
+    `terraform-pr-workflow`, `login-cta-attribution-skill`,
+    `monolith-review-orchestrator`, `frontend` (21 total).
+  - Context safe: only skill names + descriptions enter context at startup
+    (~5-10KB); full SKILL.md loads on demand via progressive disclosure.
 - `monolith-review-orchestrator`
   - Purpose: monolith-local PR review harness with structured intake,
     deterministic worktree reuse/bootstrap, persistent review context across

--- a/docs/runbooks/distribution.md
+++ b/docs/runbooks/distribution.md
@@ -134,6 +134,7 @@ From a checkout of this repo:
 pi install "$PWD/pi-packages/ci-status"
 pi install "$PWD/pi-packages/dev-workflow"
 pi install "$PWD/pi-packages/skills-bridge"
+```
 
 From the Diversio monolith root, include the submodule path:
 

--- a/docs/runbooks/distribution.md
+++ b/docs/runbooks/distribution.md
@@ -133,13 +133,14 @@ From a checkout of this repo:
 ```bash
 pi install "$PWD/pi-packages/ci-status"
 pi install "$PWD/pi-packages/dev-workflow"
-```
+pi install "$PWD/pi-packages/skills-bridge"
 
 From the Diversio monolith root, include the submodule path:
 
 ```bash
 pi install "$PWD/agent-skills-marketplace/pi-packages/ci-status"
 pi install "$PWD/agent-skills-marketplace/pi-packages/dev-workflow"
+pi install "$PWD/agent-skills-marketplace/pi-packages/skills-bridge"
 ```
 
 Plain `pi install` writes to global user settings (`~/.pi/agent/settings.json`).
@@ -149,6 +150,7 @@ current run without changing settings:
 ```bash
 pi -e ./pi-packages/ci-status
 pi -e ./pi-packages/dev-workflow
+pi -e ./pi-packages/skills-bridge
 ```
 
 Use `-l` only when you need to test project-local install, reload, or
@@ -157,6 +159,7 @@ persistence behavior that writes to `.pi/settings.json`:
 ```bash
 pi install -l ./pi-packages/ci-status
 pi install -l ./pi-packages/dev-workflow
+pi install -l ./pi-packages/skills-bridge
 ```
 
 Install a pi package in one scope at a time. Pi deduplicates the same package

--- a/pi-packages/skills-bridge/README.md
+++ b/pi-packages/skills-bridge/README.md
@@ -90,7 +90,7 @@ function findSkillDirs(root, depth=0) {
     let isDir;
     try { isDir = statSync(full).isDirectory(); } catch { continue; }
     if (!isDir) continue;
-    if (existsSync(join(full, 'SKILL.md'))) results.push(full);
+    if (existsSync(join(full, 'SKILL.md'))) { results.push(full); continue; }
     results.push(...findSkillDirs(full, depth+1));
   }
   return results;

--- a/pi-packages/skills-bridge/README.md
+++ b/pi-packages/skills-bridge/README.md
@@ -34,7 +34,9 @@ The extension uses three-tier resolution to find the `agent-skills-marketplace` 
 
 1. **`PI_SKILLS_PATH` env var** (highest priority) — explicit session-level override. The extension uses this path and skips everything else.
 2. **`~/.config/pi/skills-bridge.json` config file** — persistent per-developer config with `skillsPath` and optional `additionalPaths`.
-3. **Cwd walk-up** (fallback) — walks up from the working directory looking for `agent-skills-marketplace/plugins/`.
+3. **Cwd walk-up** (fallback) — walks up from the working directory looking
+   for a `plugins/` directory (repo-agnostic) or an
+   `agent-skills-marketplace/plugins/` child (monolith submodule convenience).
 
 For most developers in the monolith, tier 3 works automatically. No config needed.
 

--- a/pi-packages/skills-bridge/README.md
+++ b/pi-packages/skills-bridge/README.md
@@ -1,0 +1,163 @@
+# skills-bridge
+
+Pi extension that auto-discovers Claude Code plugin skills from `plugins/*/skills/` directories and registers them as pi skills. One install bridges all 21 plugin skills into pi without restructuring the repo.
+
+## What it does
+
+The Diversio team has 21 Claude Code skills (`release-manager`, `monty-code-review`, `backend-atomic-commit`, etc.) in the shared repo. Claude Code and Codex users see them automatically. Pi users don't — pi only discovers skills from `~/.pi/agent/skills/` and `pi-packages/*/skills/`, not from `plugins/*/skills/`.
+
+This extension bridges that gap. It uses pi's `resources_discover` hook to scan the plugins directory and register skill paths. One `pi install` per team member, then `/reload`, and all 21 skills appear.
+
+**Context safety:** The extension only exposes skill names + descriptions (~5-10KB total) at startup. Full `SKILL.md` bodies load on demand when a skill is invoked. No context bloat.
+
+## Install
+
+**Global (recommended for worktree-heavy teams):**
+
+```bash
+# From the monolith root
+pi install "$PWD/agent-skills-marketplace/pi-packages/skills-bridge"
+```
+
+**Project-local (for single-repo teams):**
+
+```bash
+# From the monolith root
+pi install -l ./agent-skills-marketplace/pi-packages/skills-bridge
+```
+
+Then restart pi or run `/reload` in an existing session.
+
+## How it finds the skills
+
+The extension uses three-tier resolution to find the `agent-skills-marketplace` root:
+
+1. **`PI_SKILLS_PATH` env var** (highest priority) — explicit session-level override. The extension uses this path and skips everything else.
+2. **`~/.config/pi/skills-bridge.json` config file** — persistent per-developer config with `skillsPath` and optional `additionalPaths`.
+3. **Cwd walk-up** (fallback) — walks up from the working directory looking for `agent-skills-marketplace/plugins/`.
+
+For most developers in the monolith, tier 3 works automatically. No config needed.
+
+### Config file
+
+For developers who keep skills at a non-standard path or want extra skill sources:
+
+```bash
+mkdir -p ~/.config/pi
+```
+
+Create `~/.config/pi/skills-bridge.json`:
+
+```json
+{
+  "skillsPath": "/absolute/path/to/agent-skills-marketplace",
+  "additionalPaths": [
+    "/another/checkout/agent-skills-marketplace",
+    "/path/to/experimental-skills"
+  ]
+}
+```
+
+- `skillsPath` — primary skills root (optional; falls through to cwd walk-up if absent)
+- `additionalPaths` — extra skills roots to also scan (optional)
+- Both fields are optional; an empty file `{}` means "use cwd walk-up only"
+- The config file lives outside the package repo, so updating the repo never overwrites local config
+- When `PI_SKILLS_PATH` env var is set, the config file is ignored (env var is an explicit override)
+
+## Verify
+
+After installing and restarting pi, check that skills appear:
+
+1. Type `/skill:<tab>` in pi — you should see `release-manager`, `monty-code-review`, `backend-atomic-commit`, and others
+2. Try `/skill:release-manager` — it should load the full release workflow instructions
+
+To verify discovery without restarting pi, run this standalone test:
+
+```bash
+cd /path/to/monolith
+node -e "
+const { existsSync, readdirSync, statSync } = require('node:fs');
+const { join } = require('node:path');
+function findSkillDirs(root, depth=0) {
+  const results = [];
+  if (depth > 5) return results;
+  let entries;
+  try { entries = readdirSync(root); } catch { return results; }
+  for (const entry of entries) {
+    const full = join(root, entry);
+    let isDir;
+    try { isDir = statSync(full).isDirectory(); } catch { continue; }
+    if (!isDir) continue;
+    if (existsSync(join(full, 'SKILL.md'))) results.push(full);
+    results.push(...findSkillDirs(full, depth+1));
+  }
+  return results;
+}
+const pluginsDir = 'agent-skills-marketplace/plugins';
+const plugins = readdirSync(pluginsDir);
+let total = 0;
+for (const p of plugins) {
+  const sd = join(pluginsDir, p, 'skills');
+  if (!existsSync(sd)) continue;
+  const found = findSkillDirs(sd);
+  total += found.length;
+}
+console.log('Skills discovered:', total);
+"
+```
+
+## Skills bridged
+
+The extension discovers all 21 skills from these plugins:
+
+`release-manager`, `monty-code-review`, `backend-atomic-commit`, `backend-pr-workflow`, `plan-directory`, `backend-ralph-plan`, `pr-description-writer`, `process-code-review`, `bruno-api`, `code-review-digest-writer`, `mixpanel-analytics`, `clickup-ticket`, `github-ticket`, `repo-docs-generator`, `visual-explainer`, `dependabot-remediation`, `terraform-atomic-commit`, `terraform-pr-workflow`, `login-cta-attribution-skill`, `monolith-review-orchestrator`, `frontend`
+
+## Team setup
+
+Each team member runs one command:
+
+```bash
+# In the monolith root
+pi install "$PWD/agent-skills-marketplace/pi-packages/skills-bridge"
+```
+
+Then `/reload` (or restart pi). Skills appear immediately.
+
+### Worktree behavior
+
+Global install (without `-l`) persists across all git worktrees. If you use `scripts/create_worktree.py`, you only need to install once in the main monolith checkout.
+
+## Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| Skills don't appear after `/reload` | Extension can't find skills root | Check `PI_SKILLS_PATH` or verify `agent-skills-marketplace/plugins/` exists |
+| "Skill name collision" warnings | Same skill registered from multiple sources | Check if the skill exists in both `~/.pi/agent/skills/` and the skills root |
+| Extension causes pi startup error | TypeScript syntax error in extension | Check pi startup logs |
+| Skills appear but `/skill:name` doesn't load content | SKILL.md structure issue | Verify the skill directory follows `plugins/<name>/skills/<skill>/SKILL.md` |
+| Submodule not initialized | `git submodule update --init` hasn't been run | Run `git submodule update --init agent-skills-marketplace` |
+
+## Rollback
+
+```bash
+# Find the installed package path
+pi list
+
+# Remove it
+pi remove /path/to/agent-skills-marketplace/pi-packages/skills-bridge
+
+# Restart pi or /reload
+```
+
+The config file at `~/.config/pi/skills-bridge.json` is not affected by install/remove — it's a separate per-developer file. Delete it manually if you want to remove all traces.
+
+## Updating
+
+When new skills are added or the extension is updated:
+
+```bash
+# Remove and reinstall to pick up the latest extension code
+pi remove /path/to/agent-skills-marketplace/pi-packages/skills-bridge
+pi install /path/to/agent-skills-marketplace/pi-packages/skills-bridge
+# Then /reload
+```

--- a/pi-packages/skills-bridge/extensions/skills-bridge/index.ts
+++ b/pi-packages/skills-bridge/extensions/skills-bridge/index.ts
@@ -381,20 +381,20 @@ function findSkillRoots(cwd: string): string[] {
  * Walk up the directory tree looking for a skills root.
  *
  * A "skills root" is any directory that contains a `plugins/` subdirectory
- * (the Claude Code plugin layout). We check two things at each ancestor:
+ * (the Claude Code plugin layout). We check two things at each ancestor,
+ * with the submodule path checked FIRST to avoid the monolith root's own
+ * `plugins/` directory shadowing the marketplace submodule:
  *
- *   1. Does this directory itself have a plugins/ subdirectory?
- *      → repo-agnostic: works for any checkout with the right layout.
- *      If you run pi inside agent-skills-marketplace/ itself, it's found
- *      immediately.
- *
- *   2. Does this directory have an agent-skills-marketplace/ child with
+ *   1. Does this directory have an agent-skills-marketplace/ child with
  *      a plugins/ subdirectory inside it?
- *      → monolith submodule convenience: the team's primary layout where
+ *      → monolith submodule: the team's primary layout where
  *      agent-skills-marketplace is a git submodule at the monolith root.
+ *      Checked first so it wins when both exist at the same ancestor.
  *
- * Check 1 runs first so that a direct match (the cwd IS a skills root)
- * wins over an indirect match via a submodule path.
+ *   2. Does this directory itself have a plugins/ subdirectory?
+ *      → repo-agnostic fallback: works for any checkout with the right
+ *      layout. Only reached when no agent-skills-marketplace submodule
+ *      exists at this ancestor.
  *
  * HOW IT WORKS — visual trace from a monolith checkout:
  *
@@ -433,22 +433,25 @@ function walkUpFindSkillRoot(startDir: string): string | null {
   let current = resolve(startDir);
 
   for (let depth = 0; depth < 64; depth++) {
-    // ---- Check 1: does <current>/plugins/ exist? (repo-agnostic) ----
-    // The current directory IS a skills root if it directly contains
-    // a plugins/ subdirectory with the Claude Code plugin layout.
-    const directPlugins = join(current, "plugins");
-    if (existsSync(directPlugins) && statSync(directPlugins).isDirectory()) {
-      return current;
-    }
-
-    // ---- Check 2: does <current>/agent-skills-marketplace/plugins/ exist? ----
-    // The monolith keeps agent-skills-marketplace as a git submodule.
-    // This is the team's most common layout, so we check for it as a
-    // convenience. Other submodule/repo names work via env var or config.
+    // ---- Check 1: does <current>/agent-skills-marketplace/plugins/ exist? ----
+    // The monolith keeps agent-skills-marketplace as a git submodule. When
+    // both <current>/plugins/ and <current>/agent-skills-marketplace/plugins/
+    // exist (e.g., the monolith root), we prefer the submodule path because
+    // that's where the team's 21 marketplace skills live. The direct plugins/
+    // check below is the fallback for repo-agnostic checkouts.
     const submoduleDir = join(current, monolithSubmodule);
     const subPluginsDir = join(submoduleDir, "plugins");
     if (existsSync(subPluginsDir) && statSync(subPluginsDir).isDirectory()) {
       return submoduleDir;
+    }
+
+    // ---- Check 2: does <current>/plugins/ exist? (generic fallback) ----
+    // Only reached when no agent-skills-marketplace/ submodule exists at this
+    // ancestor. This handles repo-agnostic checkouts where the current
+    // directory IS a skills root with a plugins/ subdirectory.
+    const directPlugins = join(current, "plugins");
+    if (existsSync(directPlugins) && statSync(directPlugins).isDirectory()) {
+      return current;
     }
 
     // Go up one level. resolve("..") on the root returns the root,

--- a/pi-packages/skills-bridge/extensions/skills-bridge/index.ts
+++ b/pi-packages/skills-bridge/extensions/skills-bridge/index.ts
@@ -28,7 +28,9 @@
  *     │     ├─ 1. RESOLVE skills roots        (where are the skills?)
  *     │     │     ├─ env var PI_SKILLS_PATH? → use it, skip everything else
  *     │     │     ├─ ~/.config/pi/skills-bridge.json? → use skillsPath
- *     │     │     └─ neither → walk up from cwd scanning for plugins/ dirs
+ *     │     │     └─ neither → walk up from cwd looking for a plugins/ dir
+ *     │     │                   (repo-agnostic: checks for plugins/ directly
+ *     │     │                    AND for agent-skills-marketplace/plugins/)
  *     │     │
  *     │     ├─ 2. DISCOVER skills under each root
  *     │     │     └─ scan plugins/* /skills/ recursively for SKILL.md dirs
@@ -283,11 +285,11 @@ function loadConfig(): BridgeConfig | null {
  *     a stale config entry shouldn't leave you with no skills.
  *
  *   Tier 3 — Cwd walk-up
- *     The automatic fallback. Walk up from the current directory looking
- *     for a directory that contains agent-skills-marketplace/plugins/.
- *     In a monolith checkout with the submodule initialized, this finds
- *     the skills root on the first try. Works from any depth inside the
- *     monolith (backend/, frontend/, any subdirectory).
+ *     The automatic fallback. Walks up from the current directory checking
+ *     two things at each ancestor: (a) does this directory itself have a
+ *     plugins/ subdirectory? (b) does it have an agent-skills-marketplace/
+ *     child with plugins/? This makes no-config discovery work for any
+ *     checkout with the right layout, not just the monolith submodule.
  *
  * DEDUPLICATION:
  *   Identical resolved paths only appear once. Node's path.resolve()
@@ -376,22 +378,37 @@ function findSkillRoots(cwd: string): string[] {
 }
 
 /**
- * Walk up the directory tree looking for agent-skills-marketplace/plugins/.
+ * Walk up the directory tree looking for a skills root.
+ *
+ * A "skills root" is any directory that contains a `plugins/` subdirectory
+ * (the Claude Code plugin layout). We check two things at each ancestor:
+ *
+ *   1. Does this directory itself have a plugins/ subdirectory?
+ *      → repo-agnostic: works for any checkout with the right layout.
+ *      If you run pi inside agent-skills-marketplace/ itself, it's found
+ *      immediately.
+ *
+ *   2. Does this directory have an agent-skills-marketplace/ child with
+ *      a plugins/ subdirectory inside it?
+ *      → monolith submodule convenience: the team's primary layout where
+ *      agent-skills-marketplace is a git submodule at the monolith root.
+ *
+ * Check 1 runs first so that a direct match (the cwd IS a skills root)
+ * wins over an indirect match via a submodule path.
  *
  * HOW IT WORKS — visual trace from a monolith checkout:
  *
  *   cwd = /work/monolith/backend/
  *
- *   iteration 0: check /work/monolith/backend/agent-skills-marketplace/plugins/
- *                → doesn't exist (backend/ is not the monolith root)
+ *   iteration 0: check /work/monolith/backend/plugins/ → no
+ *                check /work/monolith/backend/agent-skills-marketplace/plugins/ → no
  *                → go up to /work/monolith/
  *
- *   iteration 1: check /work/monolith/agent-skills-marketplace/plugins/
- *                → EXISTS! (submodule is at monolith root)
+ *   iteration 1: check /work/monolith/plugins/ → no
+ *                check /work/monolith/agent-skills-marketplace/plugins/ → YES!
  *                → return /work/monolith/agent-skills-marketplace
  *
- * This works from ANY depth inside the monolith — frontend/, backend/,
- * agent-skills-marketplace/plugins/, any subdirectory.
+ * This works from ANY depth inside the monolith.
  *
  * WHY WALK UP AND NOT JUST CHECK <cwd>/agent-skills-marketplace?
  *   A developer might start pi from backend/ or frontend/. Checking only
@@ -404,25 +421,34 @@ function findSkillRoots(cwd: string): string[] {
  *   we've reached the root (resolve("/..") === "/").
  *
  * WHAT IT RETURNS:
- *   The absolute path to the agent-skills-marketplace directory (NOT the
- *   plugins/ directory inside it). We return the skills root so that
- *   discoverSkills() can find plugins/ under it. This keeps the concern
- *   boundaries clean: walkUp finds the root, discoverSkills finds
- *   the skills inside it.
+ *   The absolute path to the skills root (the directory that contains the
+ *   plugins/ directory, either directly or via agent-skills-marketplace/).
+ *   This is NOT the plugins/ directory itself — discoverSkills() finds
+ *   plugins/ under the returned root.
  *
  * RETURN: Absolute path to skills root, or null if not found.
  */
 function walkUpFindSkillRoot(startDir: string): string | null {
-  const wanted = "agent-skills-marketplace";
+  const monolithSubmodule = "agent-skills-marketplace";
   let current = resolve(startDir);
 
   for (let depth = 0; depth < 64; depth++) {
-    // Does <current>/agent-skills-marketplace/plugins/ exist?
-    const candidate = join(current, wanted);
-    const pluginsDir = join(candidate, "plugins");
+    // ---- Check 1: does <current>/plugins/ exist? (repo-agnostic) ----
+    // The current directory IS a skills root if it directly contains
+    // a plugins/ subdirectory with the Claude Code plugin layout.
+    const directPlugins = join(current, "plugins");
+    if (existsSync(directPlugins) && statSync(directPlugins).isDirectory()) {
+      return current;
+    }
 
-    if (existsSync(pluginsDir) && statSync(pluginsDir).isDirectory()) {
-      return candidate;
+    // ---- Check 2: does <current>/agent-skills-marketplace/plugins/ exist? ----
+    // The monolith keeps agent-skills-marketplace as a git submodule.
+    // This is the team's most common layout, so we check for it as a
+    // convenience. Other submodule/repo names work via env var or config.
+    const submoduleDir = join(current, monolithSubmodule);
+    const subPluginsDir = join(submoduleDir, "plugins");
+    if (existsSync(subPluginsDir) && statSync(subPluginsDir).isDirectory()) {
+      return submoduleDir;
     }
 
     // Go up one level. resolve("..") on the root returns the root,
@@ -456,14 +482,25 @@ function walkUpFindSkillRoot(startDir: string): string | null {
  *       └── SKILL.md              ← FOUND
  *
  * A directory IS a skill directory if it directly contains a SKILL.md file.
- * The function continues recursing into subdirectories even after finding a
- * skill, because some plugins have nested skills (see plan-directory above).
+ * Once a skill directory is found, recursion STOPS at that boundary — Pi's
+ * skill loader treats that directory as the skill root, so we must not
+ * expose subdirectories (fixtures, templates, examples, vendored data) as
+ * separate top-level skills. Sibling skills (like plan-directory and
+ * backend-ralph-plan under the same skills/ directory) are still discovered
+ * because the parent directory is not a skill directory itself.
  *
  * WHY RECURSIVE AND NOT FLAT?
  *   A flat read of the skills/ directory would only find plan-directory/.
- *   It would miss backend-ralph-plan/ nested inside it. Recursive scanning
- *   catches both. This is necessary because the agentskills.io standard
- *   allows skill directories anywhere under skills/, not just at the top level.
+ *   It would miss backend-ralph-plan/ which is a sibling skill directory
+ *   (not nested inside plan-directory/). Recursive scanning catches all
+ *   sibling skills under plugins/<plugin>/skills/. This is necessary
+ *   because the agentskills.io standard allows skill directories anywhere
+ *   under skills/, not just at the top level.
+ *
+ * BUT: recursion STOPS at a discovered skill boundary. Subdirectories
+ *   inside a skill (references/, templates/, examples/) are never
+ *   descended into. This prevents accidental registration of fixture
+ *   or vendored SKILL.md files as separate top-level skills.
  *
  * WHY DEPTH LIMIT OF 5?
  *   The current plugin layout is:
@@ -516,10 +553,16 @@ function findSkillDirs(root: string, depth = 0): string[] {
     // named exactly "SKILL.md" (case-sensitive).
     if (existsSync(join(full, "SKILL.md"))) {
       results.push(full);
+      // Skill root boundary — Pi's skill loader treats a SKILL.md directory
+      // as the skill root and stops there. Do not recurse inside a discovered
+      // skill: fixtures, templates, examples, or vendored content with their
+      // own SKILL.md files must not be exposed as separate top-level skills.
+      continue;
     }
 
-    // Continue recursing. Even if we found SKILL.md here, there might be
-    // nested skills inside (e.g., plan-directory/skills/backend-ralph-plan/).
+    // Recurse into non-skill directories to discover nested skills.
+    // This handles sibling skills under plugins/<plugin>/skills/ (e.g.,
+    // plan-directory and backend-ralph-plan are siblings, not nested).
     results.push(...findSkillDirs(full, depth + 1));
   }
 

--- a/pi-packages/skills-bridge/extensions/skills-bridge/index.ts
+++ b/pi-packages/skills-bridge/extensions/skills-bridge/index.ts
@@ -1,0 +1,717 @@
+/**
+ * skills-bridge
+ * ============
+ *
+ * PROBLEM: The Diversio team has 21 agent skills (release-manager,
+ * monty-code-review, backend-atomic-commit, etc.) in the shared
+ * agent-skills-marketplace repo. These skills follow the agentskills.io
+ * standard — each is a directory with a SKILL.md file. Claude Code and
+ * Codex discover them automatically because those tools scan
+ * `plugins/* /skills/` directories. Pi users don't — pi only discovers
+ * skills from `~/.pi/agent/skills/` and `pi-packages/* /skills/`, not
+ * from `plugins/* /skills/`. The result: half the team can't see these
+ * skills in pi.
+ *
+ * WHAT THIS EXTENSION DOES: It bridges that gap. Using pi's
+ * `resources_discover` extension hook (the official mechanism for extensions
+ * to contribute skill paths), it scans the `plugins/* /skills/` directory
+ * tree under a skills root and registers every discovered `SKILL.md`
+ * directory as a pi skill. One `pi install`, then `/reload`, and all 21
+ * skills appear.
+ *
+ * HOW IT WORKS — high-level flow:
+ *
+ *   pi starts up
+ *     │
+ *     ├─ fires "resources_discover" event
+ *     │     │
+ *     │     ├─ 1. RESOLVE skills roots        (where are the skills?)
+ *     │     │     ├─ env var PI_SKILLS_PATH? → use it, skip everything else
+ *     │     │     ├─ ~/.config/pi/skills-bridge.json? → use skillsPath
+ *     │     │     └─ neither → walk up from cwd scanning for plugins/ dirs
+ *     │     │
+ *     │     ├─ 2. DISCOVER skills under each root
+ *     │     │     └─ scan plugins/* /skills/ recursively for SKILL.md dirs
+ *     │     │
+ *     │     └─ 3. RETURN skillPaths to pi
+ *     │           └─ pi loads each skill (name + description only, per progressive disclosure)
+ *     │
+ *     └─ pi is ready. User types /skill:release-manager → full SKILL.md loads on demand.
+ *
+ * CONTEXT SAFETY: This extension does NOT load full SKILL.md content. It only
+ * tells pi where the skill directories are. Pi's built-in progressive
+ * disclosure model handles the rest: at startup, only the skill's `name` and
+ * `description` (from SKILL.md YAML frontmatter) enter the system prompt
+ * (~5-10KB total for 21 skills). The full SKILL.md body only loads when the
+ * user explicitly invokes the skill via `/skill:name`. No context bloat.
+ *
+ * DEPENDENCIES: None beyond Node.js built-ins and pi's ExtensionAPI.
+ * The package has zero npm dependencies — everything uses `node:fs`, `node:os`,
+ * and `node:path`. This means zero `npm install` step after `pi install`.
+ *
+ * CONFIG FILE: Separate from both the extension code and pi's settings.json.
+ * Lives at ~/.config/pi/skills-bridge.json (XDG convention). Reason:
+ * pi manages its own settings.json (pi install, pi config). Writing custom keys
+ * there risks pi overwriting them. A separate XDG config file is:
+ *   - Never touched by pi tooling
+ *   - Never committed to version control (lives in home directory)
+ *   - Survives extension package updates (the extension repo changes don't
+ *     overwrite it)
+ *
+ * RESOLUTION ORDER — why this specific priority:
+ *
+ *   PI_SKILLS_PATH env var               ← "I know exactly what I want"
+ *         │ (if not set)
+ *   ~/.config/pi/skills-bridge.json      ← "I want persistent config"
+ *         │ (if skillsPath not set)
+ *   cwd walk-up                          ← "Just find it automatically"
+ *
+ * The env var is highest priority because it's an explicit, session-level
+ * override. Setting it means "use this exact path, ignore everything else."
+ * This is why additionalPaths from config are NOT merged when the env var is
+ * set — the developer made a deliberate choice to override.
+ *
+ * The config file is second because it's a persistent preference that survives
+ * terminal restarts. The cwd walk-up is the fallback that works automatically
+ * for anyone with a monolith checkout containing a plugins/ directory.
+ *
+ * ADDITIONAL PATHS: Why are they separate from skillsPath?
+ * A developer might want skills from two sources simultaneously:
+ *   - The team's primary skills root (skillsPath)
+ *   - Their personal experimental skills (additionalPaths)
+ * Both are scanned and their skills are merged. This is useful for testing new
+ * skills before they're merged into the team skills root.
+ *
+ * SKILL DISCOVERY: Why recursive + depth-limited?
+ * The plugin layout is plugins/<plugin>/skills/<skill>/SKILL.md.
+ * That's 3 levels deep. Some plugins have nested skills (e.g., plan-directory
+ * has both plan-directory/ and backend-ralph-plan/ under skills/). A flat
+ * read of skills/ would miss nested skill directories. Recursive scanning
+ * finds them all. The depth limit of 5 prevents infinite recursion from
+ * symlink loops or unusual structures while giving enough headroom for
+ * nested skill groupings.
+ *
+ * WHY ONLY plugins/* /skills/ AND NOT commands/?
+ * Claude Code's commands/*.md files are thin wrappers that delegate to skills.
+ * For example, `commands/review-prs.md` contains `/skill:monolith-review-orchestrator`.
+ * Pi has its own command system (`/skill:name` and extensions' `registerCommand`).
+ * The skill content itself is what matters — commands are a Claude Code UX
+ * convention. Bridging commands would duplicate functionality pi already has.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+// =========================================================================
+// NAVIGATION — this file is ~700 lines. Jump to:
+//   § loadConfig()              — reads ~/.config/pi/skills-bridge.json
+//   § findSkillRoots()           — three-tier resolution logic
+//   § walkUpFindSkillRoot()      — cwd walk-up with visual trace
+//   § findSkillDirs()            — recursive SKILL.md discovery
+//   § discoverSkills()           — scans plugins/* /skills/ layout
+//   § export default function    — extension entry point (resources_discover)
+// =========================================================================
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of the per-developer config file at ~/.config/pi/skills-bridge.json.
+ *
+ * Both fields are optional:
+ *   - skillsPath: primary skills root. When absent, falls through to
+ *     cwd walk-up. When present, use this as the primary root and skip walk-up.
+ *   - additionalPaths: extra skills roots scanned alongside the primary.
+ *     Always merged (unless env var is set, which overrides everything).
+ *     Useful for personal skill collections or testing checkouts.
+ *
+ * An empty file {} is valid and means "use cwd walk-up only."
+ */
+interface BridgeConfig {
+  skillsPath?: string;
+  additionalPaths?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Config loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Read and parse the XDG config file.
+ *
+ * PATH: ~/.config/pi/skills-bridge.json
+ *   (respects $XDG_CONFIG_HOME if set, falls back to ~/.config)
+ *
+ * WHY A SEPARATE FILE AND NOT pi's settings.json?
+ *   pi's settings.json is managed by pi itself (pi install, pi config,
+ *   pi remove). Writing custom keys there risks pi overwriting them on future
+ *   updates. A separate file under ~/.config/pi/ follows XDG conventions
+ *   and is never touched by pi tooling. The file also lives outside the
+ *   extension repo, so updating the repo never overwrites local config.
+ *
+ * ERROR HANDLING STRATEGY:
+ *   Every error is non-fatal. If the file doesn't exist, return null and
+ *   fall through to cwd walk-up. If the JSON is malformed, log a warning
+ *   and return null. If individual fields are wrong types, log a warning
+ *   for that field and continue parsing the rest. The extension must never
+ *   crash pi because of a bad config file — a developer's hand-edited typo
+ *   shouldn't prevent pi from starting.
+ *
+ * RETURN:
+ *   BridgeConfig on success (may be empty {}), null on missing/invalid file.
+ */
+function loadConfig(): BridgeConfig | null {
+  // Resolve config directory per XDG spec.
+  // $XDG_CONFIG_HOME/pi/skills-bridge.json, or ~/.config/pi/...
+  const configHome = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  const configPath = join(configHome, "pi", "skills-bridge.json");
+
+  // ---- Read the file ----
+  // sync is fine here: we're in startup, this file is ~100 bytes, and we
+  // need the result before we can continue discovery.
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, "utf8");
+  } catch {
+    // File doesn't exist or permission denied — not an error.
+    // Most developers will never create this file; cwd walk-up handles them.
+    return null;
+  }
+
+  // ---- Parse JSON ----
+  // Catch JSON.parse errors separately from file-read errors so we can
+  // give a specific warning message that helps the developer fix their typo.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    console.warn(
+      `[skills-bridge] Invalid JSON in ${configPath}: ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        `Falling through to cwd walk-up.`,
+    );
+    return null;
+  }
+
+  // ---- Validate top-level shape ----
+  // Must be a plain object. Arrays (valid JSON) and primitives (also valid)
+  // are not meaningful config files for us.
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    console.warn(
+      `[skills-bridge] Config at ${configPath} must be a JSON object. ` +
+        `Falling through to cwd walk-up.`,
+    );
+    return null;
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const config: BridgeConfig = {};
+
+  // ---- skillsPath ----
+  // Primary skills root. When set, this replaces cwd walk-up.
+  // When absent or empty, walk-up handles discovery automatically.
+  if (obj.skillsPath !== undefined) {
+    if (typeof obj.skillsPath !== "string" || obj.skillsPath.trim().length === 0) {
+      console.warn(
+        `[skills-bridge] Config skillsPath must be a non-empty string. Ignoring.`,
+      );
+    } else {
+      config.skillsPath = obj.skillsPath.trim();
+    }
+  }
+
+  // ---- additionalPaths ----
+  // Extra skills roots scanned alongside the primary.
+  // Typical use: a developer keeps personal/experimental skills in a separate
+  // checkout and wants them available alongside the team skills root.
+  // Each entry that is a non-empty string is kept; everything else is warned
+  // and skipped (so one bad entry doesn't discard all the good ones).
+  if (obj.additionalPaths !== undefined) {
+    if (!Array.isArray(obj.additionalPaths)) {
+      console.warn(
+        `[skills-bridge] Config additionalPaths must be an array. Ignoring.`,
+      );
+    } else {
+      const paths: string[] = [];
+      for (const item of obj.additionalPaths) {
+        if (typeof item === "string" && item.trim().length > 0) {
+          paths.push(item.trim());
+        } else {
+          console.warn(
+            `[skills-bridge] Skipping non-string additionalPaths entry: ` +
+              `${JSON.stringify(item)}`,
+          );
+        }
+      }
+      config.additionalPaths = paths;
+    }
+  }
+
+  return config;
+}
+
+// ---------------------------------------------------------------------------
+// Skills root resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the ordered set of skills root directories.
+ *
+ * This is the central decision function: "where are the skills?"
+ * It implements a three-tier priority system so that:
+ *   - A developer who needs a one-off override can set an env var.
+ *   - A developer with a persistent non-standard layout can set a config file.
+ *   - Everyone else gets automatic discovery via cwd walk-up.
+ *
+ * THREE-TIER RESOLUTION:
+ *
+ *   Tier 1 — PI_SKILLS_PATH env var
+ *     When set, this is the ONLY skills root. Config file and cwd
+ *     walk-up are both ignored. additionalPaths from config are also NOT
+ *     merged — the developer made an explicit choice to override. If they
+ *     want env-var + extra paths, they should use the config file instead.
+ *     If the path doesn't exist, we warn and return empty (graceful skip).
+ *
+ *   Tier 2 — Config file skillsPath
+ *     When set (and env var is not), this becomes the primary root.
+ *     additionalPaths from config are merged in alongside it.
+ *     If the path doesn't exist, we warn and fall through to cwd walk-up —
+ *     a stale config entry shouldn't leave you with no skills.
+ *
+ *   Tier 3 — Cwd walk-up
+ *     The automatic fallback. Walk up from the current directory looking
+ *     for a directory that contains agent-skills-marketplace/plugins/.
+ *     In a monolith checkout with the submodule initialized, this finds
+ *     the skills root on the first try. Works from any depth inside the
+ *     monolith (backend/, frontend/, any subdirectory).
+ *
+ * DEDUPLICATION:
+ *   Identical resolved paths only appear once. Node's path.resolve()
+ *   normalizes paths (trailing slashes, . and .. segments), so the simple
+ *   string comparison results.includes(resolved) is sufficient.
+ *
+ * RETURN: Array of absolute paths to skills root directories.
+ *   Empty array means "no skills root found — skip silently."
+ */
+function findSkillRoots(cwd: string): string[] {
+  // ---- Tier 1: env var (highest priority) ----
+  // A developer who sets PI_SKILLS_PATH is saying "use this exact
+  // skills root." We respect that by skipping all other discovery.
+  const envPath = process.env.PI_SKILLS_PATH?.trim();
+  if (envPath) {
+    const resolved = resolve(envPath);
+    if (!existsSync(resolved)) {
+      console.warn(
+        `[skills-bridge] PI_SKILLS_PATH is set but path doesn't exist: ` +
+          `${resolved}. Skipping skills discovery.`,
+      );
+      return [];
+    }
+    return [resolved];
+  }
+
+  // ---- Load config (may be null if file missing or invalid) ----
+  const config = loadConfig();
+  const results: string[] = [];
+
+  // ---- Tier 2: config file skillsPath ----
+  // The developer's persistent preference. We validate that the path exists
+  // before using it — a config that pointed at an old checkout that was
+  // deleted shouldn't silently fail.
+  if (config?.skillsPath) {
+    const resolved = resolve(config.skillsPath);
+    if (existsSync(resolved)) {
+      results.push(resolved);
+    } else {
+      console.warn(
+        `[skills-bridge] Config skillsPath doesn't exist: ${resolved}. ` +
+          `Falling through to cwd walk-up.`,
+      );
+    }
+  }
+
+  // ---- Tier 3: cwd walk-up (automatic fallback) ----
+  // Only runs when no primary root was found via config. This handles:
+  //   - Developers who never created a config file (the common case)
+  //   - Developers whose config skillsPath pointed at a nonexistent path
+  // Walk-up always uses the event's cwd (pi's working directory), not
+  // process.cwd(), because they could differ in forked sessions.
+  if (results.length === 0) {
+    const walked = walkUpFindSkillRoot(cwd);
+    if (walked) {
+      results.push(walked);
+    }
+  }
+
+  // ---- Merge additionalPaths (only when env var is NOT set) ----
+  // additionalPaths supplement the primary root. They're useful for:
+  //   - Personal skill collections (experimental skills)
+  //   - Multiple monolith checkouts (different branches, different submodule states)
+  //   - Testing new skills before merging to the team skills root
+  // Each path is validated; bad ones are warned and skipped individually
+  // so one typo doesn't discard all additional paths.
+  if (config?.additionalPaths && config.additionalPaths.length > 0) {
+    for (const raw of config.additionalPaths) {
+      const resolved = resolve(raw);
+      if (!existsSync(resolved)) {
+        console.warn(
+          `[skills-bridge] Config additionalPaths entry doesn't exist: ` +
+            `${resolved}. Skipping.`,
+        );
+        continue;
+      }
+      // Deduplicate: if the same skills root is already in results
+      // (e.g., from config skillsPath or cwd walk-up), don't scan twice.
+      if (!results.includes(resolved)) {
+        results.push(resolved);
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Walk up the directory tree looking for agent-skills-marketplace/plugins/.
+ *
+ * HOW IT WORKS — visual trace from a monolith checkout:
+ *
+ *   cwd = /work/monolith/backend/
+ *
+ *   iteration 0: check /work/monolith/backend/agent-skills-marketplace/plugins/
+ *                → doesn't exist (backend/ is not the monolith root)
+ *                → go up to /work/monolith/
+ *
+ *   iteration 1: check /work/monolith/agent-skills-marketplace/plugins/
+ *                → EXISTS! (submodule is at monolith root)
+ *                → return /work/monolith/agent-skills-marketplace
+ *
+ * This works from ANY depth inside the monolith — frontend/, backend/,
+ * agent-skills-marketplace/plugins/, any subdirectory.
+ *
+ * WHY WALK UP AND NOT JUST CHECK <cwd>/agent-skills-marketplace?
+ *   A developer might start pi from backend/ or frontend/. Checking only
+ *   one level would miss it. Walking up handles all depths.
+ *
+ * WHY THE 64-ITERATION LIMIT?
+ *   Prevents infinite loops if there's a symlink cycle or unusual filesystem
+ *   layout. 64 levels up from any reasonable directory reaches the filesystem
+ *   root on any OS. The loop also checks parent === current to detect when
+ *   we've reached the root (resolve("/..") === "/").
+ *
+ * WHAT IT RETURNS:
+ *   The absolute path to the agent-skills-marketplace directory (NOT the
+ *   plugins/ directory inside it). We return the skills root so that
+ *   discoverSkills() can find plugins/ under it. This keeps the concern
+ *   boundaries clean: walkUp finds the root, discoverSkills finds
+ *   the skills inside it.
+ *
+ * RETURN: Absolute path to skills root, or null if not found.
+ */
+function walkUpFindSkillRoot(startDir: string): string | null {
+  const wanted = "agent-skills-marketplace";
+  let current = resolve(startDir);
+
+  for (let depth = 0; depth < 64; depth++) {
+    // Does <current>/agent-skills-marketplace/plugins/ exist?
+    const candidate = join(current, wanted);
+    const pluginsDir = join(candidate, "plugins");
+
+    if (existsSync(pluginsDir) && statSync(pluginsDir).isDirectory()) {
+      return candidate;
+    }
+
+    // Go up one level. resolve("..") on the root returns the root,
+    // so this won't loop forever even without the depth limit.
+    const parent = resolve(current, "..");
+    if (parent === current) break; // reached filesystem root
+    current = parent;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Skill discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively find all directories under `root` that contain a SKILL.md file.
+ *
+ * HOW IT WORKS — visual trace:
+ *
+ *   skills/
+ *   ├── plan-directory/
+ *   │   ├── SKILL.md              ← FOUND (plan-directory is a skill)
+ *   │   ├── references/
+ *   │   │   └── some-guide.md     ← ignored (no SKILL.md)
+ *   │   └── backend-ralph-plan/
+ *   │       ├── SKILL.md          ← FOUND (backend-ralph-plan is a skill)
+ *   │       └── references/
+ *   └── pr-description-writer/
+ *       └── SKILL.md              ← FOUND
+ *
+ * A directory IS a skill directory if it directly contains a SKILL.md file.
+ * The function continues recursing into subdirectories even after finding a
+ * skill, because some plugins have nested skills (see plan-directory above).
+ *
+ * WHY RECURSIVE AND NOT FLAT?
+ *   A flat read of the skills/ directory would only find plan-directory/.
+ *   It would miss backend-ralph-plan/ nested inside it. Recursive scanning
+ *   catches both. This is necessary because the agentskills.io standard
+ *   allows skill directories anywhere under skills/, not just at the top level.
+ *
+ * WHY DEPTH LIMIT OF 5?
+ *   The current plugin layout is:
+ *     plugins/<plugin>/skills/<skill>/SKILL.md  = depth 3
+ *   With nesting (plan-directory/skills/backend-ralph-plan/):
+ *     plugins/<plugin>/skills/<skill>/<nested-skill>/SKILL.md = depth 4
+ *   The limit of 5 provides headroom for deeper nesting while preventing
+ *   infinite recursion from symlink loops or unusual directory structures.
+ *
+ * ERROR HANDLING:
+ *   readdirSync and statSync are wrapped in try/catch. If a directory is
+ *   unreadable (permission error, broken symlink), we skip it and continue
+ *   with the rest. A single inaccessible directory shouldn't prevent the
+ *   rest of the skills from being discovered.
+ *
+ * RETURN: Array of absolute paths to directories containing SKILL.md.
+ */
+function findSkillDirs(root: string, depth = 0): string[] {
+  // Depth guard: prevents infinite recursion from symlink cycles.
+  if (depth > 5) return [];
+
+  const results: string[] = [];
+  let entries: string[];
+
+  // If we can't read the directory (permissions, doesn't exist, etc.),
+  // just return what we have so far. Don't crash.
+  try {
+    entries = readdirSync(root);
+  } catch {
+    return results;
+  }
+
+  for (const entry of entries) {
+    const full = join(root, entry);
+
+    // Skip non-directories (files, symlinks to files, etc.).
+    // We only care about directories because skills are directories
+    // containing SKILL.md.
+    let isDir: boolean;
+    try {
+      isDir = statSync(full).isDirectory();
+    } catch {
+      // Broken symlink, permission error, etc. Skip.
+      continue;
+    }
+    if (!isDir) continue;
+
+    // KEY CHECK: a directory is a skill directory if it contains SKILL.md.
+    // This is the agentskills.io standard — the file must exist and be
+    // named exactly "SKILL.md" (case-sensitive).
+    if (existsSync(join(full, "SKILL.md"))) {
+      results.push(full);
+    }
+
+    // Continue recursing. Even if we found SKILL.md here, there might be
+    // nested skills inside (e.g., plan-directory/skills/backend-ralph-plan/).
+    results.push(...findSkillDirs(full, depth + 1));
+  }
+
+  return results;
+}
+
+/**
+ * Discover all skill directories under a skills root's plugins/ tree.
+ *
+ * A "skills root" is any directory containing a `plugins/` subdirectory
+ * with Claude Code-style plugin folders underneath. For example:
+ *   /Users/alice/work/monolith/agent-skills-marketplace  ← skills root
+ *   /Users/alice/work/monolith/agent-skills-marketplace/plugins/ ← plugins
+ *   .../plugins/monty-code-review/skills/monty-code-review/ ← skill dir
+ *
+ * This function bridges the Claude Code plugin layout to pi's skill model.
+ *
+ * CLAUDE CODE LAYOUT (what exists):
+ *   agent-skills-marketplace/
+ *   └── plugins/
+ *       ├── monty-code-review/          ← plugin (Claude Code install unit)
+ *       │   ├── .claude-plugin/
+ *       │   │   └── plugin.json
+ *       │   ├── skills/
+ *       │   │   └── monty-code-review/  ← skill dir (contains SKILL.md)
+ *       │   │       └── SKILL.md
+ *       │   └── commands/               ← Claude Code only (we skip these)
+ *       │       └── code-review.md
+ *       ├── backend-release/
+ *       │   └── skills/
+ *       │       └── release-manager/    ← skill dir (different name than plugin!)
+ *       │           └── SKILL.md
+ *       └── plan-directory/
+ *           └── skills/
+ *               ├── plan-directory/     ← skill dir
+ *               │   └── SKILL.md
+ *               └── backend-ralph-plan/ ← nested skill dir
+ *                   └── SKILL.md
+ *
+ * PI SKILL MODEL (what we produce):
+ *   Returns paths like:
+ *     /path/to/plugins/monty-code-review/skills/monty-code-review
+ *     /path/to/plugins/backend-release/skills/release-manager
+ *     /path/to/plugins/plan-directory/skills/plan-directory
+ *     /path/to/plugins/plan-directory/skills/backend-ralph-plan
+ *
+ * Pi then reads SKILL.md from each path and extracts name + description
+ * from the YAML frontmatter. The skill name comes from the SKILL.md
+ * frontmatter, NOT from the directory name (though by convention they match).
+ *
+ * WHAT WE SKIP AND WHY:
+ *   - commands/ directories — these are Claude Code UX wrappers. They
+ *     contain slash-command definitions like `/monty-code-review:code-review`
+ *     that delegate to skills. Pi has its own `/skill:name` invocation
+ *     system, so these aren't needed.
+ *   - .claude-plugin/ directories — Claude Code package manifests.
+ *     Not relevant to pi.
+ *   - references/, scripts/, assets/ — loaded on demand by pi when a
+ *     skill is invoked (progressive disclosure). We don't need to register
+ *     these separately; pi discovers them relative to the skill directory.
+ *
+ * ERROR HANDLING:
+ *   If plugins/ doesn't exist or can't be read, we warn and return empty.
+ *   Individual plugin directories that lack a skills/ subdirectory are
+ *   silently skipped (some plugins might only have commands, no skills).
+ *   Plugin directories that can't be read are also silently skipped.
+ *
+ * RETURN: Array of absolute paths to skill directories (containing SKILL.md).
+ */
+function discoverSkills(skillsRoot: string): string[] {
+  const pluginsDir = join(skillsRoot, "plugins");
+
+  // The root might not have a plugins/ directory (e.g., if the
+  // path points to a different kind of repo). Warn and skip.
+  if (!existsSync(pluginsDir)) {
+    console.warn(
+      `[skills-bridge] No plugins/ directory found at ${pluginsDir}. ` +
+        `Skipping this skills root.`,
+    );
+    return [];
+  }
+
+  // Read the list of plugin directories. Each subdirectory of plugins/
+  // is a Claude Code plugin that MAY contain skills.
+  let pluginNames: string[];
+  try {
+    pluginNames = readdirSync(pluginsDir);
+  } catch {
+    console.warn(
+      `[skills-bridge] Cannot read plugins/ directory at ${pluginsDir}.`,
+    );
+    return [];
+  }
+
+  const skillDirs: string[] = [];
+
+  for (const pluginName of pluginNames) {
+    // Claude Code plugins store skills under plugins/<plugin>/skills/.
+    // We check for this specific path — if it doesn't exist, this plugin
+    // has no skills to bridge (it might be commands-only, or a non-plugin
+    // directory like a README).
+    const skillsDir = join(pluginsDir, pluginName, "skills");
+
+    if (!existsSync(skillsDir)) continue;
+
+    // Double-check it's actually a directory, not a file named "skills".
+    let isDir: boolean;
+    try {
+      isDir = statSync(skillsDir).isDirectory();
+    } catch {
+      continue;
+    }
+    if (!isDir) continue;
+
+    // Recursively discover skill directories under this plugin's skills/.
+    // findSkillDirs handles nested skills (like plan-directory containing
+    // backend-ralph-plan).
+    const found = findSkillDirs(skillsDir);
+    skillDirs.push(...found);
+  }
+
+  return skillDirs;
+}
+
+// ---------------------------------------------------------------------------
+// Extension entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Pi extension entry point.
+ *
+ * This is the function pi calls when loading the extension. It receives the
+ * ExtensionAPI object and uses it to subscribe to lifecycle events.
+ *
+ * We subscribe to exactly ONE event: `resources_discover`. This is the
+ * canonical pi extension hook for contributing skill paths. It fires after
+ * `session_start` so we have access to the working directory.
+ *
+ * WHY resources_discover AND NOT settings.json?
+ *   pi's settings.json supports `"skills": ["~/.claude/skills"]` but that
+ *   only works for flat skill directories. This layout uses a nested
+ *   plugin structure (plugins/* /skills/) that the flat path setting can't
+ *   express. resources_discover gives us full control to walk the directory
+ *   tree and return exactly the right paths.
+ *
+ * FLOW:
+ *   1. pi fires "resources_discover" with the current working directory
+ *   2. We resolve skills roots (env var → config → walk-up)
+ *   3. We discover skill directories under each root
+ *   4. We return { skillPaths: [...] } to pi
+ *   5. Pi loads each skill (name + description only, per progressive disclosure)
+ *
+ * When no skills root is found (no roots, or roots with no skills), we return
+ * undefined. Pi continues normally as if the extension wasn't there. This is
+ * important: a missing skills root shouldn't prevent pi from starting.
+ *
+ * We use an async handler because pi requires all `resources_discover`
+ * handlers to be async (they can return promises). Our code is synchronous
+ * internally, but the async wrapper satisfies pi's contract.
+ */
+export default function (pi: ExtensionAPI) {
+  pi.on("resources_discover", async (event) => {
+    // Step 1: Where are the skills?
+    //   Empty array = nowhere. We return undefined (graceful skip).
+    const roots = findSkillRoots(event.cwd);
+    if (roots.length === 0) {
+      return;
+    }
+
+    // Step 2: What skills are in each skills root?
+    //   Collect all skill directory paths across all roots.
+    //   Multiple roots are supported (e.g., team skills root + personal
+    //   skills root via additionalPaths). All skills from all roots are
+    //   merged into one flat list.
+    const allSkillDirs: string[] = [];
+
+    for (const root of roots) {
+      const skillDirs = discoverSkills(root);
+      allSkillDirs.push(...skillDirs);
+    }
+
+    // Step 3: Tell pi about the discovered skills.
+    //   Pi handles name-collision warnings (if a skill exists in both
+    //   ~/.pi/agent/skills/ and the skills root).
+    //   Pi handles progressive disclosure (only name + description at
+    //   startup, full SKILL.md on demand).
+    if (allSkillDirs.length === 0) {
+      return;
+    }
+
+    return {
+      skillPaths: allSkillDirs,
+    };
+  });
+}

--- a/pi-packages/skills-bridge/package.json
+++ b/pi-packages/skills-bridge/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "skills-bridge",
+  "version": "0.1.0",
+  "description": "Pi extension that auto-discovers Claude Code plugin skills from plugins/*/skills/ directories and registers them as pi skills via the resources_discover hook. One install bridges all 21 plugin skills into pi.",
+  "keywords": ["pi-package", "skills", "bridge"],
+  "files": ["extensions/", "README.md"],
+  "pi": {
+    "extensions": ["./extensions/skills-bridge/index.ts"]
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*"
+  }
+}

--- a/pi-packages/skills-bridge/package.json
+++ b/pi-packages/skills-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skills-bridge",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Pi extension that auto-discovers Claude Code plugin skills from plugins/*/skills/ directories and registers them as pi skills via the resources_discover hook. One install bridges all 21 plugin skills into pi.",
   "keywords": ["pi-package", "skills", "bridge"],
   "files": ["extensions/", "README.md"],


### PR DESCRIPTION
## Problem

The team has 21 Claude Code plugin skills in this repo. Claude Code and Codex users see them automatically. **Pi users don't** — pi only discovers skills from `~/.pi/agent/skills/` and `pi-packages/*/skills/`, not from `plugins/*/skills/`.

## Solution

Add a `skills-bridge` pi package that uses pi's `resources_discover` extension hook to scan the `plugins/*/skills/` directories and register them as pi skills. One `pi install` per team member, then `/reload`, and all 21 skills appear.

**Named "skills-bridge"** because the extension doesn't know or care about any specific repo — it scans any directory with a `plugins/*/skills/` layout. The env var is `PI_SKILLS_PATH` and the config field is `skillsPath`.

### How it works

```
pi starts up
  │
  ├─ fires "resources_discover" event
  │     │
  │     ├─ 1. RESOLVE skills root
  │     │     ├─ PI_SKILLS_PATH env var? → use it
  │     │     ├─ ~/.config/pi/skills-bridge.json? → use skillsPath
  │     │     └─ neither → walk up from cwd
  │     │
  │     ├─ 2. DISCOVER skills under each root
  │     │     └─ Scan plugins/*/skills/ recursively for SKILL.md dirs
  │     │
  │     └─ 3. RETURN skillPaths to pi
  │           └─ Pi loads name + description only (progressive disclosure)
  │
  └─ Ready. /skill:release-manager loads full SKILL.md on demand.
```

### Key design decisions

| Decision | Rationale |
|----------|-----------|
| **`resources_discover` hook** (not settings.json) | pi's settings.json `"skills"` field only supports flat directories. The plugin layout (`plugins/*/skills/`) requires programmatic discovery |
| **XDG config file** (not pi settings.json) | pi manages its own settings.json. A separate `~/.config/pi/skills-bridge.json` follows XDG conventions and is never overwritten by pi tooling |
| **Env var bypasses config** | When a dev sets `PI_SKILLS_PATH`, they're making an explicit choice. Merging `additionalPaths` in that case would be surprising |
| **Recursive + depth-limited scanning** | Some plugins have nested skills (e.g., `plan-directory` contains both `plan-directory` and `backend-ralph-plan`). Depth limit of 5 prevents infinite recursion |
| **Zero npm dependencies** | Only `node:fs`, `node:os`, `node:path`. No `npm install` step needed after `pi install` |
| **Graceful errors throughout** | Missing skills root? Silent skip. Invalid config JSON? Warning, fall through to walk-up. Broken symlink in a plugin? Skip that one, continue with the rest |

### Context safety

Only skill **names + descriptions** (~5-10KB for 21 skills) enter the system prompt at startup. Full SKILL.md bodies load on demand when a skill is invoked. Pi implements progressive disclosure per the agentskills.io standard.

## Changes

### New files
- `pi-packages/skills-bridge/extensions/skills-bridge/index.ts` — extension with discovery logic, config loading, three-tier resolution, recursive SKILL.md scanning
- `pi-packages/skills-bridge/package.json` — package manifest (pi-package, v0.1.0, peerDep on pi)
- `pi-packages/skills-bridge/README.md` — install guide, config file docs, troubleshooting, team setup

### Modified files
- `README.md` — added `skills-bridge` to pi packages table + install commands
- `docs/plugins/catalog.md` — full catalog entry with purpose, install, paths, skills list, context safety
- `docs/runbooks/distribution.md` — install commands in all four sections (global, monolith-root, `-e`, `-l`)

## Verification

### Standalone discovery test (21 skills)
```
  backend-atomic-commit, backend-pr-workflow, release-manager, bruno-api,
  clickup-ticket, code-review-digest-writer, dependabot-remediation, frontend,
  github-ticket, login-cta-attribution-skill, mixpanel-analytics,
  monolith-review-orchestrator, monty-code-review, backend-ralph-plan,
  plan-directory, pr-description-writer, process-code-review,
  repo-docs-generator, terraform-atomic-commit, terraform-pr-workflow,
  visual-explainer
```

### RPC smoke test
```json
{"success": true, "commands": [21 skills registered with names and descriptions]}
```

### Config file tests
- No config file → falls through to cwd walk-up ✅
- Valid config with `skillsPath` → uses specified path ✅
- Invalid JSON → warning logged, falls through ✅
- Empty object `{}` → same as no config ✅
- `PI_SKILLS_PATH=/nonexistent` → skips silently, no crash ✅

### npm pack
```
3 files, 36.6KB unpacked (README + extension + package.json)
```

## Team install

Each team member runs one command from the monolith root:

```bash
pi install "$PWD/agent-skills-marketplace/pi-packages/skills-bridge"
```

Then `/reload`. Skills appear immediately. Global install persists across git worktrees.

### Config file (optional)

For non-standard layouts, create `~/.config/pi/skills-bridge.json`:

```json
{
  "skillsPath": "/absolute/path/to/agent-skills-marketplace",
  "additionalPaths": ["/another/path"]
}
```

Closes #70