### PR TITLE
Add root package.json with pi manifest for git-based installs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,14 @@ marketplace plugin shape.
 
 Keep the package `README.md`, `package.json`, `docs/runbooks/distribution.md`,
 `docs/plugins/catalog.md`, and the top-level `README.md` in sync when commands,
-shortcuts, install paths, or packaged resources change. If a package exposes an
+shortcuts, install paths, or packaged resources change.
+
+**When adding or removing a pi package**, update the root `package.json`
+`pi.extensions` and `pi.skills` arrays so the git-based install stays accurate.
+The root manifest is the single entrypoint that lets `pi install
+git:github.com/DiversioTeam/agent-skills-marketplace` discover every
+sub-package. If you add a package without updating the root manifest, git
+install users won't see it. If a package exposes an
 interactive TUI, document its keybindings in terms of Pi keybinding ids when
 possible (for example, `app.message.followUp`) so custom user bindings still
 make sense. Bump the package version when publishing an update rather than only

--- a/README.md
+++ b/README.md
@@ -276,11 +276,16 @@ agent-skills-marketplace/
 
 ## Available Pi Packages
 
-| Package | Description | Install |
-|---------|-------------|---------|
-| `ci-status` | Pi-native CI status extension with `/ci`, `/ci-detail`, `/ci-logs`, auto-watch after pushes, widget/status rendering, GitHub Actions + CircleCI support, and LLM CI tools | `pi install "$PWD/pi-packages/ci-status"` |
-| `dev-workflow` | Pi-native daily developer workflow with 15 core workflow prompts, `/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`, XDG/project prompt config, CI analysis, PR review feedback, release PR prep, local skills, and optional pi-subagents chain | `pi install "$PWD/pi-packages/dev-workflow"` |
-| `skills-bridge` | Auto-discovers all 21 Claude Code plugin skills from plugins/*/skills/ and registers them as pi skills. One install bridges the gap between the plugin ecosystem and pi | `pi install "$PWD/pi-packages/skills-bridge"` |
+All three packages are installable together from one git URL (recommended) or
+individually from a local checkout. The root `package.json` declares every
+sub-package so pi can discover them from a single clone — see
+[Git-based install](#git-based-install-recommended) for the one-liner.
+
+| Package | Description |
+|---------|-------------|
+| `ci-status` | Pi-native CI status extension with `/ci`, `/ci-detail`, `/ci-logs`, auto-watch after pushes, widget/status rendering, GitHub Actions + CircleCI support, and LLM CI tools |
+| `dev-workflow` | Pi-native daily developer workflow with 15 core workflow prompts, `/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`, XDG/project prompt config, CI analysis, PR review feedback, release PR prep, local skills, and optional pi-subagents chain |
+| `skills-bridge` | Auto-discovers all 21 Claude Code plugin skills from plugins/*/skills/ and registers them as pi skills. One install bridges the gap between the plugin ecosystem and pi |
 
 ## Installation
 
@@ -306,8 +311,43 @@ Project-scope plugins don't persist across worktrees.
 ### Pi-native packages
 
 Pi-native packages live under `pi-packages/` and install with the pi CLI instead
