### PR TITLE
Add oh-my-pi and improve Pi package workflows

### DIFF
--- a/.github/workflows/notify-plugin-updates.yml
+++ b/.github/workflows/notify-plugin-updates.yml
@@ -1,10 +1,22 @@
-name: Notify Plugin Updates
+# Marketplace update notifications
+#
+# Why this workflow exists:
+# - plugin-only notifications made Pi package updates effectively invisible
+# - product-release Slack (Naboo) was the wrong layer for marketplace-local Pi updates
+# - a single marketplace-local message keeps the signal close to the repo that changed
+#
+# Design rule:
+# - one Slack post per push to main that changes marketplace-delivered artifacts
+# - separate Plugin items and Pi items sections so readers can scan the update quickly
+# - short summaries only; deep install or rollout detail belongs in docs / PRs
+name: Notify Marketplace Updates
 
 on:
   push:
     branches: [main]
     paths:
       - 'plugins/**'
+      - 'pi-packages/**'
 
 permissions:
   contents: read
@@ -17,156 +29,311 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          fetch-depth: 2  # Need previous commit to diff
+          fetch-depth: 0
           persist-credentials: false
 
-      - name: Detect updated plugins and build notification
+      - name: Detect updated marketplace items and build notification
         id: detect
+        shell: bash
         run: |
-          # Get list of changed plugin directories
-          CHANGED_PLUGINS=$(git diff --name-only HEAD~1 HEAD -- plugins/ | \
-            grep -oE 'plugins/[^/]+' | sort -u || true)
+          set -euo pipefail
 
-          if [ -z "$CHANGED_PLUGINS" ]; then
-            echo "No plugin changes detected"
-            echo "has_updates=false" >> $GITHUB_OUTPUT
+          # Tiny text helper used for the top summary line, e.g.
+          #   "2 plugins · 1 Pi package"
+          pluralize() {
+            local count="$1"
+            local singular="$2"
+            local plural="${3:-${singular}s}"
+            if [ "$count" -eq 1 ]; then
+              printf '%s %s' "$count" "$singular"
+            else
+              printf '%s %s' "$count" "$plural"
+            fi
+          }
+
+          # Join with an explicit string delimiter.
+          #
+          # We do not rely on bash IFS joining here because we want multi-character
+          # delimiters like " · " and " • ", not just the first character.
+          join_by() {
+            local delimiter="$1"
+            shift || true
+            local first=1
+            for value in "$@"; do
+              if [ "$first" -eq 1 ]; then
+                printf '%s' "$value"
+                first=0
+              else
+                printf '%s%s' "$delimiter" "$value"
+              fi
+            done
+          }
+
+          # Escape user-controlled text for Slack mrkdwn.
+          #
+          # Skill summaries and package descriptions can contain <, >, or &,
+          # which Slack treats as formatting control characters.
+          escape_mrkdwn() {
+            sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'
+          }
+
+          # Pull a short human summary from the first changelog entry in the
+          # plugin's main SKILL.md. This keeps the Slack message product-facing
+          # instead of dumping raw file paths or commit noise.
+          extract_plugin_summary() {
+            local plugin_path="$1"
+            local skill_file
+            skill_file=$(find "$plugin_path/skills" -name "SKILL.md" -type f | head -1 || true)
+            if [ -z "$skill_file" ] || [ ! -f "$skill_file" ]; then
+              return 0
+            fi
+
+            awk '
+              /^### v[0-9]/ {
+                if (found) exit
+                found=1
+                next
+              }
+              found && /^### v[0-9]/ { exit }
+              found && /^## [^C]/ { exit }
+              found { print }
+            ' "$skill_file" | \
+              sed 's/`//g' | \
+              sed 's/^- \*\*\([^*]*\)\*\*/• *\1*/g' | \
+              sed 's/^- /• /g' | \
+              sed 's/\*\*\([^*]*\)\*\*/*\1*/g' | \
+              sed '/^$/d' | \
+              head -1 | \
+              sed 's/^•[[:space:]]*//' | \
+              tr '\n' ' ' | \
+              sed 's/[[:space:]]\+/ /g; s/^ *//; s/ *$//' | \
+              escape_mrkdwn || true
+          }
+
+          # Pi packages do not share one uniform changelog shape, so for the
+          # high-signal packages we keep short curated summaries here.
+          #
+          # Why hardcode them?
+          # - the Slack message should answer "what kind of thing changed?"
+          # - package.json descriptions are often too broad for that purpose
+          # - we only have four Pi packages today, so the maintenance cost is tiny
+          extract_pi_summary() {
+            local package_path="$1"
+            local package_name
+            package_name=$(basename "$package_path")
+
+            case "$package_name" in
+              ci-status)
+                printf '%s' 'GitHub Actions + CircleCI CI status, logs, and watch mode'
+                ;;
+              dev-workflow)
+                printf '%s' 'workflow prompts, review passes, CI, docs, shipping, and seeded cmux lanes'
+                ;;
+              oh-my-pi)
+                printf '%s' 'cmux notifications, readable split commands, and workspace tabs'
+                ;;
+              skills-bridge)
+                printf '%s' 'bridges marketplace plugin skills into Pi'
+                ;;
+              *)
+                jq -r '.description // ""' "$package_path/package.json" | \
+                  tr '\n' ' ' | \
+                  sed 's/[[:space:]]\+/ /g; s/^ *//; s/ *$//' | \
+                  cut -c1-140 | \
+                  escape_mrkdwn
+                ;;
+            esac
+          }
+
+          # Compare the full pushed range, not just HEAD~1.
+          #
+          # A push to main can contain multiple commits. github.event.before is
+          # the commit before the whole push, which is the right base when we
+          # want one Slack message for everything that landed together.
+          BASE_SHA="${{ github.event.before }}"
+          HEAD_SHA="${{ github.sha }}"
+          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ] || ! git rev-parse --verify "$BASE_SHA^{commit}" >/dev/null 2>&1; then
+            BASE_SHA="HEAD~1"
+          fi
+
+          # Build the plugin list from changed directories, not changed files.
+          # The Slack message is about marketplace items people can reinstall,
+          # not about every touched file under those items.
+          CHANGED_PLUGINS=()
+          while IFS= read -r path; do
+            if [ -n "$path" ] && [ -d "$path" ] && [ -f "$path/.claude-plugin/plugin.json" ]; then
+              CHANGED_PLUGINS+=("$path")
+            fi
+          done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- plugins/ | grep -oE '^plugins/[^/]+' | sort -u || true)
+
+          CHANGED_PI_PACKAGES=()
+          while IFS= read -r path; do
+            if [ -n "$path" ] && [ -d "$path" ] && [ -f "$path/package.json" ]; then
+              CHANGED_PI_PACKAGES+=("$path")
+            fi
+          done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- pi-packages/ | grep -oE '^pi-packages/[^/]+' | sort -u || true)
+
+          PLUGIN_COUNT=${#CHANGED_PLUGINS[@]}
+          PI_COUNT=${#CHANGED_PI_PACKAGES[@]}
+          TOTAL_COUNT=$((PLUGIN_COUNT + PI_COUNT))
+
+          if [ "$TOTAL_COUNT" -eq 0 ]; then
+            echo "No plugin or pi-package changes detected"
+            echo "has_updates=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "has_updates=true" >> $GITHUB_OUTPUT
+          echo "has_updates=true" >> "$GITHUB_OUTPUT"
+          echo "plugin_count=$PLUGIN_COUNT" >> "$GITHUB_OUTPUT"
+          echo "pi_count=$PI_COUNT" >> "$GITHUB_OUTPUT"
 
-          # Build the Slack message
-          MESSAGE=""
+          # Top-line summary shown under the header.
+          SUMMARY_PARTS=()
+          if [ "$PLUGIN_COUNT" -gt 0 ]; then
+            SUMMARY_PARTS+=("$(pluralize "$PLUGIN_COUNT" "plugin")")
+          fi
+          if [ "$PI_COUNT" -gt 0 ]; then
+            SUMMARY_PARTS+=("$(pluralize "$PI_COUNT" "Pi package")")
+          fi
+          SUMMARY=$(join_by ' · ' "${SUMMARY_PARTS[@]}")
 
-          for PLUGIN_PATH in $CHANGED_PLUGINS; do
-            PLUGIN_NAME=$(basename "$PLUGIN_PATH")
+          # Plugin items section.
+          #
+          # Format example:
+          #   *Plugin items:*
+          #   • *frontend* `v0.0.1` — collapse 9 frontend plugins into one digest-first plugin
+          PLUGIN_SECTION=""
+          if [ "$PLUGIN_COUNT" -gt 0 ]; then
+            PLUGIN_SECTION="*Plugin items:*"
+            for plugin_path in "${CHANGED_PLUGINS[@]}"; do
+              plugin_name=$(basename "$plugin_path")
+              version=$(jq -r '.version // "unknown"' "$plugin_path/.claude-plugin/plugin.json")
+              summary=$(extract_plugin_summary "$plugin_path")
+              line="• *${plugin_name}* \`v${version}\`"
+              if [ -n "$summary" ]; then
+                line="${line} — ${summary}"
+              fi
+              PLUGIN_SECTION+=$'\n'"$line"
+            done
+          fi
 
-            # Get version from plugin.json
-            PLUGIN_JSON="$PLUGIN_PATH/.claude-plugin/plugin.json"
-            if [ -f "$PLUGIN_JSON" ]; then
-              VERSION=$(jq -r '.version // "unknown"' "$PLUGIN_JSON")
-            else
-              VERSION="unknown"
-            fi
+          # Pi items section.
+          #
+          # This is the important addition: Pi package changes should be visible
+          # in their own lane instead of being mixed into plugin updates or sent
+          # through unrelated product-release messaging.
+          PI_SECTION=""
+          if [ "$PI_COUNT" -gt 0 ]; then
+            PI_SECTION="*Pi items:*"
+            for package_path in "${CHANGED_PI_PACKAGES[@]}"; do
+              package_name=$(basename "$package_path")
+              version=$(jq -r '.version // "unknown"' "$package_path/package.json")
+              summary=$(extract_pi_summary "$package_path")
+              line="• *${package_name}* \`v${version}\`"
+              if [ -n "$summary" ]; then
+                line="${line} — ${summary}"
+              fi
+              PI_SECTION+=$'\n'"$line"
+            done
+          fi
 
-            # Find the main SKILL.md (first one found)
-            SKILL_FILE=$(find "$PLUGIN_PATH/skills" -name "SKILL.md" -type f | head -1)
+          # Short action hints at the bottom of the message.
+          # Keep these compact — they are reminders, not full runbooks.
+          INSTALL_HINTS=()
+          if [ "$PLUGIN_COUNT" -gt 0 ]; then
+            INSTALL_HINTS+=("Plugin reinstall: \`/plugin install <name>@diversiotech\`")
+          fi
+          if [ "$PI_COUNT" -gt 0 ]; then
+            INSTALL_HINTS+=("Pi refresh: \`pi update --extensions\`")
+          fi
+          HINTS=$(join_by ' • ' "${INSTALL_HINTS[@]}")
 
-            # Extract latest changelog entry
-            CHANGELOG=""
-            if [ -n "$SKILL_FILE" ] && [ -f "$SKILL_FILE" ]; then
-              # Extract content between first "### v" and second "### v" (or end of changelog section)
-              CHANGELOG=$(awk '
-                /^### v[0-9]/ {
-                  if (found) exit
-                  found=1
-                  next
-                }
-                found && /^### v[0-9]/ { exit }
-                found && /^## [^C]/ { exit }
-                found { print }
-              ' "$SKILL_FILE" | head -20)
-            fi
-
-            # Format this plugin's update
-            MESSAGE="${MESSAGE}*:electric_plug: ${PLUGIN_NAME}* \`v${VERSION}\`"$'\n'
-
-            if [ -n "$CHANGELOG" ]; then
-              # Convert markdown to Slack format, escape backticks
-              FORMATTED_CHANGELOG=$(echo "$CHANGELOG" | \
-                sed 's/`//g' | \
-                sed 's/^- \*\*\([^*]*\)\*\*/• *\1*/g' | \
-                sed 's/^- /• /g' | \
-                sed 's/\*\*\([^*]*\)\*\*/*\1*/g' | \
-                grep -v '^$' | \
-                head -8)
-              MESSAGE="${MESSAGE}${FORMATTED_CHANGELOG}"$'\n'
-            fi
-
-            MESSAGE="${MESSAGE}"$'\n'
-          done
-
-          # Add reinstall instructions and mention developers
-          PLUGIN_LIST=$(echo "$CHANGED_PLUGINS" | xargs -I{} basename {} | tr '\n' ' ')
-          MESSAGE="${MESSAGE}_Reinstall:_ \`/plugin install <name>@diversiotech\`"$'\n'
-          MESSAGE="${MESSAGE}_Plugins:_ ${PLUGIN_LIST}"$'\n\n'
-          MESSAGE="${MESSAGE}cc @developers"
-
-          # Store message for next step (handle multiline)
           EOF_MARKER=$(openssl rand -hex 8)
-          echo "message<<${EOF_MARKER}" >> $GITHUB_OUTPUT
-          echo "$MESSAGE" >> $GITHUB_OUTPUT
-          echo "${EOF_MARKER}" >> $GITHUB_OUTPUT
-
-          # Also store plugin count
-          PLUGIN_COUNT=$(echo "$CHANGED_PLUGINS" | wc -l | tr -d ' ')
-          echo "plugin_count=$PLUGIN_COUNT" >> $GITHUB_OUTPUT
+          {
+            echo "summary<<${EOF_MARKER}"
+            echo "$SUMMARY"
+            echo "${EOF_MARKER}"
+            echo "plugin_section<<${EOF_MARKER}"
+            echo "$PLUGIN_SECTION"
+            echo "${EOF_MARKER}"
+            echo "pi_section<<${EOF_MARKER}"
+            echo "$PI_SECTION"
+            echo "${EOF_MARKER}"
+            echo "hints<<${EOF_MARKER}"
+            echo "$HINTS"
+            echo "${EOF_MARKER}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Post to Slack
         if: steps.detect.outputs.has_updates == 'true'
         env:
           AUTHOR: ${{ github.actor }}
-          PLUGIN_COUNT: ${{ steps.detect.outputs.plugin_count }}
-          SLACK_MESSAGE: ${{ steps.detect.outputs.message }}
+          SUMMARY: ${{ steps.detect.outputs.summary }}
+          PLUGIN_SECTION: ${{ steps.detect.outputs.plugin_section }}
+          PI_SECTION: ${{ steps.detect.outputs.pi_section }}
+          HINTS: ${{ steps.detect.outputs.hints }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PLUGIN_UPDATES_WEBHOOK }}
+        shell: bash
         run: |
           set -euo pipefail
 
-          # Build the payload
+          # Build one compact Block Kit message:
+          # - header
+          # - who merged what to main
+          # - Plugin items section (if any)
+          # - Pi items section (if any)
+          # - tiny reinstall/update hints
           COMMIT_URL="${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
-          COMMIT_MSG=$(git log -1 --pretty=%s)
+          COMMIT_MSG=$(git log -1 --pretty=%s | tr '\n' ' ' | sed 's/[<>|]/-/g')
+          HEADER="Marketplace Updated"
 