-of the Claude Code marketplace. For normal use, install them globally from an
-absolute local path:
+of the Claude Code marketplace.
+
+#### Git-based install (recommended)
+
+A root `package.json` at the top of this repo declares every sub-package so pi
+can discover `ci-status`, `dev-workflow`, and `skills-bridge` from one clone:
+
+```bash
+pi install git:github.com/DiversioTeam/agent-skills-marketplace
+```
+
+Run `/reload` in pi after installation. To pull the latest updates later:
+
+```bash
+pi update --extensions
+```
+
+**Why this exists.** Before this root manifest, each package needed its own
+`pi install "$PWD/pi-packages/<pkg>"` command. Those local paths were relative to
+whichever worktree you happened to be in. Two problems emerged:
+
+1. **Duplicate extensions.** If the same package was installed from two different
+   worktrees (e.g. `monolith/agent-skills-marketplace` and
+   `monolith-for-release/agent-skills-marketplace`), pi saw them as distinct
+   packages because their resolved absolute paths differed. Both copies loaded,
+   producing duplicate tool registrations and confusing `[Extensions]` output.
+2. **Fragile paths.** When a worktree was deleted, pi failed to find the package
+   at the old path. Team members on different machines or worktrees inevitably
+   had different paths.
+
+The git-based install solves both: one stable URL that works on any machine,
+any worktree, and always loads exactly one copy of each extension.
+
+#### Local-path install (legacy)
+
+If you need to install from a local checkout — for example, when testing a
+local change before pushing:
 
 ```bash
 pi install "$PWD/pi-packages/ci-status"

--- a/docs/runbooks/distribution.md
+++ b/docs/runbooks/distribution.md
@@ -128,6 +128,46 @@ Troubleshooting:
 Pi-native packages live under `pi-packages/` and are installed with the pi CLI,
 not the Claude Code marketplace.
 
+### Git-based install (recommended)
+
+The root `package.json` at the top of this repo declares every sub-package so pi
+can discover all three from a single clone. One command replaces three:
+
+```bash
+pi install git:github.com/DiversioTeam/agent-skills-marketplace
+```
+
+Run `/reload` in pi after installation. To pull the latest updates later:
+
+```bash
+pi update --extensions
+```
+
+This does a `git pull` on the cloned repo and reloads all extensions and
+skills. Versions are not pinned, so `pi update --extensions` always fetches
+the latest `main`. If you want to freeze at a known version, pin the install
+with a tag:
+
+```bash
+pi install git:github.com/DiversioTeam/agent-skills-marketplace@v0.0.1
+```
+
+Pinned refs are skipped by `pi update --extensions`.
+
+**How it works.** When you `pi install` a git URL, pi clones the repo to
+`~/.pi/agent/git/github.com/DiversioTeam/agent-skills-marketplace`, runs
+`npm install` if a `package.json` exists, and then reads the `pi` manifest to
+discover extensions, skills, prompts, and themes. The root manifest points into
+the `pi-packages/` subdirectories so pi finds `ci-status`, `dev-workflow`, and
+`skills-bridge` without any extra configuration.
+
+**Migrating from local-path installs.** If you previously installed packages
+via local paths (e.g. `pi install "$PWD/pi-packages/ci-status"`), remove those
+entries from `~/.pi/agent/settings.json` before switching to the git install.
+Otherwise pi loads both copies and you get duplicate extensions.
+
+### Local-path install (legacy / local dev)
+
 From a checkout of this repo:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "agent-skills-marketplace",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Root pi manifest for the Diversio Team agent-skills-marketplace. This file lets pi discover every sub-package (ci-status, dev-workflow, skills-bridge) from a single git clone. Without it, each sub-package needs its own fragile local-path install — which breaks across worktrees and causes duplicate extensions. One pi install git:github.com/DiversioTeam/agent-skills-marketplace now replaces three separate pi install $PWD/pi-packages/<pkg> commands.",
+  "keywords": ["pi-package"],
+  "pi": {
+    "extensions": [
+      "pi-packages/ci-status/extensions",
+      "pi-packages/dev-workflow/extensions",
+      "pi-packages/skills-bridge/extensions"
+    ],
+    "skills": [
+      "pi-packages/dev-workflow/skills"
+    ]
+  }
+}

--- a/pi-packages/README.md
+++ b/pi-packages/README.md
@@ -1,0 +1,91 @@
+# Pi Packages
+
+Pi-native packages that extend pi with tools, commands, skills, and UI widgets.
+
+## Available Packages
+
+| Package | What it gives you |
+|---------|-------------------|
+| [`ci-status`](./ci-status) | `/ci`, `/ci-detail`, `/ci-logs` commands, CI auto-watch after pushes, status-line widget, GitHub Actions + CircleCI support, and `get_ci_status` / `ci_fetch_job_logs` LLM tools |
+| [`dev-workflow`](./dev-workflow) | 15 core workflow prompts (`/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`), CI analysis, PR review feedback, release PR prep, local skills, and optional pi-subagents chain |
+| [`skills-bridge`](./skills-bridge) | Auto-discovers all 21 Claude Code plugin skills from `plugins/*/skills/` and registers them as pi skills — one install bridges the entire plugin ecosystem into pi |
+
+## Install
+
+### One command for everything (recommended)
+
+```bash
+pi install git:github.com/DiversioTeam/agent-skills-marketplace
+```
+
+The root `package.json` at the top of this repo tells pi where to find every
+package, so one clone discovers all three. Run `/reload` after installing.
+
+To pull the latest updates later:
+
+```bash
+pi update --extensions
+```
+
+This does a `git pull` on the cloned repo and reloads all extensions and skills.
+Versions are not pinned, so `pi update --extensions` always fetches the latest
+`main`.
+
+### One package at a time (local dev)
+
+From a checkout of this repo:
+
+```bash
+pi install "$PWD/pi-packages/ci-status"
+pi install "$PWD/pi-packages/dev-workflow"
+pi install "$PWD/pi-packages/skills-bridge"
+```
+
+Use `pi -e ./pi-packages/<pkg>` to test a package without writing to settings.
+
+### Duplicate warning
+
+Install each package in one scope. If the same package is installed from two
+different local paths (e.g. two worktrees), pi loads both copies and you get
+duplicate extensions. Remove the old entry from `~/.pi/agent/settings.json`
+first, or switch to the git-based install which avoids this entirely.
+
+## Structure
+
+```
+pi-packages/
+├── README.md                 ← this file
+├── ci-status/
+│   ├── package.json
+│   ├── README.md
+│   └── extensions/
+├── dev-workflow/
+│   ├── package.json
+│   ├── README.md
+│   ├── extensions/
+│   ├── skills/
+│   └── agents/
+└── skills-bridge/
+    ├── package.json
+    ├── README.md
+    └── extensions/
+```
+
+Each subdirectory is a standalone pi package with its own `package.json` and
+README. The root `package.json` at the repo top references them so pi can
+discover everything from a single `git:` install.
+
+## Contributing
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full guide. Key rules:
+
+- Keep each package's `package.json`, `README.md`, and version in sync.
+- **When adding or removing a package**, update the root `package.json`
+  `pi.extensions` and `pi.skills` arrays so the git-based install stays accurate.
+- Use `pi -e ./pi-packages/<pkg>` for local smoke tests.
+- Bump the package version when publishing an update.
+
+## More
+
+- [Root README](../README.md) — full repo overview and plugin catalog
+- [Distribution runbook](../docs/runbooks/distribution.md) — install, uninstall, and migration guides


### PR DESCRIPTION
## Summary

This PR adds a root `package.json` to the repo so all three pi packages (`ci-status`, `dev-workflow`, `skills-bridge`) can be installed with a single command instead of three fragile local-path installs.

### Key Features

| Feature | Description |
|---------|-------------|
| **Root `package.json`** | Declares all sub-package extensions and skills so pi discovers them from one git clone |
| **Git-based install** | `pi install git:github.com/DiversioTeam/agent-skills-marketplace` replaces three separate `pi install $PWD/pi-packages/<pkg>` commands |
| **Updated docs** | README, CONTRIBUTING, and distribution runbook all explain the new flow with first-principles reasoning |

## Why

### Before (fragile)

```
pi install $PWD/pi-packages/ci-status
pi install $PWD/pi-packages/dev-workflow
pi install $PWD/pi-packages/skills-bridge
```

Each path is relative to the current worktree. Two problems:
1. **Duplicate extensions** — installing from two different worktrees (e.g. `monolith/` and `monolith-for-release/`) produces two copies because resolved absolute paths differ
2. **Fragile paths** — deleting a worktree breaks the install; team members on different machines have different paths

### After (stable)

```
pi install git:github.com/DiversioTeam/agent-skills-marketplace
```

One URL, any machine, any worktree, exactly one copy of each extension.

## How It Works

```
pi install git:...
       │
       ▼
   git clone to ~/.pi/agent/git/github.com/DiversioTeam/agent-skills-marketplace
       │
       ▼
   reads package.json → pi.extensions → discovers:
       ├── pi-packages/ci-status/extensions       → ci-status extension
       ├── pi-packages/dev-workflow/extensions     → dev-workflow extension
       ├── pi-packages/skills-bridge/extensions    → skills-bridge extension
       └── pi-packages/dev-workflow/skills         → ci + dev-workflow skills
```

## Files Changed

<details>
<summary>4 files (+93, −8)</summary>

| File | Description |
|------|-------------|
| `package.json` (new) | Root manifest with `pi.extensions` and `pi.skills` arrays |
| `README.md` | Restructured pi package table + install section; git-based first, local-path as legacy |
| `CONTRIBUTING.md` | Added rule to update root manifest when adding/removing pi packages |
| `docs/runbooks/distribution.md` | Added git install section with how-it-works and migration guide |

</details>

## Test Plan

1. **Local validation**: `jq -e . package.json` passes; all manifest paths resolve to real directories
2. **CI**: `Validate Marketplace` workflow checks pi package JSON validity and command discovery (triggers on PR push)
3. **Manual smoke test**: After merge, run `pi install git:github.com/DiversioTeam/agent-skills-marketplace` in a fresh environment and verify `/ci`, `/workflow:help`, and skill auto-discovery all work

## Notes

- The branch name (`feature/add-root-pi-manifest`) does not follow the issue-linked convention from `AGENTS.md` because this is a lightweight harness improvement without a corresponding GitHub issue. Happy to create one if reviewers prefer.
- Local-path installs still work and are documented as the legacy/dev option.