-          # Determine header based on plugin count
-          if [ "$PLUGIN_COUNT" -eq 1 ]; then
-            HEADER=":package: Plugin Updated"
-          else
-            HEADER=":package: ${PLUGIN_COUNT} Plugins Updated"
-          fi
-
-          # Create Slack Block Kit payload for rich formatting
-          # Using legacy webhook - can specify channel in payload
           PAYLOAD=$(jq -n \
             --arg header "$HEADER" \
-            --arg message "$SLACK_MESSAGE" \
+            --arg author "$AUTHOR" \
+            --arg summary "$SUMMARY" \
+            --arg plugin_section "$PLUGIN_SECTION" \
+            --arg pi_section "$PI_SECTION" \
             --arg commit_url "$COMMIT_URL" \
             --arg commit_msg "$COMMIT_MSG" \
-            --arg author "$AUTHOR" \
+            --arg hints "$HINTS" \
             '{
               "channel": "#ask-tech-team",
-              "username": "Plugin Updates",
+              "username": "Marketplace Updates",
               "icon_emoji": ":package:",
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": $header,
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": $message
-                  }
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "mrkdwn",
-                      "text": ("by *" + $author + "* • <" + $commit_url + "|" + $commit_msg + ">")
+              "blocks": (
+                [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": $header,
+                      "emoji": true
                     }
-                  ]
-                },
-                {
-                  "type": "divider"
-                }
-              ]
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": ("Merged to *main* by *" + $author + "*\n" + $summary + "\n<" + $commit_url + "|" + $commit_msg + ">")
+                    }
+                  }
+                ]
+                + (if ($plugin_section | length) > 0 or ($pi_section | length) > 0 then [{"type": "divider"}] else [] end)
+                + (if ($plugin_section | length) > 0 then [{
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": $plugin_section}
+                  }] else [] end)
+                + (if ($pi_section | length) > 0 then [{
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": $pi_section}
+                  }] else [] end)
+                + (if ($hints | length) > 0 then [{
+                    "type": "context",
+                    "elements": [{"type": "mrkdwn", "text": $hints}]
+                  }] else [] end)
+              )
             }')
 
-          # Post to Slack
           curl --fail-with-body -X POST \
             -H 'Content-type: application/json' \
             --data "$PAYLOAD" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,8 @@ git diff -- AGENTS.md CLAUDE.md README.md CONTRIBUTING.md docs .claude-plugin pl
 - `scripts/validate-skills.sh` - local and CI `SKILL.md` size budget check
 - `.github/workflows/validate-marketplace.yml` - JSON, version, and structure CI
 - `.github/workflows/notify-plugin-updates.yml` - Slack notification on plugin
-  changes pushed to `main`
+  and pi-package changes pushed to `main`, with separate Plugin items and Pi
+  items sections
 
 ## Docs Index
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ agent-skills-marketplace/
 │   └── marketplace.json               # Marketplace definition
 ├── pi-packages/
 │   ├── ci-status/                     # Pi-native CI status extension
-│   └── dev-workflow/                  # Pi-native daily developer workflow extension + skills
+│   ├── dev-workflow/                  # Pi-native daily developer workflow extension + skills
+│   ├── oh-my-pi/                      # Pi-native cmux integration (notifications, split panes, workspace tabs)
+│   └── skills-bridge/                 # Pi-native bridge to Claude Code plugin skills
 ├── plugins/
 │   ├── monty-code-review/             # Monty backend code review plugin
 │   │   ├── .claude-plugin/plugin.json
@@ -276,7 +278,7 @@ agent-skills-marketplace/
 
 ## Available Pi Packages
 
-All three packages are installable together from one git URL (recommended) or
+All four packages are installable together from one git URL (recommended) or
 individually from a local checkout. The root `package.json` declares every
 sub-package so pi can discover them from a single clone — see
 [Git-based install](#git-based-install-recommended) for the one-liner.
@@ -284,8 +286,39 @@ sub-package so pi can discover them from a single clone — see
 | Package | Description |
 |---------|-------------|
 | `ci-status` | Pi-native CI status extension with `/ci`, `/ci-detail`, `/ci-logs`, auto-watch after pushes, widget/status rendering, GitHub Actions + CircleCI support, and LLM CI tools |
-| `dev-workflow` | Pi-native daily developer workflow with 15 core workflow prompts, `/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`, XDG/project prompt config, CI analysis, PR review feedback, release PR prep, local skills, and optional pi-subagents chain |
+| `dev-workflow` | Pi-native daily developer workflow with 15 core workflow prompts, `/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`, XDG/project prompt config, CI analysis, PR review feedback, release PR prep, local skills, optional pi-subagents chain, and default cmux split launching for subagent-style workflow prompts when Pi runs inside cmux |
+| `oh-my-pi` | Pi-native cmux integration with native cmux notifications (Waiting / Task Complete / Error), readable split pane commands (`/omp-split-*`) and workspace tab commands (`/omp-workspace*`), plus short aliases for faster typing. Zero runtime deps, works only inside cmux |
 | `skills-bridge` | Auto-discovers all 21 Claude Code plugin skills from plugins/*/skills/ and registers them as pi skills. One install bridges the gap between the plugin ecosystem and pi |
+
+Helpful mental model:
+
+```text
+oh-my-pi      -> explicit cmux commands you can run yourself
+              -> /omp-split-*, /omp-workspace*
+
+dev-workflow  -> automatic cmux use when the workflow clearly benefits
+              -> /workflow:scout, /workflow:oracle, /workflow:reviewer, /workflow:parallel
+```
+
+## Marketplace update notifications
+
+Pushes to `main` that change marketplace-delivered artifacts now post one Slack
+message from this repo's own GitHub Actions workflow.
+
+Why this exists:
+
+- plugin updates and Pi package updates both matter to engineers
+- Pi updates should not be hidden inside plugin-only notifications
+- product-release Slack is the wrong layer for marketplace-local Pi changes
+
+Mental model:
+
+```text
+push to main
+  ├─ changed plugins?     -> Plugin items section
+  ├─ changed pi-packages? -> Pi items section
+  └─ one compact Slack post in #ask-tech-team
+```
 
 ## Installation
 
@@ -316,7 +349,7 @@ of the Claude Code marketplace.
 #### Git-based install (recommended)
 
 A root `package.json` at the top of this repo declares every sub-package so pi
-can discover `ci-status`, `dev-workflow`, and `skills-bridge` from one clone:
+can discover `ci-status`, `dev-workflow`, `oh-my-pi`, and `skills-bridge` from one clone:
 
 ```bash
 pi install git:github.com/DiversioTeam/agent-skills-marketplace
@@ -352,13 +385,14 @@ local change before pushing:
 ```bash
 pi install "$PWD/pi-packages/ci-status"
 pi install "$PWD/pi-packages/dev-workflow"
+pi install "$PWD/pi-packages/oh-my-pi"
 pi install "$PWD/pi-packages/skills-bridge"
 ```
 
-Plain `pi install` writes to global user settings. Use `pi -e ./pi-packages/<package>`
-for one-off extension testing without changing settings. Use `pi install -l`
-only when you need to test project-local install, reload, or persistence
-behavior.
+Plain `pi install` writes to global user settings. Use `pi --no-extensions -e ./pi-packages/<package>`
+for one-off extension testing from the repo root without loading a duplicate copy
+from the root marketplace manifest. Use `pi install -l` only when you need to
+test project-local install, reload, or persistence behavior.
 
 Install each pi package in one scope at a time. If `ci-status` is installed
 globally and also from a different project-local path, Pi can load both copies
@@ -366,9 +400,9 @@ and duplicate `get_ci_status` / `ci_fetch_job_logs` tool registration. Remove
 the duplicate project package entry from `.pi/settings.json` or uninstall the
 global copy before reloading.
 
-Run `/reload` in pi after installation. See `pi-packages/ci-status/README.md`
-and `pi-packages/dev-workflow/README.md` for command inventory, contribution
-workflow, and local testing commands.
+Run `/reload` in pi after installation. See `pi-packages/ci-status/README.md`,
+`pi-packages/dev-workflow/README.md`, and `pi-packages/oh-my-pi/README.md` for
+command inventory, contribution workflow, and local testing commands.
 
 ### Monolith Review Orchestrator
 
@@ -505,6 +539,12 @@ Once plugins are installed:
    /frontend:review                        # Review a frontend PR using the repo-local digest and Bumang-style priorities
    /frontend:commit                        # Create a digest-aware atomic frontend commit with quality gates
    /frontend:new-branch                    # Create a frontend branch using the repo's detected branch model
+   /omp-split-right                          # Recommended default: open new right-side cmux split → fresh Pi session
+   /omp-split-right-command <cmd>            # Recommended default: open new right-side cmux split → shell command
+   /omp-split-down                           # Recommended default: open new down-side cmux split → fresh Pi session
+   /omp-split-down-command <cmd>             # Recommended default: open new down-side cmux split → shell command
+   /omp-workspace [--name <title>] [prompt]  # Stronger isolation: open new cmux workspace tab → fresh Pi session (focus-switching)
+   /omp-workspace-command [--name <title>] <cmd> # Stronger isolation: open new cmux workspace tab → shell command (focus-switching)
    ```
 
 ## Monty Review Memory

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -24,7 +24,8 @@
   - Structure and consistency checks for marketplace metadata and changed
     skills.
 - `.github/workflows/notify-plugin-updates.yml`
-  - Post-merge notification flow for plugin changes pushed to `main`.
+  - Post-merge notification flow for plugin and pi-package changes pushed to
+    `main`, rendered in separate Plugin items and Pi items Slack sections.
 
 ## Boundaries
 
@@ -62,8 +63,10 @@
      directory/manifest consistency, version sync, presence of skills, and the
      `SKILL.md` size budget.
 5. Post-merge notification
-   - Pushes to `main` that touch `plugins/**` trigger Slack update messages with
-     plugin names, versions, and changelog snippets.
+   - Pushes to `main` that touch `plugins/**` or `pi-packages/**` trigger Slack
+     update messages.
+   - Plugin changes render under a dedicated `Plugin items` section.
+   - Pi package changes render under a dedicated `Pi items` section.
 
 ## Useful References
 

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -25,7 +25,9 @@ when command files change.
   - Purpose: pi-native daily developer workflow with TypeScript extension
     commands, stable workflow prompt codes, XDG/project prompt config,
     interactive TUI help panel, CI analysis, PR review feedback handling,
-    release PR prep prompts, local skills, and optional pi-subagents chain.
+    release PR prep prompts, local skills, optional pi-subagents chain, and
+    default seeded cmux split launching for subagent-style workflow prompts when
+    Pi runs inside cmux.
   - Pi install from repo checkout:
     `pi install "$PWD/pi-packages/dev-workflow"`
   - Package path: `pi-packages/dev-workflow`
@@ -52,9 +54,37 @@ when command files change.
     `app.message.followUp` keybinding (default `Alt+Enter`, often
     `Option+Enter` on macOS) to queue the selected prompt or edited prompt as a
     follow-up while pi is streaming.
+  - cmux behavior: `/workflow:scout`, `/workflow:oracle`,
+    `/workflow:reviewer`, and `/workflow:parallel` default to a seeded cmux
+    split when Pi is inside cmux and the parent session is idle; otherwise they
+    stay inline. `PI_WORKFLOW_CMUX_MODE=inline` disables this and
+    `PI_WORKFLOW_CMUX_SPLIT_DIRECTION=down` changes split direction.
+  - One-off local test from repo root:
+    `pi --no-extensions -e ./pi-packages/dev-workflow`
   - Recommended companion package: `ci-status` for `/ci`, `/ci-detail`, and
     `/ci-logs`; workflow prompts fall back to `get_ci_status` /
     `ci_fetch_job_logs` only when the current harness exposes those tools.
+- `oh-my-pi` (pi package)
+  - Purpose: Pi-native cmux integration with native notifications, readable
+    split-pane commands, and workspace-tab commands.
+  - Pi install from repo checkout: `pi install "$PWD/pi-packages/oh-my-pi"`
+  - Package path: `pi-packages/oh-my-pi`
+  - Extension path: `pi-packages/oh-my-pi/extensions/oh-my-pi`
+  - Canonical slash commands: `/omp-split-right`,
+    `/omp-split-right-command`, `/omp-split-down`,
+    `/omp-split-down-command`, `/omp-workspace`,
+    `/omp-workspace-command`
+  - Short aliases: `/ompv`, `/ompr`, `/omph`, `/omphr`, `/ompw`, `/ompwr`
+  - Recommendation: prefer split-pane commands by default; use workspace tabs
+    for stronger isolation or named long-lived lanes.
+  - Relationship to `dev-workflow`: `oh-my-pi` is the explicit user-facing cmux
+    command surface, while `dev-workflow` uses a small amount of direct cmux
+    logic for automatic seeded split launching on subagent-style workflow
+    prompts.
+  - Environment: `PI_CMUX_NOTIFY_LEVEL`, `PI_CMUX_NOTIFY_THRESHOLD_MS`,
+    `PI_CMUX_NOTIFY_DEBOUNCE_MS`, `PI_CMUX_NOTIFY_TITLE`
+  - One-off local test from repo root:
+    `pi --no-extensions -e ./pi-packages/oh-my-pi`
 - `skills-bridge` (pi package)
   - Purpose: auto-discovers Claude Code plugin skills from
     `plugins/*/skills/` directories and registers them as pi

--- a/docs/quality/gates.md
+++ b/docs/quality/gates.md
@@ -53,10 +53,10 @@ skills target:
     or the workflow file itself.
   - Validates JSON, unique plugin names, plugin directory coverage, manifest
     name and version sync, skill presence, and changed-skill size budgets.
-- `Notify Plugin Updates`
-  - Triggered by pushes to `main` that touch `plugins/**`.
-  - Diffs the previous commit, extracts changed plugin versions and top
-    changelog snippets, and posts a Slack message.
+- `Notify Marketplace Updates`
+  - Triggered by pushes to `main` that touch `plugins/**` or `pi-packages/**`.
+  - Diffs the full pushed range, groups changes by marketplace item, and posts
+    one Slack message with separate `Plugin items` and `Pi items` sections.
 
 Docs-only changes do not currently trigger the marketplace validation workflow,
 so run the local checks manually when you touch shared instructions.

--- a/docs/runbooks/distribution.md
+++ b/docs/runbooks/distribution.md
@@ -131,7 +131,7 @@ not the Claude Code marketplace.
 ### Git-based install (recommended)
 
 The root `package.json` at the top of this repo declares every sub-package so pi
-can discover all three from a single clone. One command replaces three:
+can discover all four from a single clone. One command replaces four:
 
 ```bash
 pi install git:github.com/DiversioTeam/agent-skills-marketplace
@@ -158,8 +158,8 @@ Pinned refs are skipped by `pi update --extensions`.
 `~/.pi/agent/git/github.com/DiversioTeam/agent-skills-marketplace`, runs
 `npm install` if a `package.json` exists, and then reads the `pi` manifest to
 discover extensions, skills, prompts, and themes. The root manifest points into
-the `pi-packages/` subdirectories so pi finds `ci-status`, `dev-workflow`, and
-`skills-bridge` without any extra configuration.
+the `pi-packages/` subdirectories so pi finds `ci-status`, `dev-workflow`,
+`oh-my-pi`, and `skills-bridge` without any extra configuration.
 
 **Migrating from local-path installs.** If you previously installed packages
 via local paths (e.g. `pi install "$PWD/pi-packages/ci-status"`), remove those
@@ -173,6 +173,7 @@ From a checkout of this repo:
 ```bash
 pi install "$PWD/pi-packages/ci-status"
 pi install "$PWD/pi-packages/dev-workflow"
+pi install "$PWD/pi-packages/oh-my-pi"
 pi install "$PWD/pi-packages/skills-bridge"
 ```
 
@@ -181,17 +182,20 @@ From the Diversio monolith root, include the submodule path:
 ```bash
 pi install "$PWD/agent-skills-marketplace/pi-packages/ci-status"
 pi install "$PWD/agent-skills-marketplace/pi-packages/dev-workflow"
+pi install "$PWD/agent-skills-marketplace/pi-packages/oh-my-pi"
 pi install "$PWD/agent-skills-marketplace/pi-packages/skills-bridge"
 ```
 
 Plain `pi install` writes to global user settings (`~/.pi/agent/settings.json`).
-For one-off extension testing, prefer `-e` so Pi loads the package for the
-current run without changing settings:
+For one-off extension testing from the repo root, prefer `--no-extensions -e`
+so Pi loads only the target package and does not also load the same package a
+second time from the root marketplace manifest:
 
 ```bash
-pi -e ./pi-packages/ci-status
-pi -e ./pi-packages/dev-workflow
-pi -e ./pi-packages/skills-bridge
+pi --no-extensions -e ./pi-packages/ci-status
+pi --no-extensions -e ./pi-packages/dev-workflow
+pi --no-extensions -e ./pi-packages/oh-my-pi
+pi --no-extensions -e ./pi-packages/skills-bridge
 ```
 
 Use `-l` only when you need to test project-local install, reload, or
@@ -200,6 +204,7 @@ persistence behavior that writes to `.pi/settings.json`:
 ```bash
 pi install -l ./pi-packages/ci-status
 pi install -l ./pi-packages/dev-workflow
+pi install -l ./pi-packages/oh-my-pi
 pi install -l ./pi-packages/skills-bridge
 ```
 
@@ -210,14 +215,36 @@ tool registration conflicts for `get_ci_status` and `ci_fetch_job_logs`. Remove
 the duplicate project package entry or uninstall the global copy before
 restarting or running `/reload`.
 
-After install, restart pi or run `/reload`. The `ci-status` package provides
-`/ci`, `/ci-detail`, `/ci-logs`, CI auto-watch, UI widgets, notifications, and
-LLM tools (`get_ci_status`, `ci_fetch_job_logs`). The `dev-workflow`
-package provides `/workflow:*` commands, `/workflow:help`, `/workflow:run`,
-`/workflow:prompts`, `/workflow:flow`, the `dev-workflow` and `ci` skills,
-XDG/project prompt config, and a bundled `agents/workflow-pipeline.chain.md`
-file for pi-subagents. If your pi-subagents setup only scans `.pi/agents/`, copy
-that chain file there manually.
+After install, restart pi or run `/reload`.
+
+Quick mental model:
+
+```text
+ci-status    -> CI visibility and job logs
+
+dev-workflow -> workflow prompts, review passes, shipping, and
+                automatic seeded cmux splits for subagent-style prompts
+                when Pi is inside cmux and the parent session is idle
+
+oh-my-pi     -> explicit cmux notifications, split-pane commands,
+                and workspace-tab commands
+
+skills-bridge -> exposes marketplace plugin skills inside Pi
+```
+
+The `ci-status` package provides `/ci`, `/ci-detail`, `/ci-logs`, CI auto-watch,
+UI widgets, notifications, and LLM tools (`get_ci_status`,
+`ci_fetch_job_logs`).
+
+The `dev-workflow` package provides `/workflow:*` commands,
+`/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`, the
+`dev-workflow` and `ci` skills, XDG/project prompt config, and a bundled
+`agents/workflow-pipeline.chain.md` file for pi-subagents. If your
+pi-subagents setup only scans `.pi/agents/`, copy that chain file there
+manually.
+
+The `oh-my-pi` package provides explicit `/omp-split-*` and
+`/omp-workspace*` cmux commands plus native cmux notifications.
 
 ## Codex Skill Installation
 

--- a/package.json
+++ b/package.json
@@ -2,13 +2,16 @@
   "name": "agent-skills-marketplace",
   "version": "0.0.1",
   "private": true,
-  "description": "Root pi manifest for the Diversio Team agent-skills-marketplace. This file lets pi discover every sub-package (ci-status, dev-workflow, skills-bridge) from a single git clone. Without it, each sub-package needs its own fragile local-path install — which breaks across worktrees and causes duplicate extensions. One pi install git:github.com/DiversioTeam/agent-skills-marketplace now replaces three separate pi install $PWD/pi-packages/<pkg> commands.",
-  "keywords": ["pi-package"],
+  "description": "Root pi manifest for the Diversio Team agent-skills-marketplace. This file lets pi discover every sub-package (ci-status, dev-workflow, oh-my-pi, skills-bridge) from a single git clone. Without it, each sub-package needs its own fragile local-path install — which breaks across worktrees and causes duplicate extensions. One pi install git:github.com/DiversioTeam/agent-skills-marketplace now replaces four separate pi install $PWD/pi-packages/<pkg> commands.",
+  "keywords": [
+    "pi-package"
+  ],
   "pi": {
     "extensions": [
       "pi-packages/ci-status/extensions",
       "pi-packages/dev-workflow/extensions",
-      "pi-packages/skills-bridge/extensions"
+      "pi-packages/skills-bridge/extensions",
+      "pi-packages/oh-my-pi/extensions"
     ],
     "skills": [
       "pi-packages/dev-workflow/skills"

--- a/pi-packages/README.md
+++ b/pi-packages/README.md
@@ -7,7 +7,8 @@ Pi-native packages that extend pi with tools, commands, skills, and UI widgets.
 | Package | What it gives you |
 |---------|-------------------|
 | [`ci-status`](./ci-status) | `/ci`, `/ci-detail`, `/ci-logs` commands, CI auto-watch after pushes, status-line widget, GitHub Actions + CircleCI support, and `get_ci_status` / `ci_fetch_job_logs` LLM tools |
-| [`dev-workflow`](./dev-workflow) | 15 core workflow prompts (`/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`), CI analysis, PR review feedback, release PR prep, local skills, and optional pi-subagents chain |
+| [`dev-workflow`](./dev-workflow) | 15 core workflow prompts (`/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`), CI analysis, PR review feedback, release PR prep, local skills, optional pi-subagents chain, and seeded cmux split launching for subagent-style prompts |
+| [`oh-my-pi`](./oh-my-pi) | Pi-native cmux integration with notifications, readable split commands, and workspace tabs |
 | [`skills-bridge`](./skills-bridge) | Auto-discovers all 21 Claude Code plugin skills from `plugins/*/skills/` and registers them as pi skills — one install bridges the entire plugin ecosystem into pi |
 
 ## Install
@@ -19,7 +20,7 @@ pi install git:github.com/DiversioTeam/agent-skills-marketplace
 ```
 
 The root `package.json` at the top of this repo tells pi where to find every
-package, so one clone discovers all three. Run `/reload` after installing.
+package, so one clone discovers all four. Run `/reload` after installing.
 
 To pull the latest updates later:
 
@@ -38,10 +39,13 @@ From a checkout of this repo:
 ```bash
 pi install "$PWD/pi-packages/ci-status"
 pi install "$PWD/pi-packages/dev-workflow"
+pi install "$PWD/pi-packages/oh-my-pi"
 pi install "$PWD/pi-packages/skills-bridge"
 ```
 
-Use `pi -e ./pi-packages/<pkg>` to test a package without writing to settings.
+Use `pi --no-extensions -e ./pi-packages/<pkg>` to test a package from the repo
+root without writing to settings or loading a duplicate copy from the root
+marketplace manifest.
 
 ### Duplicate warning
 
@@ -65,6 +69,10 @@ pi-packages/
 │   ├── extensions/
 │   ├── skills/
 │   └── agents/
+├── oh-my-pi/
+│   ├── package.json
+│   ├── README.md
+│   └── extensions/
 └── skills-bridge/
     ├── package.json
     ├── README.md
@@ -82,7 +90,7 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full guide. Key rules:
 - Keep each package's `package.json`, `README.md`, and version in sync.
 - **When adding or removing a package**, update the root `package.json`
   `pi.extensions` and `pi.skills` arrays so the git-based install stays accurate.
-- Use `pi -e ./pi-packages/<pkg>` for local smoke tests.
+- Use `pi --no-extensions -e ./pi-packages/<pkg>` for local smoke tests from the repo root.
 - Bump the package version when publishing an update.
 
 ## More

--- a/pi-packages/ci-status/README.md
+++ b/pi-packages/ci-status/README.md
@@ -26,13 +26,14 @@ before `/reload`.
 
 ## Contributing And Local Testing
 
-Use `-e` for one-off extension testing while actively editing this package. It
-loads the package for the current Pi run without changing global or project
-settings:
+Use `--no-extensions -e` for one-off extension testing while actively editing
+this package from the repo root. That loads only this package for the current
+Pi run without changing global or project settings, and avoids loading a second
+copy from the root marketplace manifest:
 
 ```bash
 # From the agent-skills-marketplace repo root
-pi -e ./pi-packages/ci-status
+pi --no-extensions -e ./pi-packages/ci-status
 ```
 
 Use a project-local install only when you need to test `.pi/settings.json`,

--- a/pi-packages/dev-workflow/README.md
+++ b/pi-packages/dev-workflow/README.md
@@ -50,6 +50,112 @@ package project-locally as a developer.
 | `/workflow:reviewer` | `workflow.reviewer` | `reviewer` | Independent review with forked context |
 | `/workflow:parallel` | `workflow.parallel` | 3× `reviewer` | Parallel reviews (correctness, tests, complexity) |
 
+### Default cmux behavior for subagent-style workflow commands
+
+When Pi is running **inside cmux**, these subagent-style commands default to a
+**fresh split pane** with a seeded child session when they are run directly from
+an **idle** parent session:
+
+- `/workflow:scout`
+- `/workflow:oracle`
+- `/workflow:reviewer`
+- `/workflow:parallel`
+
+Why:
+
+- reduce developer overhead — no extra `omp-*` command to remember
+- keep the parent workflow lane uncluttered
+- preserve a focused adjacent lane for review / recon work
+
+Mental model:
+
+```text
+/workflow:reviewer
+  ├─ inside cmux + idle parent session -> open seeded split -> run reviewer prompt there
+  └─ otherwise                         -> run inline in current session
+```
+
+Queued / follow-up flows keep their normal current-session behavior instead of
+unexpectedly opening a split later.
+
+If the split launch fails for any reason, the command falls back inline instead
+of failing outright.
+
+If `pi-subagents` is installed, the child session can still use the `subagent`
+tool from inside that split. So cmux handles **surface separation**, while
+`pi-subagents` still handles **agent isolation**.
+
+### What gets seeded into the child lane
+
+The new split is not a blank Pi session.
+
+It starts with a small, focused handoff message that includes:
+
+- the same working directory
+- the current git branch
+- a short `git status --short` snapshot
+- a small recent conversation snapshot from the parent workflow lane
+- any extra text you passed to the workflow command
+- the parent session's selected model when available
+
+Mental model:
+
+```text
+Parent workflow lane
+  ├─ /workflow:reviewer focus on API error handling
+  └─ New cmux split
+       ├─ same repo + cwd
+       ├─ seeded child session on disk
+       ├─ recent parent context
+       └─ reviewer prompt runs there
+```
+
+### Why this logic lives inside dev-workflow
+
+You might reasonably ask:
+
+> "Why not force users to run an explicit `/omp-*` command first?"
+
+Because that adds memory burden.
+
+The goal here is:
+
+```text
+I want review / recon help
+  -> run /workflow:reviewer
+  -> get the right lane automatically when cmux can help
+```
+
+`oh-my-pi` is still the **explicit user-facing cmux command surface** for people
+who want manual control.
+
+`dev-workflow` duplicates a tiny amount of cmux-launch logic on purpose so it:
+
+- works even when installed by itself
+- does not require users to remember a second command
+- keeps the common workflow as one obvious action
+
+### Examples
+
+```text
+/workflow:reviewer
+/workflow:reviewer focus on API error handling
+/workflow:oracle is this migration rollout safe?
+/workflow:parallel only review backend changes
+```
+
+Force inline behavior even inside cmux:
+
+```bash
+PI_WORKFLOW_CMUX_MODE=inline pi --no-extensions -e ./pi-packages/dev-workflow
+```
+
+Prefer a down split instead of a right split:
+
+```bash
+PI_WORKFLOW_CMUX_SPLIT_DIRECTION=down pi --no-extensions -e ./pi-packages/dev-workflow
+```
+
 ### Navigation and prompt registry
 | Command / Shortcut | Does |
 |---|---|
@@ -151,7 +257,7 @@ settings:
 
 ```bash
 # From the agent-skills-marketplace repo root
-pi -e ./pi-packages/dev-workflow
+pi --no-extensions -e ./pi-packages/dev-workflow
 ```
 
 Use a project-local install only when you need to test `.pi/settings.json`,
@@ -181,6 +287,15 @@ After changing commands, tools, shortcuts, prompt inventory, skills, chain
 files, or package resources, update this README plus the top-level `README.md`,
 `docs/runbooks/distribution.md`, and `docs/plugins/catalog.md`.
 
+## Configuration
+
+Optional environment variables:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `PI_WORKFLOW_CMUX_MODE` | `auto` | `auto` = subagent-style workflow commands prefer a seeded cmux split when available; `inline` = always stay in the current session |
+| `PI_WORKFLOW_CMUX_SPLIT_DIRECTION` | `right` | Split direction for subagent-style workflow commands: `right` or `down` |
+
 ## Requirements
 
 - pi >= 1.0.0
@@ -194,4 +309,4 @@ files, or package resources, update this README plus the top-level `README.md`,
   `ci-status` both globally and from a different project-local path; duplicated
   CI tools can conflict.
 
-Subagent commands require [pi-subagents](https://github.com/nicobailon/pi-subagents) for true agent isolation; they fall back to inline execution without it. CI prompts prefer the `ci-status` package when installed and only fall back to `get_ci_status` / `ci_fetch_job_logs` when the current harness exposes those tools.
+Subagent commands can use [pi-subagents](https://github.com/nicobailon/pi-subagents) for true agent isolation. When Pi is inside cmux, the default workflow behavior is to open a seeded split for subagent-style prompts; inside that split, the prompt still asks the AI to use the `subagent` tool when available and to fall back gracefully when it is not. CI prompts prefer the `ci-status` package when installed and only fall back to `get_ci_status` / `ci_fetch_job_logs` when the current harness exposes those tools.

--- a/pi-packages/dev-workflow/extensions/dev-workflow/index.ts
+++ b/pi-packages/dev-workflow/extensions/dev-workflow/index.ts
@@ -1,4 +1,4 @@
-import { DynamicBorder, type ExtensionAPI, type Theme } from "@mariozechner/pi-coding-agent";
+import { DynamicBorder, SessionManager, type ExtensionAPI, type Theme } from "@mariozechner/pi-coding-agent";
 import { HelpPanel, PromptEditor, type WorkflowHelpCommand, type WorkflowPromptCategory, type WorkflowPromptSource } from "./help-panel";
 import { Container, Input, Key, matchesKey, SelectList, Spacer, Text, truncateToWidth, type SelectItem } from "@mariozechner/pi-tui";
 import { access, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
@@ -1448,6 +1448,324 @@ interface WorkflowContext {
   isIdle?: () => boolean;
 }
 
+/**
+ * cmux workflow-lane helpers
+ *
+ * Why this logic lives inside `dev-workflow` instead of depending on
+ * `oh-my-pi` command names:
+ * - `dev-workflow` should stay useful when installed by itself.
+ * - Workflow commands need behavior, not a second command the user must remember.
+ * - Calling cmux directly keeps the default workflow low-friction.
+ *
+ * Mental model:
+ *
+ * ```text
+ * current workflow session
+ *   ├─ decide whether this prompt deserves a fresh adjacent lane
+ *   ├─ if yes: create a seeded child Pi session on disk
+ *   ├─ open a cmux split beside the parent
+ *   └─ launch Pi in that child session with the workflow prompt
+ * ```
+ */
+type WorkflowSplitDirection = "right" | "down";
+
+type WorkflowSessionMessage = {
+  role?: string;
+  content?: unknown;
+};
+
+type WorkflowSessionEntry = {
+  type?: string;
+  message?: WorkflowSessionMessage;
+};
+
+/**
+ * Cheap environment check for "should we even consider cmux behavior?"
+ *
+ * We still ask cmux for authoritative workspace/surface refs later before
+ * opening a split. This helper is only the fast first gate.
+ */
+function isInsideCmux(): boolean {
+  return Boolean(
+    process.env.CMUX_SOCKET_PATH &&
+    process.env.CMUX_WORKSPACE_ID &&
+    process.env.CMUX_SURFACE_ID,
+  );
+}
+
+function getWorkflowCmuxMode(): "auto" | "inline" {
+  const value = process.env.PI_WORKFLOW_CMUX_MODE?.trim().toLowerCase();
+  return value === "inline" ? "inline" : "auto";
+}
+
+function getWorkflowSplitDirection(): WorkflowSplitDirection {
+  const value = process.env.PI_WORKFLOW_CMUX_SPLIT_DIRECTION?.trim().toLowerCase();
+  return value === "down" ? "down" : "right";
+}
+
+/**
+ * Escape one shell argument for `sh -lc`-style command composition.
+ *
+ * We keep this tiny and local because the spawned cmux lane receives free-form
+ * prompt text. A single quote bug here would launch the wrong command.
+ */
+function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Build the exact command cmux should run inside the child split.
+ *
+ * Important details:
+ * - `--session <file>` points Pi at the seeded child session we created.
+ * - `--` before the prompt prevents prompts starting with `-` from being
+ *   misread as CLI flags.
+ * - `exec pi` replaces the temporary shell with Pi itself.
+ */
+function buildPiSessionCommand(cwd: string, sessionFile: string, prompt: string): string {
+  return [
+    "cd",
+    shellEscape(cwd),
+    "&&",
+    "exec",
+    "pi",
+    "--session",
+    shellEscape(sessionFile),
+    "--",
+    shellEscape(prompt),
+  ].join(" ");
+}
+
+function truncateForWorkflow(text: string, max = 320): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= max) return normalized;
+  return `${normalized.slice(0, max - 1)}…`;
+}
+
+function messageTextForWorkflow(message: WorkflowSessionMessage | undefined): string | undefined {
+  if (!message) return undefined;
+  const content = message.content;
+
+  if (typeof content === "string") {
+    return truncateForWorkflow(content);
+  }
+
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+
+  const parts = content.flatMap((part) => {
+    if (!part || typeof part !== "object") return [] as string[];
+    const item = part as { type?: unknown; text?: unknown };
+    if (item.type === "text" && typeof item.text === "string" && item.text.trim().length > 0) {
+      return [item.text.trim()];
+    }
+    return [] as string[];
+  });
+
+  if (parts.length === 0) return undefined;
+  return truncateForWorkflow(parts.join("\n"));
+}
+
+/**
+ * Build a tiny, human-readable snapshot of the most recent conversation.
+ *
+ * Why only a few messages?
+ * - The child lane needs enough context to orient itself.
+ * - Copying the whole session would be noisy and defeat the point of a focused
+ *   adjacent lane.
+ */
+function recentConversationSnapshot(entries: WorkflowSessionEntry[]): string {
+  const lines = entries
+    .filter((entry): entry is WorkflowSessionEntry & { type: "message"; message: WorkflowSessionMessage } => entry.type === "message" && !!entry.message)
+    .filter((entry) => entry.message.role === "user" || entry.message.role === "assistant")
+    .slice(-4)
+    .flatMap((entry) => {
+      const text = messageTextForWorkflow(entry.message);
+      if (!text) return [] as string[];
+      return [`- ${entry.message.role}: ${text}`];
+    });
+
+  return lines.length > 0 ? lines.join("\n") : "- (no recent text conversation found)";
+}
+
+async function execTextOptional(pi: ExtensionAPI, command: string, args: string[], cwd: string, timeout = 5_000): Promise<string | undefined> {
+  try {
+    return await execText(pi, command, args, cwd, timeout);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Execute one cmux command with normalized error handling.
+ *
+ * This keeps the workflow code readable: higher-level logic can think in terms
+ * of "open a split" instead of child-process edge cases.
+ */
+async function execCmux(pi: ExtensionAPI, args: string[], timeout = 5_000) {
+  const result = await pi.exec("cmux", args, { timeout });
+  if (result.killed) {
+    return { ok: false as const, error: "cmux command timed out", stdout: result.stdout };
+  }
+  if (result.code !== 0) {
+    return {
+      ok: false as const,
+      error: result.stderr.trim() || result.stdout.trim() || `cmux exited with code ${result.code}`,
+      stdout: result.stdout,
+    };
+  }
+  return { ok: true as const, stdout: result.stdout };
+}
+
+/**
+ * Ask cmux which workspace/surface launched the current session.
+ *
+ * We use cmux itself as the source of truth instead of trusting environment
+ * variables for split targeting.
+ */
+async function identifyCmuxCaller(pi: ExtensionAPI): Promise<{ ok: true; workspaceRef: string; surfaceRef: string } | { ok: false; error: string }> {
+  const result = await execCmux(pi, ["--json", "identify"]);
+  if (!result.ok) {
+    return { ok: false, error: result.error };
+  }
+
+  try {
+    const parsed = JSON.parse(result.stdout) as {
+      caller?: { workspace_ref?: string; surface_ref?: string };
+    };
+    const workspaceRef = parsed?.caller?.workspace_ref;
+    const surfaceRef = parsed?.caller?.surface_ref;
+    if (!workspaceRef || !surfaceRef) {
+      return { ok: false, error: "Could not determine cmux workspace/surface for this session" };
+    }
+    return { ok: true, workspaceRef, surfaceRef };
+  } catch {
+    return { ok: false, error: "Failed to parse cmux identify output" };
+  }
+}
+
+/**
+ * Open a new cmux split beside the parent workflow session and run one command.
+ *
+ * Two-step flow:
+ * 1. `new-split` creates the new surface and returns its surface ref.
+ * 2. `respawn-pane` replaces the placeholder shell with the real Pi command.
+ *
+ * This matches how `oh-my-pi` launches splits, but is duplicated locally so
+ * `dev-workflow` remains independently installable.
+ */
+async function openWorkflowSplit(
+  pi: ExtensionAPI,
+  direction: WorkflowSplitDirection,
+  command: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const caller = await identifyCmuxCaller(pi);
+  if (!caller.ok) return caller;
+
+  const created = await execCmux(pi, [
+    "--json",
+    "new-split",
+    direction,
+    "--workspace",
+    caller.workspaceRef,
+    "--surface",
+    caller.surfaceRef,
+  ]);
+  if (!created.ok) {
+    return { ok: false, error: created.error };
+  }
+
+  let newSurfaceRef: string | undefined;
+  try {
+    const parsed = JSON.parse(created.stdout) as { surface_ref?: string };
+    newSurfaceRef = parsed.surface_ref;
+  } catch {
+    return { ok: false, error: "Failed to parse cmux split response" };
+  }
+
+  if (!newSurfaceRef) {
+    return { ok: false, error: "cmux did not return a new split surface ref" };
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 250));
+
+  const respawned = await execCmux(pi, [
+    "respawn-pane",
+    "--workspace",
+    caller.workspaceRef,
+    "--surface",
+    newSurfaceRef,
+    "--command",
+    command,
+  ]);
+  if (!respawned.ok) {
+    return { ok: false, error: respawned.error };
+  }
+
+  return { ok: true };
+}
+
+function workflowSessionName(prompt: WorkflowPrompt, extra?: string): string {
+  const suffix = extra?.trim();
+  if (!suffix) return prompt.label;
+  return truncateForWorkflow(`${prompt.label} — ${suffix}`, 80);
+}
+
+/**
+ * Build the first user message stored in the child session.
+ *
+ * This is the bridge between the parent lane and the new split. It explains:
+ * - why the child lane exists
+ * - what repo state it should care about
+ * - enough recent context to start intelligently
+ */
+function buildWorkflowLaneContext(options: {
+  prompt: WorkflowPrompt;
+  cwd: string;
+  gitBranch?: string;
+  gitStatus?: string;
+  recentConversation: string;
+  extra?: string;
+}): string {
+  const gitStatus = options.gitStatus?.trim()
+    ? options.gitStatus.trim().split("\n").slice(0, 12).join("\n")
+    : "(working tree clean or unavailable)";
+  const extraContext = options.extra?.trim() ? options.extra.trim() : "(none)";
+
+  return `## Why this session exists
+This Pi session was opened automatically in a fresh cmux split for ${options.prompt.code}.
+
+Why:
+- keep the parent workflow session uncluttered
+- give this review / recon / oracle lane its own focused workspace
+- reduce developer overhead by making the extra lane the default when cmux is available
+
+Treat this message as background context for the next user instruction in this session.
+Do not answer this message directly.
+
+## Working directory
+${options.cwd}
+
+## Git context
+- branch: ${options.gitBranch ?? "(unavailable)"}
+
+## Current git status
+${gitStatus}
+
+## Recent parent-session conversation
+${options.recentConversation}
+
+## Extra context from the command invocation
+${extraContext}
+
+## Ground rules for this lane
+- Use the current repository state as source of truth.
+- Read git diff, changed files, and surrounding code as needed.
+- Assume the parent session may have in-progress local changes.
+- End with a concise, actionable summary.`;
+}
+
 export default function (pi: ExtensionAPI) {
   const detectSubagents = (): boolean => {
     try {
@@ -1513,9 +1831,111 @@ export default function (pi: ExtensionAPI) {
     pi.sendUserMessage(text, options);
   };
 
+  /**
+   * Try to run one workflow prompt in a fresh cmux split.
+   *
+   * Returns `true` only when the split was launched successfully and the caller
+   * should stop. Returns `false` to mean "fall back to normal inline workflow
+   * behavior".
+   */
+  const maybeRunPromptInCmuxLane = async (
+    ctx: WorkflowContext,
+    prompt: WorkflowPrompt,
+    extra?: string,
+  ): Promise<boolean> => {
+    if (prompt.category !== "subagent") return false;
+    if (getWorkflowCmuxMode() !== "auto") return false;
+    if (!isInsideCmux()) return false;
+
+    const commandCtx = ctx as WorkflowContext & {
+      sessionManager?: { getBranch: () => WorkflowSessionEntry[]; getSessionFile: () => string | undefined };
+      model?: { provider: string; id: string };
+    };
+    const sessionManager = commandCtx.sessionManager;
+    if (!sessionManager) return false;
+
+    let childSessionFile: string | undefined;
+    try {
+      const taskPrompt = appendExtra(prompt.prompt, extra);
+      const gitBranch = await execTextOptional(pi, "git", ["branch", "--show-current"], ctx.cwd, 5_000);
+      const gitStatus = await execTextOptional(pi, "git", ["status", "--short", "--untracked-files=normal"], ctx.cwd, 5_000);
+      const recentConversation = recentConversationSnapshot(sessionManager.getBranch());
+      const parentSession = sessionManager.getSessionFile();
+
+      // Create a real persisted child session first, then point the new split
+      // at it. This gives the new lane a stable session file, inherited model
+      // choice, and a seeded context message before Pi ever starts rendering.
+      const childSession = SessionManager.create(ctx.cwd);
+      if (commandCtx.model) {
+        childSession.appendModelChange(commandCtx.model.provider, commandCtx.model.id);
+      }
+      childSession.appendSessionInfo(workflowSessionName(prompt, extra));
+      childSession.appendMessage({
+        role: "user",
+        content: [{
+          type: "text",
+          text: buildWorkflowLaneContext({
+            prompt,
+            cwd: ctx.cwd,
+            gitBranch,
+            gitStatus,
+            recentConversation,
+            extra: [
+              parentSession ? `parent session: ${parentSession}` : undefined,
+              extra?.trim() ? extra.trim() : undefined,
+            ].filter(Boolean).join("\n"),
+          }),
+        }],
+        timestamp: Date.now(),
+      });
+
+      childSessionFile = childSession.getSessionFile();
+      if (!childSessionFile) {
+        ctx.ui.notify(`Could not create child session for ${prompt.code}; running inline instead.`, "warning");
+        return false;
+      }
+
+      const direction = getWorkflowSplitDirection();
+      const splitResult = await openWorkflowSplit(
+        pi,
+        direction,
+        buildPiSessionCommand(ctx.cwd, childSessionFile, taskPrompt),
+      );
+      if (!splitResult.ok) {
+        await unlink(childSessionFile).catch(() => undefined);
+        ctx.ui.notify(`cmux lane launch failed for ${prompt.code}; running inline instead. ${splitResult.error}`, "warning");
+        return false;
+      }
+
+      ctx.ui.notify(
+        `Opened ${prompt.code} in a ${direction === "right" ? "right-side" : "down-side"} cmux split with a seeded child session.`,
+        "info",
+      );
+      return true;
+    } catch (error) {
+      if (childSessionFile) {
+        await unlink(childSessionFile).catch(() => undefined);
+      }
+      ctx.ui.notify(
+        `cmux lane launch failed for ${prompt.code}; running inline instead. ${error instanceof Error ? error.message : String(error)}`,
+        "warning",
+      );
+      return false;
+    }
+  };
+
   const runPrompt = async (ctx: WorkflowContext, prompt: WorkflowPrompt, extra?: string, deliverAs: "normal" | "followUp" = "normal") => {
     const text = appendExtra(prompt.prompt, extra);
-    const willQueue = deliverAs === "followUp" && !(ctx.isIdle?.() ?? true);
+    const isIdle = ctx.isIdle?.() ?? true;
+    const willQueue = deliverAs === "followUp" && !isIdle;
+
+    // Only attempt cmux lane launching when the prompt is being run directly,
+    // immediately, from an idle session. Follow-up/queue flows should preserve
+    // their existing semantics instead of unexpectedly opening a new split.
+    if (deliverAs === "normal" && isIdle && (await maybeRunPromptInCmuxLane(ctx, prompt, extra))) {
+      return;
+    }
+
     ctx.ui.notify(`${willQueue ? "Queueing" : "Running"} ${prompt.code}${willQueue ? " as follow-up" : ""}…`, "info");
     sendWorkflowMessage(ctx, text, deliverAs);
   };

--- a/pi-packages/dev-workflow/extensions/dev-workflow/index.ts
+++ b/pi-packages/dev-workflow/extensions/dev-workflow/index.ts
@@ -1,4 +1,4 @@
-import { DynamicBorder, SessionManager, type ExtensionAPI, type Theme } from "@mariozechner/pi-coding-agent";
+import { DynamicBorder, SessionManager, type ExtensionAPI, type SessionEntry, type SessionHeader, type Theme } from "@mariozechner/pi-coding-agent";
 import { HelpPanel, PromptEditor, type WorkflowHelpCommand, type WorkflowPromptCategory, type WorkflowPromptSource } from "./help-panel";
 import { Container, Input, Key, matchesKey, SelectList, Spacer, Text, truncateToWidth, type SelectItem } from "@mariozechner/pi-tui";
 import { access, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
@@ -1766,6 +1766,45 @@ ${extraContext}
 - End with a concise, actionable summary.`;
 }
 
+/**
+ * Force a seeded child session onto disk before launching `pi --session <file>`.
+ *
+ * Why this exists:
+ * - `SessionManager.create()` gives us a future session file path immediately.
+ * - But Pi intentionally delays writing a brand-new session file until it sees
+ *   an assistant message, to avoid duplicate-header edge cases during normal
+ *   interactive use.
+ * - Our cmux lane flow is different: we launch a brand-new Pi process against
+ *   that path immediately after seeding only user-side context.
+ *
+ * Without this helper, the new split can start from an empty session file path
+ * and lose the seeded branch / git / conversation context that makes the lane
+ * useful in the first place.
+ */
+async function persistSeededWorkflowSession(session: {
+  getHeader(): SessionHeader | null;
+  getEntries(): SessionEntry[];
+  getSessionFile(): string | undefined;
+}): Promise<string> {
+  const sessionFile = session.getSessionFile();
+  const header = session.getHeader();
+
+  if (!sessionFile) {
+    throw new Error("Child workflow session has no session file path");
+  }
+  if (!header) {
+    throw new Error("Child workflow session has no session header");
+  }
+
+  const lines = [header, ...session.getEntries()]
+    .map((entry) => JSON.stringify(entry))
+    .join("\n");
+
+  await mkdir(dirname(sessionFile), { recursive: true });
+  await writeFile(sessionFile, `${lines}\n`, "utf8");
+  return sessionFile;
+}
+
 export default function (pi: ExtensionAPI) {
   const detectSubagents = (): boolean => {
     try {
@@ -1889,11 +1928,11 @@ export default function (pi: ExtensionAPI) {
         timestamp: Date.now(),
       });
 
-      childSessionFile = childSession.getSessionFile();
-      if (!childSessionFile) {
-        ctx.ui.notify(`Could not create child session for ${prompt.code}; running inline instead.`, "warning");
-        return false;
-      }
+      // Persist the seeded user-only session before launching the child Pi
+      // process. Pi's SessionManager intentionally defers flushes for brand-new
+      // sessions until an assistant message exists, but our split launcher needs
+      // the file to exist immediately.
+      childSessionFile = await persistSeededWorkflowSession(childSession);
 
       const direction = getWorkflowSplitDirection();
       const splitResult = await openWorkflowSplit(

--- a/pi-packages/dev-workflow/package.json
+++ b/pi-packages/dev-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflow",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Daily developer workflow for pi — workflow prompt registry, plan review, self-review, standards, CI, PR review comments, release PR prep, docs, and shipping. 15 core prompts plus help, run, prompts, and flow.",
   "keywords": ["pi-package"],
   "files": ["extensions/", "skills/", "agents/", "README.md"],

--- a/pi-packages/dev-workflow/skills/dev-workflow/SKILL.md
+++ b/pi-packages/dev-workflow/skills/dev-workflow/SKILL.md
@@ -153,7 +153,21 @@ When [pi-subagents](https://github.com/nicobailon/pi-subagents) is installed, th
 | `/workflow:reviewer` | `reviewer` | Independent review with forked context (correctness, edge cases, tests, simplicity) |
 | `/workflow:parallel` | 3× `reviewer` | Three parallel reviewers (correctness, tests, complexity) → synthesized fixes |
 
-All subagent commands fall back to inline execution if pi-subagents is not installed. The prompts guide the AI to use the subagent tool when available.
+When Pi is running inside cmux, subagent-style workflow commands default to opening a **seeded split pane** when they are run directly from an **idle** parent session, so the review / recon lane gets its own adjacent surface without the engineer having to remember a separate cmux command.
+
+Mental model:
+
+```text
+/workflow:reviewer
+  ├─ inside cmux + idle parent session -> open seeded split -> run reviewer prompt there
+  └─ otherwise                         -> run inline in current session
+```
+
+Queued / follow-up flows keep their normal current-session behavior instead of unexpectedly opening a split later.
+
+The seeded child session carries a small handoff: same cwd, current branch, short git status, a recent parent-session conversation snapshot, and any extra command text.
+
+Inside that child session, the prompt still guides the AI to use the `subagent` tool when available. If `pi-subagents` is not installed, it falls back gracefully to inline analysis / review logic in that lane.
 
 ### Reusable Chains
 

--- a/pi-packages/oh-my-pi/README.md
+++ b/pi-packages/oh-my-pi/README.md
@@ -1,0 +1,335 @@
+# oh-my-pi
+
+Pi-native cmux integration package. Provides cmux notifications, split panes, and
+workspace tabs via the native cmux CLI — no tmux-compat shims, no OMC/OMX/OMO
+dependency.
+
+## Why this package exists
+
+Diversio uses **Pi inside cmux** all day.
+
+That means we already have two strong systems:
+
+- **Pi** knows when the agent starts, reads files, changes code, fails, and waits.
+- **cmux** knows how to open panes, create workspace tabs, track unread state,
+  and show native notifications.
+
+So the simplest good solution is:
+
+```text
+Pi lifecycle events  ──► summarize what happened ──► cmux native UX
+```
+
+We intentionally do **not** emulate tmux, fake notifications with OSC escape
+sequences, or add runtime-heavy dependencies. We use the cmux features that
+already exist.
+
+## Mental model
+
+```text
+cmux-core.ts
+  ├─ knows how to talk to cmux safely
+  ├─ builds shell / Pi launch commands
+  ├─ opens splits
+  └─ opens workspace tabs
+
+cmux-notify.ts
+  ├─ listens to Pi events
+  ├─ collects simple facts during a run
+  └─ sends one useful notification at the end
+
+cmux-split.ts
+  └─ exposes readable /omp-split-* commands (+ short aliases)
+
+cmux-workspace.ts
+  └─ exposes readable /omp-workspace* commands (+ short aliases)
+```
+
+## How this relates to dev-workflow
+
+`oh-my-pi` is the **explicit** cmux command surface.
+
+That means if you want to manually say:
+
+- "open a split to the right"
+- "run this shell command in a split"
+- "open a named workspace tab"
+
+then `oh-my-pi` is the package that gives you those commands.
+
+`dev-workflow` now also uses cmux automatically for some workflow commands like
+`/workflow:reviewer` when Pi is inside cmux and the parent session is idle.
+
+Why not make `dev-workflow` call `/omp-split-right` directly?
+
+Because the packages should stay independently installable.
+
+So the mental model is:
+
+```text
+oh-my-pi      -> explicit user-facing cmux commands
+              -> /omp-split-*, /omp-workspace*
+
+dev-workflow  -> automatic cmux use when a workflow lane clearly benefits
+              -> /workflow:scout, /workflow:oracle, /workflow:reviewer, /workflow:parallel
+```
+
+## Quick Install (local test)
+
+From the marketplace root, use `--no-extensions` so the root marketplace
+manifest does not load a second copy of `oh-my-pi`:
+
+```bash
+cd /path/to/agent-skills-marketplace
+pi --no-extensions -e ./pi-packages/oh-my-pi
+```
+
+Or with an absolute path:
+
+```bash
+pi --no-extensions -e /path/to/pi-packages/oh-my-pi
+```
+
+## Commands
+
+All commands use the `omp` prefix to avoid collisions with other cmux
+integrations (e.g., pi-cmux).
+
+## Recommended default
+
+For most day-to-day work, **prefer split panes first**.
+
+Why:
+
+- they keep you in the same workspace tab
+- they avoid a focus jump
+- they are better for short-lived side work
+- they feel more like "open a helper lane next to me"
+
+Use **workspace tabs** when you want stronger isolation, a named lane, or a
+longer-lived task you plan to come back to later.
+
+```text
+Default for quick adjacent work
+├─ /omp-split-right
+├─ /omp-split-right-command <cmd>
+├─ /omp-split-down
+└─ /omp-split-down-command <cmd>
+
+Escalate to a workspace tab when the work deserves its own lane
+├─ /omp-workspace [--name <title>] [prompt]
+└─ /omp-workspace-command [--name <title>] <cmd>
+```
+
+### Split Panes
+
+| Canonical command | Alias | Direction | Launches |
+|-------------------|-------|-----------|----------|
+| `/omp-split-right` | `/ompv` | Right | Fresh Pi session in current cwd |
+| `/omp-split-right-command` | `/ompr` | Right | Arbitrary shell command in current cwd |
+| `/omp-split-down` | `/omph` | Down | Fresh Pi session in current cwd |
+| `/omp-split-down-command` | `/omphr` | Down | Arbitrary shell command in current cwd |
+
+Examples:
+
+```
+/omp-split-right
+/omp-split-right fix the user auth module
+/omp-split-right-command htop
+/omp-split-down-command npm run test
+```
+
+Short aliases still work if you prefer them:
+
+```
+/ompv
+/ompr htop
+/omph
+/omphr npm run test
+```
+
+### Workspace Tabs
+
+Think of workspace tabs as a **stronger boundary** than split panes.
+
+Choose them when you want:
+
+- a named context like `Auth Review` or `Build Watch`
+- a longer-running task
+- a lane you expect to revisit later
+- clearer unread / focus signals from cmux
+
+| Canonical command | Alias | Launches |
+|-------------------|-------|----------|
+| `/omp-workspace` | `/ompw` | Fresh Pi session in a new workspace tab. Switches focus to the new tab. |
+| `/omp-workspace-command` | `/ompwr` | Arbitrary shell command in a new workspace tab. Switches focus to the new tab. |
+
+Both accept an optional `--name <title>` argument. Quote multi-word titles:
+
+```
+/omp-workspace --name "Auth Review" review the login flow
+/omp-workspace-command --name "Build Watch" npm run dev
+```
+
+You can also use ` -- ` to disambiguate an unquoted multi-word title:
+
+```
+/omp-workspace --name Auth Review -- review the login flow
+/omp-workspace-command --name Build Watch -- npm run dev
+```
+
+**Important**: Creating a new workspace tab switches focus to it. There is no
+`--no-focus` option in cmux v1. Do not treat workspace creation as a background
+operation.
+
+## Notifications
+
+### How the notification system thinks
+
+The package does **not** notify on every tool call.
+
+That would be noisy and hard to trust.
+
+Instead it follows this model:
+
+```text
+agent_start
+  └─ start collecting facts
+       ├─ read files
+       ├─ changed files
+       ├─ searches
+       ├─ shell commands
+       └─ first failure
+
+agent_end
+  └─ build one summary
+       ├─ Waiting
+       ├─ Task Complete
+       └─ Error
+```
+
+This gives the user one answer to the question:
+
+> "What just happened in that Pi run?"
+
+instead of a stream of low-value noise.
+
+Pi sends native cmux notifications at the end of each agent run. Notification
+titles include the workspace name for quick context (e.g. `Pi — my-project`).
+Bodies show rich activity detail instead of generic messages.
+
+Notifications are classified as:
+
+- **Waiting** — Pi is idle and waiting for input
+- **Task Complete** — Pi changed files or the run exceeded the threshold
+- **Error** — The agent run ended in an error
+
+### Example notifications
+
+```text
+Title:   Pi — agent-skills-marketplace
+Sub:     Task Complete
+Body:    Changed cmux-notify.ts, README.md · 47s
+
+Title:   Pi — backend
+Sub:     Waiting
+Body:    Read settings.py, urls.py · 3 searches · 5s
+
+Title:   Pi — frontend
+Sub:     Error
+Body:    edit failed for App.tsx [2 cmds run]
+```
+
+Notifications also appear as in-Pi TUI notifications for immediate visibility.
+They are silent when running outside cmux.
+
+## Configuration (environment variables)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PI_CMUX_NOTIFY_LEVEL` | `all` | `all`, `medium` (skip "Waiting"), `low` (errors only), `disabled` |
+| `PI_CMUX_NOTIFY_THRESHOLD_MS` | `15000` | Duration in ms above which a success run becomes "Task Complete" |
+| `PI_CMUX_NOTIFY_DEBOUNCE_MS` | `3000` | Minimum ms between duplicate notifications |
+| `PI_CMUX_NOTIFY_TITLE` | `Pi` | Notification title shown in the cmux notification panel |
+
+## Architecture
+
+### Why some behavior looks "strict"
+
+A few choices in this package are intentionally conservative:
+
+- **Shell escaping is centralized** because prompts and commands can contain
+  spaces and quotes, and split/tab launches are painful to debug when escaping
+  is wrong.
+- **`new-workspace` is parsed as plain text** because cmux currently returns
+  `OK workspace:<n>` in real usage, even when JSON might be expected.
+- **Pi prompts are passed after `--`** so prompts that start with `-` are not
+  misread as CLI flags.
+- **Notifications are deduplicated** because repeated "Waiting" summaries are
+  more annoying than helpful.
+
+## Architecture
+
+```
+extensions/oh-my-pi/
+├── index.ts           # Entry point (auto-discovered by pi)
+├── cmux-core.ts       # Shared cmux helpers (caller detection, shell escaping,
+│                      #   command building, notify, openSplit, openWorkspace)
+├── cmux-notify.ts     # Notification logic (listens to agent_start,
+│                      #   tool_result, agent_end)
+├── cmux-split.ts      # Split pane commands (/omp-split-* + aliases)
+└── cmux-workspace.ts  # Workspace tab commands (/omp-workspace* + aliases)
+```
+
+### Design decisions
+
+- Uses native `cmux notify` (not OSC escape sequences)
+- Uses `cmux --json new-split` + `respawn-pane` (no polling)
+- Treats `cmux new-workspace` as text output (not JSON)
+- No runtime npm dependencies
+- Silent no-op outside cmux for notifications; interactive commands warn
+
+## Limitations (v1)
+
+- Workspace tab creation always switches focus; no background creation
+- No session-file passing across splits/tabs (each new Pi session is independent)
+- Notifications occur at agent_end only; no mid-run progress notifications
+- Commands are cmux-only; they warn if run outside cmux
+
+## Maintainer notes
+
+### If you need to extend this package later
+
+Use this rule of thumb:
+
+- If the change is about **talking to cmux**, put it in `cmux-core.ts`.
+- If the change is about **when / what to notify**, put it in `cmux-notify.ts`.
+- If the change is about **slash command UX**, put it in `cmux-split.ts` or
+  `cmux-workspace.ts`.
+
+### Safe places to evolve next
+
+```text
+Good next v2 ideas
+├─ custom notification templates
+├─ more split directions / aliases
+├─ better workspace title parsing
+├─ optional background workspace behavior if cmux adds it
+└─ richer notification classification
+```
+
+## Verification
+
+```bash
+# Manifest check
+jq -e . pi-packages/oh-my-pi/package.json >/dev/null
+
+# Command registration check
+printf '{"id":"cmds","type":"get_commands"}\n' | \
+  PI_OFFLINE=1 pi --mode rpc --no-session --no-context-files \
+    --no-extensions -e ./pi-packages/oh-my-pi \
+    --no-prompt-templates --no-skills | jq .
+
+# Interactive test (inside cmux, isolated from the repo root manifest)
+pi --no-extensions -e ./pi-packages/oh-my-pi
+```

--- a/pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-core.ts
+++ b/pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-core.ts
@@ -1,0 +1,379 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+/**
+ * Shared cmux helpers
+ *
+ * Why this file exists:
+ * - `cmux-split.ts`, `cmux-workspace.ts`, and `cmux-notify.ts` all need a few
+ *   of the same low-level building blocks.
+ * - cmux output is *mixed mode*: some commands return JSON, others still return
+ *   plain text. Centralizing the parsing rules here keeps that weirdness in one
+ *   place instead of scattering it across command handlers.
+ *
+ * First principles:
+ * - Ask cmux who the caller is instead of guessing.
+ * - Build shell commands once, in one place, with strict escaping.
+ * - Treat every cmux CLI call like a small RPC boundary that can fail or time out.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SplitDirection = "right" | "down";
+
+export interface CmuxCallerInfo {
+  workspace_ref: string;
+  surface_ref: string;
+}
+
+interface CmuxIdentifyResponse {
+  caller?: {
+    workspace_ref?: string;
+    surface_ref?: string;
+  };
+}
+
+interface CmuxSplitResponse {
+  surface_ref?: string;
+}
+
+interface CmuxExecResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CMUX_TIMEOUT_MS = 5000;
+const SPLIT_BOOT_DELAY_MS = 250;
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function parseJson<T>(text: string): T | undefined {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shell escaping
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape one shell argument for `sh -lc '...'` style commands.
+ *
+ * Why so strict?
+ * - Split/workspace commands let the user pass free-form prompts and shell text.
+ * - A single bad quote can launch the wrong command in the wrong tab.
+ *
+ * We use classic single-quote shell escaping because it is boring, predictable,
+ * and works well for the short command lines we generate here.
+ */
+export function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+// ---------------------------------------------------------------------------
+// Command builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the exact shell command we want cmux to run for a fresh Pi session.
+ *
+ * Design choices:
+ * - `cd <cwd>` makes the new pane/tab start in the same directory as the
+ *   current Pi session.
+ * - `exec pi` replaces the temporary shell with Pi itself.
+ * - `--` before the prompt prevents prompts that start with `-` from being
+ *   misread as Pi CLI flags.
+ */
+export function buildPiCommand(
+  cwd: string,
+  options?: { sessionFile?: string; prompt?: string },
+): string {
+  const parts = ["cd", shellEscape(cwd), "&&", "exec", "pi"];
+  if (options?.sessionFile) {
+    parts.push("--session", shellEscape(options.sessionFile));
+  }
+  const prompt = options?.prompt?.trim();
+  if (prompt) {
+    parts.push("--", shellEscape(prompt));
+  }
+  return parts.join(" ");
+}
+
+/**
+ * Build the exact shell command we want cmux to run for arbitrary shell work.
+ *
+ * We intentionally route through `sh -lc` instead of trying to split the user's
+ * command into argv pieces ourselves. The user asked for "run this shell text",
+ * so we preserve normal shell behavior.
+ */
+export function buildShellCommand(cwd: string, command: string): string {
+  return ["cd", shellEscape(cwd), "&&", "exec", "sh", "-lc", shellEscape(command)].join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// cmux execution
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute one cmux CLI command with a small timeout and normalized errors.
+ *
+ * Why normalize here?
+ * - Extension command handlers should talk in product terms like "open split"
+ *   and "notify", not in child-process edge cases.
+ * - Returning one small `{ ok, stdout, stderr, error }` shape keeps the rest of
+ *   the package easy to read.
+ */
+async function execCmux(pi: ExtensionAPI, args: string[]): Promise<CmuxExecResult> {
+  const result = await pi.exec("cmux", args, { timeout: CMUX_TIMEOUT_MS });
+  if (result.killed) {
+    return {
+      ok: false,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      error: "cmux command timed out",
+    };
+  }
+  if (result.code !== 0) {
+    return {
+      ok: false,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      error: result.stderr.trim() || result.stdout.trim() || `cmux exited with code ${result.code}`,
+    };
+  }
+  return {
+    ok: true,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Caller identification
+// ---------------------------------------------------------------------------
+
+/**
+ * Fast environment check used for "should we even try cmux?" decisions.
+ *
+ * This is intentionally cheap and slightly conservative. Interactive commands
+ * still call `identifyCaller()` for the real source of truth before opening
+ * panes or tabs.
+ */
+export function isInsideCmux(): boolean {
+  return Boolean(
+    process.env.CMUX_SOCKET_PATH &&
+    process.env.CMUX_WORKSPACE_ID &&
+    process.env.CMUX_SURFACE_ID,
+  );
+}
+
+/**
+ * Ask cmux which workspace/surface launched this extension command.
+ *
+ * Why not trust environment variables alone?
+ * - Env vars are useful for a quick "inside cmux?" check.
+ * - For actual pane splitting we want cmux itself to tell us the authoritative
+ *   workspace/surface refs to operate on.
+ */
+export async function identifyCaller(
+  pi: ExtensionAPI,
+): Promise<{ ok: true; caller: CmuxCallerInfo } | { ok: false; error: string }> {
+  const result = await execCmux(pi, ["--json", "identify"]);
+  if (!result.ok) {
+    return { ok: false, error: result.error || "Failed to identify cmux caller" };
+  }
+
+  const parsed = parseJson<CmuxIdentifyResponse>(result.stdout);
+  const workspaceRef = parsed?.caller?.workspace_ref;
+  const surfaceRef = parsed?.caller?.surface_ref;
+
+  if (!workspaceRef || !surfaceRef) {
+    return {
+      ok: false,
+      error: "This command must be run from inside a cmux surface",
+    };
+  }
+
+  return {
+    ok: true,
+    caller: { workspace_ref: workspaceRef, surface_ref: surfaceRef },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Notifications
+// ---------------------------------------------------------------------------
+
+/**
+ * Send one native cmux notification.
+ *
+ * We use cmux's built-in notification system instead of OSC escape sequences
+ * because cmux understands focus state, unread badges, and the notification
+ * panel. That gives a better "cmux-native" experience.
+ */
+export async function notify(
+  pi: ExtensionAPI,
+  title: string,
+  subtitle: string,
+  body: string,
+  options?: { timeout?: number },
+): Promise<{ ok: boolean; error?: string }> {
+  const args = ["notify", "--title", title, "--subtitle", subtitle, "--body", body];
+  const result = await pi.exec("cmux", args, {
+    timeout: options?.timeout ?? CMUX_TIMEOUT_MS,
+  });
+
+  if (result.killed) {
+    return { ok: false, error: "cmux notify timed out" };
+  }
+  if (result.code !== 0) {
+    const error =
+      result.stderr.trim() || result.stdout.trim() || `cmux exited with code ${result.code}`;
+    return { ok: false, error };
+  }
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Split pane
+//
+// Uses cmux --json new-split and parses the returned surface_ref directly,
+// then calls respawn-pane. No polling needed.
+// ---------------------------------------------------------------------------
+
+/**
+ * Open a new split pane beside the caller and launch one command in it.
+ *
+ * Why the two-step flow?
+ * 1. `cmux --json new-split ...` creates the new surface and tells us its ref.
+ * 2. `cmux respawn-pane ... --command` replaces the placeholder shell with the
+ *    real Pi or shell command we want.
+ *
+ * This is simpler and more reliable than polling `list-panes` waiting for a new
+ * surface to appear.
+ */
+export async function openSplit(
+  pi: ExtensionAPI,
+  direction: SplitDirection,
+  command: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const callerResult = await identifyCaller(pi);
+  if (!callerResult.ok) {
+    return callerResult;
+  }
+
+  const { workspace_ref: workspaceRef, surface_ref: surfaceRef } = callerResult.caller;
+
+  const splitResult = await execCmux(pi, [
+    "--json",
+    "new-split",
+    direction,
+    "--workspace",
+    workspaceRef,
+    "--surface",
+    surfaceRef,
+  ]);
+  if (!splitResult.ok) {
+    return { ok: false, error: splitResult.error || "Failed to create cmux split" };
+  }
+
+  const parsed = parseJson<CmuxSplitResponse>(splitResult.stdout);
+  const newSurfaceRef = parsed?.surface_ref;
+  if (!newSurfaceRef) {
+    return {
+      ok: false,
+      error: `Created split, but could not parse surface_ref from: ${splitResult.stdout.trim().slice(0, 200)}`,
+    };
+  }
+
+  // Brief delay to let the new surface boot.
+  //
+  // In practice, `new-split` returns before the new surface is always ready to
+  // accept `respawn-pane`. A tiny delay keeps the UX reliable without needing a
+  // more complex retry loop.
+  await delay(SPLIT_BOOT_DELAY_MS);
+
+  const respawnResult = await execCmux(pi, [
+    "respawn-pane",
+    "--workspace",
+    workspaceRef,
+    "--surface",
+    newSurfaceRef,
+    "--command",
+    command,
+  ]);
+  if (!respawnResult.ok) {
+    return {
+      ok: false,
+      error: respawnResult.error || "Failed to start command in the new split",
+    };
+  }
+
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Workspace tab
+//
+// cmux new-workspace returns plain text "OK workspace:<n>" even with --json.
+// We parse the text response rather than assuming JSON.
+// ---------------------------------------------------------------------------
+
+export interface OpenWorkspaceOptions {
+  cwd: string;
+  name?: string;
+  command: string;
+}
+
+/**
+ * Open a new cmux workspace tab and launch one command in it.
+ *
+ * Important cmux quirk:
+ * - `new-workspace` currently returns plain text like `OK workspace:19`
+ *   even when `--json` would suggest otherwise.
+ * - We therefore parse text here on purpose. This is not an accident.
+ */
+export async function openWorkspace(
+  pi: ExtensionAPI,
+  options: OpenWorkspaceOptions,
+): Promise<{ ok: true; workspaceRef: string } | { ok: false; error: string }> {
+  const args: string[] = ["new-workspace", "--cwd", options.cwd, "--command", options.command];
+  if (options.name) {
+    args.push("--name", options.name);
+  }
+
+  const result = await execCmux(pi, args);
+  if (!result.ok) {
+    return { ok: false, error: result.error || "Failed to create cmux workspace" };
+  }
+
+  // Parse text response: "OK workspace:<n>"
+  const match = result.stdout.match(/^OK\s+(workspace:\d+)/m);
+  if (!match) {
+    return {
+      ok: false,
+      error: `Created workspace, but could not parse ref from: ${result.stdout.trim().slice(0, 200)}`,
+    };
+  }
+
+  return { ok: true, workspaceRef: match[1] };
+}

--- a/pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-notify.ts
+++ b/pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-notify.ts
@@ -1,0 +1,485 @@
+import type { ExtensionAPI, ToolResultEvent } from "@mariozechner/pi-coding-agent";
+import {
+  isBashToolResult,
+  isEditToolResult,
+  isFindToolResult,
+  isGrepToolResult,
+  isReadToolResult,
+  isWriteToolResult,
+} from "@mariozechner/pi-coding-agent";
+import { basename } from "node:path";
+import { isInsideCmux, notify } from "./cmux-core.ts";
+
+/**
+ * Native cmux notifications for Pi
+ *
+ * First principles:
+ * - Pi already knows when an agent run starts, does work, and ends.
+ * - cmux already knows how to show notifications, unread state, and focus-aware UX.
+ * - So the simplest useful product is: listen to Pi lifecycle events, summarize
+ *   the work in plain language, and hand that summary to cmux.
+ *
+ * This file is intentionally opinionated about *useful summaries* instead of
+ * trying to mirror every low-level tool event 1:1. The goal is signal, not spam.
+ */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_THRESHOLD_MS = 15_000;
+const DEFAULT_DEBOUNCE_MS = 3_000;
+const NOTIFY_TIMEOUT_MS = 5_000;
+const DEFAULT_NOTIFY_LEVEL = "all";
+const FAILURE_CACHE_CLEAR_MS = 120_000;
+const MAX_FAILURES_BEFORE_CACHE = 3;
+
+type NotifyLevel = "all" | "medium" | "low" | "disabled";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-agent-run facts we collect while Pi is working.
+ *
+ * We use these to build one concise summary at the end instead of sending a
+ * notification for every tool call.
+ */
+interface RunState {
+  startedAt: number;
+  readFiles: Set<string>;
+  changedFiles: Set<string>;
+  searchCount: number;
+  bashCount: number;
+  firstToolError: string | undefined;
+}
+
+interface AssistantMessageLike {
+  role: "assistant";
+  stopReason?: string;
+  errorMessage?: string;
+  content?: Array<{ type?: string; text?: string }>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Small env parser used for numeric notification settings.
+ */
+function getNumberFromEnv(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+/**
+ * Notification level controls how noisy the package should be.
+ *
+ * - all     = waiting + success + error
+ * - medium  = success + error
+ * - low     = error only
+ * - disabled = nothing
+ */
+function getNotifyLevelFromEnv(): NotifyLevel {
+  const value = process.env.PI_CMUX_NOTIFY_LEVEL?.trim().toLowerCase();
+  if (value === "all" || value === "medium" || value === "low" || value === "disabled") {
+    return value;
+  }
+  return DEFAULT_NOTIFY_LEVEL;
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return count === 1 ? singular : plural;
+}
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(1, Math.round(ms / 1_000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes === 0) return `${seconds}s`;
+  if (seconds === 0) return `${minutes}m`;
+  return `${minutes}m ${seconds}s`;
+}
+
+function getPathFromInput(event: ToolResultEvent): string | undefined {
+  const path = event.input.path;
+  return typeof path === "string" && path.length > 0 ? path : undefined;
+}
+
+function getFirstText(event: ToolResultEvent): string | undefined {
+  const textPart = event.content.find((part) => part.type === "text");
+  if (!textPart || textPart.type !== "text") return undefined;
+  const text = textPart.text.trim();
+  return text.length > 0 ? text : undefined;
+}
+
+function summarizeError(event: ToolResultEvent): string {
+  const path = getPathFromInput(event);
+  if (path) {
+    return `${event.toolName} failed for ${basename(path)}`;
+  }
+  if (isBashToolResult(event)) {
+    return "bash command failed";
+  }
+  const text = getFirstText(event);
+  if (!text) {
+    return `${event.toolName} failed`;
+  }
+  return text.length > 120 ? `${text.slice(0, 117)}…` : text;
+}
+
+/**
+ * Turn the collected run facts into one human-friendly success summary.
+ *
+ * Why this shape?
+ * - File names are more useful than raw counts for short runs.
+ * - Counts are more useful than long file lists for larger runs.
+ * - Duration helps the user judge whether Pi was doing something substantial
+ *   or just came back almost immediately.
+ */
+function summarizeSuccess(
+  state: RunState,
+  durationMs: number,
+  thresholdMs: number,
+): string {
+  const parts: string[] = [];
+
+  // Changed files
+  const changedCount = state.changedFiles.size;
+  if (changedCount > 0) {
+    const names = [...state.changedFiles].map((f) => basename(f));
+    if (names.length <= 3) {
+      parts.push(`Changed ${names.join(", ")}`);
+    } else {
+      parts.push(`Changed ${names.slice(0, 2).join(", ")} +${changedCount - 2} more`);
+    }
+  }
+
+  // Read files
+  const readCount = state.readFiles.size;
+  if (readCount > 0) {
+    const names = [...state.readFiles].map((f) => basename(f));
+    if (names.length <= 3) {
+      parts.push(`Read ${names.join(", ")}`);
+    } else {
+      parts.push(`Read ${names.slice(0, 2).join(", ")} +${readCount - 2} more`);
+    }
+  }
+
+  // Searches
+  if (state.searchCount > 0) {
+    parts.push(`${state.searchCount} ${pluralize(state.searchCount, "search", "searches")}`);
+  }
+
+  // Bash commands
+  if (state.bashCount > 0) {
+    parts.push(`${state.bashCount} ${pluralize(state.bashCount, "cmd", "cmds")}`);
+  }
+
+  // Duration is always shown when above threshold or there was activity
+  if (durationMs >= thresholdMs || parts.length > 0) {
+    parts.push(formatDuration(durationMs));
+  }
+
+  if (parts.length === 0) {
+    return durationMs >= thresholdMs
+      ? `Idle after ${formatDuration(durationMs)}`
+      : "Waiting for input";
+  }
+
+  return parts.join(" · ");
+}
+
+function isAssistantMessage(message: unknown): message is AssistantMessageLike {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    (message as { role?: unknown }).role === "assistant"
+  );
+}
+
+function getLastAssistantMessage(
+  messages: readonly unknown[],
+): AssistantMessageLike | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (isAssistantMessage(message)) return message;
+  }
+  return undefined;
+}
+
+function summarizeAssistantText(message: AssistantMessageLike): string | undefined {
+  if (!Array.isArray(message.content)) return undefined;
+
+  const text = message.content
+    .filter(
+      (part): part is { type: "text"; text: string } =>
+        typeof part === "object" &&
+        part !== null &&
+        part.type === "text" &&
+        typeof part.text === "string" &&
+        part.text.trim().length > 0,
+    )
+    .map((part) => part.text.trim())
+    .join("\n")
+    .trim();
+
+  if (text.length === 0) return undefined;
+  return text.length > 120 ? `${text.slice(0, 117)}…` : text;
+}
+
+/**
+ * Build one error summary from the final assistant message plus the run state.
+ *
+ * We prefer assistant-provided error text when available because it often has
+ * more product context than a single tool failure. We then append a short
+ * activity hint like `[2 cmds run]` so future readers know what Pi was doing
+ * right before it failed.
+ */
+function summarizeRunError(
+  messages: readonly unknown[],
+  fallbackError?: string,
+  state?: RunState,
+): string | undefined {
+  const assistantMessage = getLastAssistantMessage(messages);
+  if (!assistantMessage) return fallbackError;
+
+  if (
+    assistantMessage.stopReason !== "error" &&
+    assistantMessage.stopReason !== "aborted"
+  ) {
+    return undefined;
+  }
+
+  // Build context: what was happening when the error occurred
+  const contextParts: string[] = [];
+  if (state) {
+    const changedCount = state.changedFiles.size;
+    if (changedCount > 0) {
+      contextParts.push(`${changedCount} ${pluralize(changedCount, "file")} changed`);
+    }
+    if (state.bashCount > 0) {
+      contextParts.push(`${state.bashCount} ${pluralize(state.bashCount, "cmd", "cmds")} run`);
+    }
+  }
+  const context = contextParts.length > 0 ? ` [${contextParts.join(", ")}]` : "";
+
+  const baseSummary =
+    assistantMessage.errorMessage?.trim() ||
+    summarizeAssistantText(assistantMessage) ||
+    fallbackError ||
+    "Agent run failed";
+  const summary = context && !baseSummary.includes(context)
+    ? `${baseSummary}${context}`
+    : baseSummary;
+  return summary.length > 140 ? `${summary.slice(0, 137)}…` : summary;
+}
+
+function buildSubtitle(
+  hasRunError: boolean,
+  state: RunState,
+  durationMs: number,
+  thresholdMs: number,
+): string {
+  if (hasRunError) return "Error";
+  if (state.changedFiles.size > 0 || durationMs >= thresholdMs) return "Task Complete";
+  return "Waiting";
+}
+
+function shouldNotify(level: NotifyLevel, subtitle: string): boolean {
+  if (level === "disabled") return false;
+  if (level === "all") return true;
+  if (level === "medium") return subtitle === "Task Complete" || subtitle === "Error";
+  if (level === "low") return subtitle === "Error";
+  return true;
+}
+
+function createEmptyRunState(): RunState {
+  return {
+    startedAt: Date.now(),
+    readFiles: new Set<string>(),
+    changedFiles: new Set<string>(),
+    searchCount: 0,
+    bashCount: 0,
+    firstToolError: undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Workspace name resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick the name shown in notification titles.
+ *
+ * Rules:
+ * - If the cmux workspace has an explicit human title, keep it.
+ * - If the workspace title is really just a path, shorten it to `basename(cwd)`.
+ *
+ * This keeps titles informative without flooding the notification UI with long
+ * absolute paths.
+ */
+async function resolveWorkspaceName(pi: ExtensionAPI, cwd: string): Promise<string> {
+  try {
+    const result = await pi.exec("cmux", ["--json", "current-workspace"], {
+      timeout: 3_000,
+    });
+    if (result.code === 0 && result.stdout) {
+      const parsed = JSON.parse(result.stdout);
+      const title = parsed?.workspace?.title;
+      if (typeof title === "string" && title.trim().length > 0) {
+        const trimmedTitle = title.trim();
+        // If the tab title looks like a path (including cmux's truncated …/path form),
+        // prefer a short cwd basename. Otherwise keep the explicit workspace tab name.
+        const looksLikePath = trimmedTitle.startsWith("/") || trimmedTitle.startsWith("~/") || trimmedTitle.startsWith("…/");
+        if (!looksLikePath) {
+          return trimmedTitle;
+        }
+      }
+    }
+  } catch {
+    // Fall through
+  }
+  return basename(cwd) || "pi";
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+export default function cmuxNotifyExtension(pi: ExtensionAPI) {
+  // Notifications are a cmux-only feature. Outside cmux we do nothing on
+  // purpose: no warnings, no fallback shell escape codes, no extra noise.
+  if (!isInsideCmux()) return;
+
+  const thresholdMs = getNumberFromEnv("PI_CMUX_NOTIFY_THRESHOLD_MS", DEFAULT_THRESHOLD_MS);
+  const debounceMs = getNumberFromEnv("PI_CMUX_NOTIFY_DEBOUNCE_MS", DEFAULT_DEBOUNCE_MS);
+  const notifyLevel = getNotifyLevelFromEnv();
+  const baseTitle = process.env.PI_CMUX_NOTIFY_TITLE || "Pi";
+
+  let runState = createEmptyRunState();
+  let workspaceName = "";
+  let lastNotificationAt = 0;
+  let lastNotificationKey = "";
+  let cmuxUnavailable = false;
+  let consecutiveFailures = 0;
+  let failureCacheClearedAt = Date.now();
+
+  const buildTitle = (): string => {
+    const wsPart = workspaceName ? ` — ${workspaceName}` : "";
+    return `${baseTitle}${wsPart}`;
+  };
+
+  /**
+   * Send one deduplicated cmux notification.
+   *
+   * Why cache failures?
+   * - If cmux becomes unavailable, repeatedly trying to notify on every agent
+   *   run would just create avoidable delays and noise.
+   * - After a short cooldown we try again automatically.
+   */
+  const sendNotification = async (
+    title: string,
+    subtitle: string,
+    body: string,
+  ): Promise<{ ok: boolean; error?: string }> => {
+    // Clear cached unavailability after cooldown
+    if (cmuxUnavailable && Date.now() - failureCacheClearedAt > FAILURE_CACHE_CLEAR_MS) {
+      cmuxUnavailable = false;
+      consecutiveFailures = 0;
+    }
+
+    if (cmuxUnavailable) {
+      return { ok: false, error: "cmux notify is unavailable" };
+    }
+
+    // Debounce duplicate notifications
+    const notificationKey = `${title}\n${subtitle}\n${body}`;
+    const now = Date.now();
+    if (notificationKey === lastNotificationKey && now - lastNotificationAt < debounceMs) {
+      return { ok: true };
+    }
+
+    const result = await notify(pi, title, subtitle, body, { timeout: NOTIFY_TIMEOUT_MS });
+    if (!result.ok) {
+      consecutiveFailures += 1;
+      if (consecutiveFailures >= MAX_FAILURES_BEFORE_CACHE) {
+        cmuxUnavailable = true;
+        failureCacheClearedAt = Date.now();
+      }
+      return result;
+    }
+
+    consecutiveFailures = 0;
+    lastNotificationAt = now;
+    lastNotificationKey = notificationKey;
+    return { ok: true };
+  };
+
+  // Resolve workspace/tab naming once per session start so each notification
+  // carries useful context like `Pi — backend` or `Pi — Auth Review`.
+  pi.on("session_start", async (_event, ctx) => {
+    workspaceName = await resolveWorkspaceName(pi, ctx.cwd);
+  });
+
+  // Each user prompt gets a fresh run state.
+  pi.on("agent_start", async () => {
+    runState = createEmptyRunState();
+  });
+
+  // Collect simple facts while Pi works so the final notification can answer:
+  // "What just happened?" in one line.
+  pi.on("tool_result", async (event) => {
+    if (event.isError && !runState.firstToolError) {
+      runState.firstToolError = summarizeError(event);
+    }
+
+    if (isReadToolResult(event)) {
+      const path = getPathFromInput(event);
+      if (path) runState.readFiles.add(path);
+      return;
+    }
+
+    if (isEditToolResult(event) || isWriteToolResult(event)) {
+      const path = getPathFromInput(event);
+      if (path && !event.isError) runState.changedFiles.add(path);
+      return;
+    }
+
+    if (isGrepToolResult(event) || isFindToolResult(event)) {
+      if (!event.isError) runState.searchCount += 1;
+      return;
+    }
+
+    if (isBashToolResult(event) && !event.isError) {
+      runState.bashCount += 1;
+    }
+  });
+
+  // Emit one final summary when Pi stops and waits for the next user input.
+  pi.on("agent_end", async (event, ctx) => {
+    const durationMs = Date.now() - runState.startedAt;
+    const runError = summarizeRunError(event.messages, runState.firstToolError, runState);
+    const subtitle = buildSubtitle(Boolean(runError), runState, durationMs, thresholdMs);
+    if (!shouldNotify(notifyLevel, subtitle)) {
+      return;
+    }
+    const body = runError || summarizeSuccess(runState, durationMs, thresholdMs);
+    const title = buildTitle();
+
+    // Also surface the same summary inside Pi itself.
+    //
+    // Why both?
+    // - cmux notifications are great when you are looking elsewhere.
+    // - in-Pi notifications are great when the cmux notification panel is not open.
+    const notifyType =
+      subtitle === "Error" ? "error" : subtitle === "Task Complete" ? "success" : "info";
+    ctx.ui.notify(`${title}: ${subtitle} — ${body}`, notifyType);
+
+    await sendNotification(title, subtitle, body);
+  });
+}

--- a/pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-split.ts
+++ b/pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-split.ts
@@ -1,0 +1,193 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import {
+  buildPiCommand,
+  buildShellCommand,
+  isInsideCmux,
+  openSplit,
+  type SplitDirection,
+} from "./cmux-core.ts";
+
+/**
+ * Split pane commands
+ *
+ * UX recommendation:
+ * - Splits are the default / recommended lane for most quick adjacent work.
+ * - They keep the user in the same workspace tab and avoid an immediate focus jump.
+ * - Workspace tabs are still useful, but mainly when the task deserves stronger
+ *   isolation or a named long-lived lane.
+ *
+ * Product goal:
+ * - Stay tiny and predictable.
+ * - One command should do one obvious thing: open a split to the right or down,
+ *   then launch either Pi or one shell command.
+ *
+ * We intentionally keep "fancy" behavior out of this file. Things like shell
+ * escaping, caller detection, and split creation live in `cmux-core.ts` so this
+ * file reads more like a command catalog than a process-management script.
+ */
+
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+
+/**
+ * Open a fresh Pi session in a new split, preserving the current cwd.
+ */
+async function openPiInSplit(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+  direction: SplitDirection,
+  args: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  return openSplit(
+    pi,
+    direction,
+    buildPiCommand(ctx.cwd, { prompt: args.trim().length > 0 ? args : undefined }),
+  );
+}
+
+/**
+ * Open one arbitrary shell command in a new split.
+ */
+async function openShellInSplit(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+  direction: SplitDirection,
+  args: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (!args.trim()) {
+    return {
+      ok: false,
+      error: "A shell command is required. Use /omp-split-right-command <command> or /omp-split-down-command <command>",
+    };
+  }
+  return openSplit(pi, direction, buildShellCommand(ctx.cwd, args.trim()));
+}
+
+function ensureInsideCmux(ctx: ExtensionCommandContext): boolean {
+  if (!isInsideCmux()) {
+    ctx.ui.notify("This command must be run from inside a cmux surface", "warning");
+    return false;
+  }
+  return true;
+}
+
+function registerPiSplitCommand(
+  pi: ExtensionAPI,
+  name: string,
+  direction: SplitDirection,
+  description: string,
+  successMessage: string,
+) {
+  pi.registerCommand(name, {
+    description,
+    handler: async (args, ctx) => {
+      if (!ensureInsideCmux(ctx)) return;
+      const result = await openPiInSplit(pi, ctx, direction, args);
+      if (result.ok) ctx.ui.notify(successMessage, "info");
+      else ctx.ui.notify(`cmux split failed: ${result.error}`, "error");
+    },
+  });
+}
+
+function registerShellSplitCommand(
+  pi: ExtensionAPI,
+  name: string,
+  direction: SplitDirection,
+  description: string,
+  successMessage: string,
+) {
+  pi.registerCommand(name, {
+    description,
+    handler: async (args, ctx) => {
+      if (!ensureInsideCmux(ctx)) return;
+      const result = await openShellInSplit(pi, ctx, direction, args);
+      if (result.ok) ctx.ui.notify(successMessage, "info");
+      else ctx.ui.notify(`cmux split failed: ${result.error}`, "error");
+    },
+  });
+}
+
+/**
+ * Register the split-pane command surface.
+ *
+ * Canonical commands use readable `omp-<slug>` names.
+ * Short mnemonic aliases remain for faster typing.
+ *
+ * Canonical:
+ * - `omp-split-right`
+ * - `omp-split-right-command`
+ * - `omp-split-down`
+ * - `omp-split-down-command`
+ *
+ * Aliases:
+ * - `ompv`, `ompr`, `omph`, `omphr`
+ */
+function registerSplitCommands(pi: ExtensionAPI) {
+  registerPiSplitCommand(
+    pi,
+    "omp-split-right",
+    "right",
+    "Open a new right-side cmux split pane and launch a fresh Pi session in the current cwd",
+    "Opened a new right-side cmux split with Pi",
+  );
+  registerPiSplitCommand(
+    pi,
+    "ompv",
+    "right",
+    "Alias for /omp-split-right",
+    "Opened a new right-side cmux split with Pi",
+  );
+
+  registerShellSplitCommand(
+    pi,
+    "omp-split-right-command",
+    "right",
+    "Open a new right-side cmux split pane and run an arbitrary shell command in the current cwd",
+    "Opened a new right-side cmux split with shell command",
+  );
+  registerShellSplitCommand(
+    pi,
+    "ompr",
+    "right",
+    "Alias for /omp-split-right-command",
+    "Opened a new right-side cmux split with shell command",
+  );
+
+  registerPiSplitCommand(
+    pi,
+    "omp-split-down",
+    "down",
+    "Open a new down-side cmux split pane and launch a fresh Pi session in the current cwd",
+    "Opened a new down-side cmux split with Pi",
+  );
+  registerPiSplitCommand(
+    pi,
+    "omph",
+    "down",
+    "Alias for /omp-split-down",
+    "Opened a new down-side cmux split with Pi",
+  );
+
+  registerShellSplitCommand(
+    pi,
+    "omp-split-down-command",
+    "down",
+    "Open a new down-side cmux split pane and run an arbitrary shell command in the current cwd",
+    "Opened a new down-side cmux split with shell command",
+  );
+  registerShellSplitCommand(
+    pi,
+    "omphr",
+    "down",
+    "Alias for /omp-split-down-command",
+    "Opened a new down-side cmux split with shell command",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+export default function cmuxSplitExtension(pi: ExtensionAPI) {
+  registerSplitCommands(pi);
+}

--- a/pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-workspace.ts
+++ b/pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-workspace.ts
@@ -1,0 +1,241 @@
+import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
+import {
+  buildPiCommand,
+  buildShellCommand,
+  isInsideCmux,
+  openWorkspace,
+} from "./cmux-core.ts";
+
+/**
+ * Workspace tab commands
+ *
+ * UX recommendation:
+ * - Workspace tabs are not the default recommendation for quick helper work.
+ * - In v1, opening a workspace tab switches focus immediately.
+ * - They are best when the user wants a stronger boundary than a split pane:
+ *   a named lane, a longer-running task, or something worth revisiting later.
+ *
+ * Why this file exists separately from split panes:
+ * - Workspace tabs are a different cmux concept with different UX tradeoffs.
+ * - Future readers should be able to adjust tab-specific behavior without
+ *   wading through split-pane logic.
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse optional `--name` arguments for workspace commands.
+ *
+ * We support two human-friendly forms:
+ *
+ * 1. Quoted multi-word titles
+ *    /omp-workspace --name "Auth Review" review the login flow
+ *
+ * 2. Unquoted titles separated from the remaining prompt/command with ` -- `
+ *    /omp-workspace --name Auth Review -- review the login flow
+ *
+ * Why not use a full CLI parser?
+ * - Pi command handlers receive one plain string.
+ * - These two forms cover the common cases while staying easy to explain in docs.
+ */
+function parseNamedArgs(args: string): { title?: string; rest: string; error?: string } {
+  const trimmed = args.trim();
+  if (!trimmed.startsWith("--name")) return { rest: args };
+
+  let remainder = trimmed.slice("--name".length).trimStart();
+  if (!remainder) {
+    return { rest: "", error: "Missing workspace title after --name" };
+  }
+
+  let title = "";
+  if (remainder.startsWith('"') || remainder.startsWith("'")) {
+    const quote = remainder[0];
+    const endIndex = remainder.indexOf(quote, 1);
+    if (endIndex === -1) {
+      return { rest: "", error: `Unterminated ${quote} quote in --name title` };
+    }
+    title = remainder.slice(1, endIndex).trim();
+    remainder = remainder.slice(endIndex + 1).trim();
+  } else {
+    const delimiterIndex = remainder.indexOf(" -- ");
+    if (delimiterIndex >= 0) {
+      title = remainder.slice(0, delimiterIndex).trim();
+      remainder = remainder.slice(delimiterIndex + 4).trim();
+    } else {
+      const firstSpace = remainder.indexOf(" ");
+      if (firstSpace === -1) {
+        title = remainder.trim();
+        remainder = "";
+      } else {
+        title = remainder.slice(0, firstSpace).trim();
+        remainder = remainder.slice(firstSpace + 1).trim();
+      }
+    }
+  }
+
+  if (!title) {
+    return { rest: remainder, error: "Workspace title after --name cannot be empty" };
+  }
+
+  return { title, rest: remainder };
+}
+
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+
+/**
+ * Open a new workspace tab with a fresh Pi session.
+ */
+async function openPiInWorkspace(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+  args: string,
+  title?: string,
+): Promise<{ ok: true; workspaceRef: string } | { ok: false; error: string }> {
+  return openWorkspace(pi, {
+    cwd: ctx.cwd,
+    name: title,
+    command: buildPiCommand(ctx.cwd, {
+      prompt: args.trim().length > 0 ? args : undefined,
+    }),
+  });
+}
+
+/**
+ * Open a new workspace tab with one arbitrary shell command.
+ */
+async function openShellInWorkspace(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+  args: string,
+  title?: string,
+): Promise<{ ok: true; workspaceRef: string } | { ok: false; error: string }> {
+  if (!args.trim()) {
+    return {
+      ok: false,
+      error: "A shell command is required. Use /omp-workspace-command <command> or /omp-workspace-command --name \"My Tab\" <command>",
+    };
+  }
+  return openWorkspace(pi, {
+    cwd: ctx.cwd,
+    name: title,
+    command: buildShellCommand(ctx.cwd, args.trim()),
+  });
+}
+
+function ensureInsideCmux(ctx: ExtensionCommandContext): boolean {
+  if (!isInsideCmux()) {
+    ctx.ui.notify("This command must be run from inside a cmux surface", "warning");
+    return false;
+  }
+  return true;
+}
+
+function registerPiWorkspaceCommand(
+  pi: ExtensionAPI,
+  name: string,
+  description: string,
+) {
+  pi.registerCommand(name, {
+    description,
+    handler: async (args, ctx) => {
+      if (!ensureInsideCmux(ctx)) return;
+
+      const parsed = parseNamedArgs(args);
+      if (parsed.error) {
+        ctx.ui.notify(`cmux workspace failed: ${parsed.error}`, "error");
+        return;
+      }
+
+      const result = await openPiInWorkspace(pi, ctx, parsed.rest, parsed.title);
+      if (result.ok) {
+        ctx.ui.notify(
+          parsed.title
+            ? `Opened new workspace tab "${parsed.title}" with Pi`
+            : "Opened new workspace tab with Pi",
+          "info",
+        );
+      } else {
+        ctx.ui.notify(`cmux workspace failed: ${result.error}`, "error");
+      }
+    },
+  });
+}
+
+function registerShellWorkspaceCommand(
+  pi: ExtensionAPI,
+  name: string,
+  description: string,
+) {
+  pi.registerCommand(name, {
+    description,
+    handler: async (args, ctx) => {
+      if (!ensureInsideCmux(ctx)) return;
+
+      const parsed = parseNamedArgs(args);
+      if (parsed.error) {
+        ctx.ui.notify(`cmux workspace failed: ${parsed.error}`, "error");
+        return;
+      }
+
+      const result = await openShellInWorkspace(pi, ctx, parsed.rest, parsed.title);
+      if (result.ok) {
+        ctx.ui.notify(
+          parsed.title
+            ? `Opened new workspace tab "${parsed.title}" with shell command`
+            : "Opened new workspace tab with shell command",
+          "info",
+        );
+      } else {
+        ctx.ui.notify(`cmux workspace failed: ${result.error}`, "error");
+      }
+    },
+  });
+}
+
+/**
+ * Register the workspace-tab command surface.
+ *
+ * Canonical commands use readable `omp-<slug>` names.
+ * Short mnemonic aliases remain for faster typing.
+ *
+ * Canonical:
+ * - `omp-workspace`
+ * - `omp-workspace-command`
+ *
+ * Aliases:
+ * - `ompw`, `ompwr`
+ */
+function registerWorkspaceCommands(pi: ExtensionAPI) {
+  registerPiWorkspaceCommand(
+    pi,
+    "omp-workspace",
+    "Open a new cmux workspace tab with a fresh Pi session in the current cwd. This switches focus to the new workspace tab.",
+  );
+  registerPiWorkspaceCommand(
+    pi,
+    "ompw",
+    "Alias for /omp-workspace",
+  );
+
+  registerShellWorkspaceCommand(
+    pi,
+    "omp-workspace-command",
+    "Open a new cmux workspace tab and run an arbitrary shell command in the current cwd. This switches focus to the new workspace tab.",
+  );
+  registerShellWorkspaceCommand(
+    pi,
+    "ompwr",
+    "Alias for /omp-workspace-command",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+export default function cmuxWorkspaceExtension(pi: ExtensionAPI) {
+  registerWorkspaceCommands(pi);
+}

--- a/pi-packages/oh-my-pi/extensions/oh-my-pi/index.ts
+++ b/pi-packages/oh-my-pi/extensions/oh-my-pi/index.ts
@@ -1,0 +1,22 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import cmuxNotifyExtension from "./cmux-notify.ts";
+import cmuxSplitExtension from "./cmux-split.ts";
+import cmuxWorkspaceExtension from "./cmux-workspace.ts";
+
+/**
+ * oh-my-pi entrypoint
+ *
+ * Mental model:
+ * - `cmux-notify.ts` watches Pi lifecycle events and sends native cmux notifications.
+ * - `cmux-split.ts` adds commands for opening split panes.
+ * - `cmux-workspace.ts` adds commands for opening workspace tabs.
+ *
+ * We keep the three concerns separate so future maintainers can change one area
+ * (for example, notification wording) without having to reason about pane or
+ * workspace launching code at the same time.
+ */
+export default function (pi: ExtensionAPI) {
+  cmuxNotifyExtension(pi);
+  cmuxSplitExtension(pi);
+  cmuxWorkspaceExtension(pi);
+}

--- a/pi-packages/oh-my-pi/package.json
+++ b/pi-packages/oh-my-pi/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "oh-my-pi",
+  "version": "0.0.1",
+  "description": "Pi-native cmux integration: notifications, split panes, and workspace tabs via native cmux CLI. No tmux-compat shims.",
+  "keywords": ["pi-package", "cmux", "notifications", "split-panes", "workspace-tabs"],
+  "files": ["extensions/", "README.md"],
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*"
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a new Pi-native cmux package (`oh-my-pi`), teaches `dev-workflow` to open seeded cmux review/recon lanes automatically when that behavior clearly helps, and updates the marketplace notification flow so Pi package updates get their own Slack section instead of being buried in plugin-only messaging.

### Key Features

| Feature | Description |
|---------|-------------|
| **New `oh-my-pi` package** | Adds native cmux notifications, readable split commands, workspace-tab commands, and package docs |
| **cmux-aware `dev-workflow`** | Makes `/workflow:scout`, `/workflow:oracle`, `/workflow:reviewer`, and `/workflow:parallel` open seeded splits by default when Pi is inside cmux and the parent session is idle |
| **Marketplace Slack updates** | Moves Pi package update messaging into this repo's GitHub Actions workflow with separate `Plugin items` and `Pi items` sections |
| **Doc and install cleanup** | Aligns READMEs/runbooks/catalog docs around four Pi packages, duplicate-safe local testing, and the new cmux mental model |

## Visuals

### 1. cmux workflow lane behavior

```text
/workflow:reviewer
  ├─ inside cmux + idle parent session
  │    ├─ create seeded child session on disk
  │    ├─ open adjacent split
  │    └─ run reviewer prompt there
  └─ otherwise
       └─ run inline in the current session
```

### 2. marketplace Slack update flow

```text
push to main
  ├─ changed plugins?     -> Plugin items section
  ├─ changed pi-packages? -> Pi items section
  └─ one compact Slack post in #ask-tech-team
```

## Detailed Changes

---

## `oh-my-pi`: native cmux command surface

Adds a new Pi package under `pi-packages/oh-my-pi/`.

What it provides:
- native cmux notifications via `cmux notify`
- readable split commands:
  - `/omp-split-right`
  - `/omp-split-right-command`
  - `/omp-split-down`
  - `/omp-split-down-command`
- readable workspace commands:
  - `/omp-workspace`
  - `/omp-workspace-command`
- short aliases for faster typing

Why this exists:
- Diversio uses Pi inside cmux heavily
- Pi already knows what the agent is doing
- cmux already knows how to show notifications and open panes/tabs
- native cmux behavior is simpler and cleaner than tmux shims or OSC tricks

---

## `dev-workflow`: automatic seeded cmux lanes

Subagent-style workflow prompts now prefer a fresh adjacent cmux split when that is the lowest-friction UX.

Current defaulted commands:
- `/workflow:scout`
- `/workflow:oracle`
- `/workflow:reviewer`
- `/workflow:parallel`

The child session is seeded with:
- same cwd
- current branch
- short `git status --short`
- small recent parent-session conversation snapshot
- extra command context
- parent model selection when available

Why this approach:
- no extra `/omp-*` command for the developer to remember
- keeps the parent workflow lane uncluttered
- still falls back inline if cmux is unavailable or split launch fails
- keeps `dev-workflow` independently installable instead of depending on `oh-my-pi`

---

## Marketplace notifications: Pi items belong here, not in Naboo

The marketplace notification workflow now watches both:
- `plugins/**`
- `pi-packages/**`

And renders one cleaner Slack message with:
- top summary
- `Plugin items`
- `Pi items`
- compact reinstall/update hints

Why here instead of Naboo:
- these are marketplace-local updates, not product-release updates
- Pi package changes were previously invisible or awkward to surface
- the repository that ships the packages should own the package-update announcement

## Files Changed

<details>
<summary>Root manifest + shared docs</summary>

- `.github/workflows/notify-plugin-updates.yml`
- `AGENTS.md`
- `README.md`
- `docs/architecture/overview.md`
- `docs/plugins/catalog.md`
- `docs/quality/gates.md`
- `docs/runbooks/distribution.md`
- `package.json`
- `pi-packages/README.md`
- `pi-packages/ci-status/README.md`

</details>

<details>
<summary>`dev-workflow` package</summary>

- `pi-packages/dev-workflow/README.md`
- `pi-packages/dev-workflow/extensions/dev-workflow/index.ts`
- `pi-packages/dev-workflow/skills/dev-workflow/SKILL.md`

</details>

<details>
<summary>New `oh-my-pi` package</summary>

- `pi-packages/oh-my-pi/package.json`
- `pi-packages/oh-my-pi/README.md`
- `pi-packages/oh-my-pi/extensions/oh-my-pi/index.ts`
- `pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-core.ts`
- `pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-notify.ts`
- `pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-split.ts`
- `pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-workspace.ts`

</details>

## How to Test

```bash
bash scripts/validate-skills.sh
jq -e . package.json >/dev/null
jq -e . pi-packages/dev-workflow/package.json >/dev/null
jq -e . pi-packages/oh-my-pi/package.json >/dev/null

(cd pi-packages/ci-status && npm pack --dry-run --json >/tmp/ci-status-pack.json)
(cd pi-packages/dev-workflow && npm pack --dry-run --json >/tmp/dev-workflow-pack.json)
(cd pi-packages/oh-my-pi && npm pack --dry-run --json >/tmp/oh-my-pi-pack.json)

printf '{"id":"cmds","type":"get_commands"}\n' | \
  PI_OFFLINE=1 pi --mode rpc --no-session --no-context-files \
    --no-extensions -e ./pi-packages/ci-status \
    --no-prompt-templates --no-skills >/tmp/ci-status-commands.json

printf '{"id":"cmds","type":"get_commands"}\n' | \
  PI_OFFLINE=1 pi --mode rpc --no-session --no-context-files \
    --no-extensions -e ./pi-packages/dev-workflow \
    --no-prompt-templates --no-skills >/tmp/dev-workflow-commands.json

printf '{"id":"cmds","type":"get_commands"}\n' | \
  PI_OFFLINE=1 pi --mode rpc --no-session --no-context-files \
    --no-extensions -e ./pi-packages/oh-my-pi \
    --no-prompt-templates --no-skills >/tmp/oh-my-pi-commands.json

printf '{"id":"cmds","type":"get_commands"}\n' | \
  PI_OFFLINE=1 pi --mode rpc --no-session --no-context-files \
    --no-extensions -e . \
    --no-prompt-templates --no-skills >/tmp/root-commands.json

git diff --check
```

### Manual / interactive checks

Inside a real cmux Pi session:
- `/reload`
- `/workflow:reviewer`
- `/workflow:oracle`
- `/workflow:parallel`
- `/omp-split-right`
- `/omp-split-right-command pwd`
- `/omp-workspace --name "Auth Review" review the login flow`

## Notes

- No related GitHub issue was found in `agent-skills-marketplace`, so this PR is not linked to an existing issue.
- The branch started from a detached submodule checkout and was moved onto a normal feature branch before shipping.
