### PR TITLE
Harden oh-my-pi cmux split launches

### DIFF
--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -77,6 +77,15 @@ when command files change.
   - Short aliases: `/ompv`, `/ompr`, `/omph`, `/omphr`, `/ompw`, `/ompwr`
   - Recommendation: prefer split-pane commands by default; use workspace tabs
     for stronger isolation or named long-lived lanes.
+  - Launch behavior: split/workspace commands restore the current Pi session's
+    PATH before running shell commands; fresh Pi lanes launch through the same
+    underlying Node/Pi install as the current session so panes do not die from
+    `command not found: pi` in stripped respawn environments. Mental model:
+    Pi split commands open adjacent AI lanes; shell split commands open adjacent
+    terminal-program lanes. Short successful shell commands still exit when
+    done; long-running or interactive commands are the best fit for persistent
+    helper lanes. `PI_CLI_PATH` can override the spawned Pi launcher when
+    needed.
   - Relationship to `dev-workflow`: `oh-my-pi` is the explicit user-facing cmux
     command surface, while `dev-workflow` uses a small amount of direct cmux
     logic for automatic seeded split launching on subagent-style workflow

--- a/pi-packages/oh-my-pi/README.md
+++ b/pi-packages/oh-my-pi/README.md
@@ -130,22 +130,73 @@ Escalate to a workspace tab when the work deserves its own lane
 | `/omp-split-down` | `/omph` | Down | Fresh Pi session in current cwd |
 | `/omp-split-down-command` | `/omphr` | Down | Arbitrary shell command in current cwd |
 
+Launch behavior:
+
+- Fresh Pi splits now launch Pi using the same Node/Pi install that is already
+  running the current session, instead of trusting the respawned pane's PATH.
+  This avoids the classic `command not found: pi` fast-close failure.
+- Shell-command splits restore the current session's PATH before running the
+  command. That means commands like `npm run dev` or `npm test` can find the
+  same tools you have in the current Pi session.
+- If a shell command fails immediately, the pane stays open in a shell with the
+  error visible so the lane does not blink shut before you can read it.
+- Short successful shell commands still exit when they are done. Long-running or
+  interactive commands like `top`, `npm run dev`, or `lazygit` naturally stay
+  open.
+
+Mental model:
+
+```text
+Pi split command
+  └─ open a new adjacent AI lane
+       └─ same cwd
+       └─ same working Pi install
+       └─ optional prompt handed to Pi
+
+Shell split command
+  └─ open a new adjacent terminal lane
+       └─ same cwd
+       └─ restored PATH from the current Pi session
+       ├─ success + short command -> lane may exit normally
+       ├─ success + interactive command -> lane stays open naturally
+       └─ failure -> lane stays open so you can debug it
+```
+
+Why this design exists:
+
+- a new cmux pane is a weaker environment than the current running Pi session
+- reusing the current session's launcher and PATH is more reliable than hoping a
+  fresh shell will rebuild them the same way
+- the main UX bug we are solving is "pane opens and disappears before I can see
+  what went wrong"
+
 Examples:
 
-```
+```text
+# Open an adjacent AI lane
 /omp-split-right
 /omp-split-right fix the user auth module
-/omp-split-right-command htop
-/omp-split-down-command npm run test
+
+# Open an adjacent terminal lane that naturally stays open
+/omp-split-right-command top
+/omp-split-down-command npm run dev
 ```
 
 Short aliases still work if you prefer them:
 
-```
+```text
 /ompv
-/ompr htop
+/ompr top
 /omph
-/omphr npm run test
+/omphr npm run dev
+```
+
+A simple rule of thumb:
+
+```text
+Want another Pi lane?                -> /omp-split-right or /omp-split-down
+Want another terminal program lane?  -> /omp-split-*-command
+Want the lane to stay visible?       -> use an interactive or long-running command
 ```
 
 ### Workspace Tabs
@@ -247,6 +298,7 @@ They are silent when running outside cmux.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `PI_CLI_PATH` | auto-detect | Optional absolute path override for the Pi launcher used in spawned cmux panes. Usually unnecessary because `oh-my-pi` reuses the current session's Node/Pi install automatically. |
 | `PI_CMUX_NOTIFY_LEVEL` | `all` | `all`, `medium` (skip "Waiting"), `low` (errors only), `disabled` |
 | `PI_CMUX_NOTIFY_THRESHOLD_MS` | `15000` | Duration in ms above which a success run becomes "Task Complete" |
 | `PI_CMUX_NOTIFY_DEBOUNCE_MS` | `3000` | Minimum ms between duplicate notifications |
@@ -261,6 +313,12 @@ A few choices in this package are intentionally conservative:
 - **Shell escaping is centralized** because prompts and commands can contain
   spaces and quotes, and split/tab launches are painful to debug when escaping
   is wrong.
+- **Spawned panes restore the current PATH explicitly** because respawned cmux
+  surfaces may not inherit the same shell initialization as the current Pi
+  session. Without that, commands can work here and fail there.
+- **Fresh Pi panes launch through the current Node binary + Pi CLI entrypoint**
+  instead of blindly running `pi`. This avoids `#!/usr/bin/env node` wrapper
+  failures in stripped respawn environments.
 - **`new-workspace` is parsed as plain text** because cmux currently returns
   `OK workspace:<n>` in real usage, even when JSON might be expected.
 - **Pi prompts are passed after `--`** so prompts that start with `-` are not

--- a/pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-core.ts
+++ b/pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-core.ts
@@ -121,23 +121,43 @@ export function shellEscape(value: string): string {
  */
 function resolvePiLauncher(): string {
   const explicit = process.env.PI_CLI_PATH?.trim();
-  const candidate = explicit || join(dirname(process.execPath), "pi");
+  if (explicit) {
+    try {
+      if (!existsSync(explicit)) {
+        return shellEscape(explicit);
+      }
 
-  if (!existsSync(candidate)) {
-    return shellEscape(candidate);
+      const resolvedExplicit = realpathSync(explicit);
+      if (resolvedExplicit.endsWith(".js")) {
+        return `${shellEscape(process.execPath)} ${shellEscape(resolvedExplicit)}`;
+      }
+
+      return shellEscape(explicit);
+    } catch {
+      return shellEscape(explicit);
+    }
   }
 
-  const resolved = realpathSync(candidate);
-
-  // The common Pi install path is a small `#!/usr/bin/env node` wrapper script.
-  // Launching that wrapper can still fail in respawned panes if PATH no longer
-  // contains `node`. When the wrapper resolves to a JS entrypoint, call it
-  // through the currently running Node binary directly.
-  if (resolved.endsWith(".js")) {
-    return `${shellEscape(process.execPath)} ${shellEscape(resolved)}`;
+  const siblingCandidate = join(dirname(process.execPath), "pi");
+  if (!existsSync(siblingCandidate)) {
+    return "pi";
   }
 
-  return shellEscape(candidate);
+  try {
+    const resolvedSibling = realpathSync(siblingCandidate);
+
+    // The common Pi install path is a small `#!/usr/bin/env node` wrapper
+    // script. Launching that wrapper can still fail in respawned panes if PATH
+    // no longer contains `node`. When the wrapper resolves to a JS entrypoint,
+    // call it through the currently running Node binary directly.
+    if (resolvedSibling.endsWith(".js")) {
+      return `${shellEscape(process.execPath)} ${shellEscape(resolvedSibling)}`;
+    }
+
+    return shellEscape(siblingCandidate);
+  } catch {
+    return "pi";
+  }
 }
 
 /**

--- a/pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-core.ts
+++ b/pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-core.ts
@@ -1,3 +1,6 @@
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 /**
@@ -93,20 +96,117 @@ export function shellEscape(value: string): string {
 // ---------------------------------------------------------------------------
 
 /**
+ * Resolve the Pi launcher we should use inside spawned cmux surfaces.
+ *
+ * Why not just run `pi` and trust PATH?
+ * - The current interactive shell usually has Pi on PATH.
+ * - A newly respawned cmux pane may not inherit the same shell initialization.
+ * - In practice that means `pi` can be available *here* while failing with
+ *   `command not found: pi` inside the new split.
+ *
+ * The most reliable default is: if Pi is running right now, use the `pi`
+ * executable sitting next to the current Node binary.
+ *
+ * Visual model:
+ *
+ * ```text
+ * current Pi session
+ *   └─ knows exactly which Node + Pi install is working now
+ *        └─ spawned cmux pane should reuse that exact launcher
+ *             └─ do not rediscover it from scratch in a weaker environment
+ * ```
+ *
+ * Advanced escape hatch:
+ * - `PI_CLI_PATH=/absolute/path/to/pi` forces a specific launcher when needed.
+ */
+function resolvePiLauncher(): string {
+  const explicit = process.env.PI_CLI_PATH?.trim();
+  const candidate = explicit || join(dirname(process.execPath), "pi");
+
+  if (!existsSync(candidate)) {
+    return shellEscape(candidate);
+  }
+
+  const resolved = realpathSync(candidate);
+
+  // The common Pi install path is a small `#!/usr/bin/env node` wrapper script.
+  // Launching that wrapper can still fail in respawned panes if PATH no longer
+  // contains `node`. When the wrapper resolves to a JS entrypoint, call it
+  // through the currently running Node binary directly.
+  if (resolved.endsWith(".js")) {
+    return `${shellEscape(process.execPath)} ${shellEscape(resolved)}`;
+  }
+
+  return shellEscape(candidate);
+}
+
+/**
+ * Wrap one command in a tiny shell trampoline.
+ *
+ * Why this helper exists:
+ * - cmux panes disappearing instantly feels broken when a launch fails before
+ *   the user can read the error.
+ * - Respawned cmux panes may not inherit the same PATH as the current Pi
+ *   session, so we restore it explicitly before running the real command.
+ *
+ * Current policy:
+ * - normal clean exits are allowed to close the pane
+ * - failed launches drop into an interactive shell so the error stays visible
+ *
+ * We intentionally do not try to keep every successful short-lived command open.
+ * Interactive tools already stay open naturally, and forcing a post-success
+ * shell fallback was flaky in respawned cmux panes during local testing.
+ *
+ * Visual model:
+ *
+ * ```text
+ * restore PATH
+ *   └─ run real command
+ *        ├─ success -> exit normally
+ *        └─ failure -> show error -> drop into shell -> let the user inspect it
+ * ```
+ */
+function wrapSpawnedCommand(command: string, notice: string): string {
+  const lines = [
+    `PATH=${shellEscape(process.env.PATH ?? "")}`,
+    "export PATH",
+    command,
+    "status=$?",
+    'if [ "$status" -ne 0 ]; then printf "\\n[oh-my-pi] %s\\n[oh-my-pi] Exit status: %s\\n" ' + shellEscape(notice) + ' "$status"; exec "${SHELL:-/bin/sh}" -i; fi',
+    'exit "$status"',
+  ];
+
+  return ["exec", "sh", "-lc", shellEscape(lines.join("; "))].join(" ");
+}
+
+/**
  * Build the exact shell command we want cmux to run for a fresh Pi session.
  *
  * Design choices:
  * - `cd <cwd>` makes the new pane/tab start in the same directory as the
  *   current Pi session.
- * - `exec pi` replaces the temporary shell with Pi itself.
+ * - We launch Pi by absolute path instead of relying on PATH inside the new
+ *   cmux surface.
  * - `--` before the prompt prevents prompts that start with `-` from being
  *   misread as Pi CLI flags.
+ * - If Pi fails to start, keep the pane open in a shell so the error is visible
+ *   instead of the pane disappearing instantly.
+ *
+ * Visual model:
+ *
+ * ```text
+ * /omp-split-right review this diff
+ *   └─ open split
+ *        └─ cd into same cwd
+ *             └─ launch Pi with same Node/Pi install as parent session
+ *                  └─ pass prompt after `--`
+ * ```
  */
 export function buildPiCommand(
   cwd: string,
   options?: { sessionFile?: string; prompt?: string },
 ): string {
-  const parts = ["cd", shellEscape(cwd), "&&", "exec", "pi"];
+  const parts = [resolvePiLauncher()];
   if (options?.sessionFile) {
     parts.push("--session", shellEscape(options.sessionFile));
   }
@@ -114,7 +214,16 @@ export function buildPiCommand(
   if (prompt) {
     parts.push("--", shellEscape(prompt));
   }
-  return parts.join(" ");
+
+  return [
+    "cd",
+    shellEscape(cwd),
+    "&&",
+    wrapSpawnedCommand(
+      parts.join(" "),
+      "Pi failed to stay open. Keeping this pane open for debugging.",
+    ),
+  ].join(" ");
 }
 
 /**
@@ -123,9 +232,30 @@ export function buildPiCommand(
  * We intentionally route through `sh -lc` instead of trying to split the user's
  * command into argv pieces ourselves. The user asked for "run this shell text",
  * so we preserve normal shell behavior.
+ *
+ * We currently keep the pane open only on error.
+ *
+ * Why not keep it open after every successful command?
+ * - interactive programs like `top`, `lazygit`, or `npm run dev` naturally stay
+ *   open already
+ * - some shells launched after a successful non-interactive command immediately
+ *   exit again in respawned cmux panes, which creates a flaky UX
+ * - the high-value fix is preserving PATH and surfacing failures instead of
+ *   pretending every short-lived command should become a persistent shell lane
+ *
+ * First-principles rule:
+ * - use Pi split commands for "open an adjacent AI work lane"
+ * - use shell split commands for "run a real terminal program beside me"
+ * - prefer long-running or interactive commands when you want the lane to stay
+ *   visible after launch
  */
 export function buildShellCommand(cwd: string, command: string): string {
-  return ["cd", shellEscape(cwd), "&&", "exec", "sh", "-lc", shellEscape(command)].join(" ");
+  return [
+    "cd",
+    shellEscape(cwd),
+    "&&",
+    wrapSpawnedCommand(command, "Command failed. Keeping this pane open for debugging."),
+  ].join(" ");
 }
 
 // ---------------------------------------------------------------------------

--- a/pi-packages/oh-my-pi/package.json
+++ b/pi-packages/oh-my-pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-pi",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pi-native cmux integration: notifications, split panes, and workspace tabs via native cmux CLI. No tmux-compat shims.",
   "keywords": ["pi-package", "cmux", "notifications", "split-panes", "workspace-tabs"],
   "files": ["extensions/", "README.md"],


### PR DESCRIPTION
## Summary

This PR hardens `oh-my-pi` split/workspace launches so respawned cmux panes reuse the current working Pi/Node environment instead of depending on a weaker fresh-shell PATH. It also documents the launch model in simple terms and bumps `oh-my-pi` for the shipped runtime behavior change.

### Key Features

| Feature | Description |
|---------|-------------|
| **Pi launcher hardening** | Fresh Pi panes now reuse the current session's working Node + Pi install instead of blindly running `pi` from the respawned pane PATH |
| **Shell PATH restoration** | Shell-command lanes restore the current Pi session PATH before running the requested command |
| **Failure-visible lanes** | Failed shell/Pi launches keep the pane open with visible error output instead of blinking shut immediately |
| **Docs + versioning** | Adds first-principles docs for the launch model and bumps `oh-my-pi` to `0.0.2` |

## Visuals

### 1. Why the old launch path was brittle

```text
current Pi session
  ├─ has working Node + Pi + PATH
  └─ opens new cmux pane
       └─ respawned shell may have weaker PATH / shell init
            └─ bare `pi` can fail -> pane opens -> pane closes
```

### 2. New launcher model

```text
/omp-split-right
  └─ open split
       └─ cd into same cwd
            └─ restore current PATH
                 └─ launch Pi with same Node/Pi install as parent session
                      ├─ success -> Pi stays open normally
                      └─ failure -> visible error + debug shell
```

### 3. Shell-command lane model

```text
/omp-split-down-command <cmd>
  └─ open split
       └─ cd into same cwd
            └─ restore current PATH
                 └─ run command
                      ├─ short success -> exit normally
                      ├─ interactive/long-running success -> stays open naturally
                      └─ failure -> visible error + debug shell
```

## Detailed Changes

---

## Runtime hardening in `cmux-core.ts`

What changed:
- added launcher resolution that prefers the current working Pi install
- added PATH restoration in spawned shell trampolines
- added an explicit failure-visible fallback shell on launch errors
- kept the success path simple instead of forcing every short command into a persistent post-run shell

Why this approach:
- the real bug was not “cmux splits close too fast” in the abstract
- the real bug was “the respawned pane is a weaker environment than the current running Pi session”
- fixing the launcher + PATH is more reliable than trying to paper over failures with generic shell fallback behavior everywhere

---

## Documentation pass for future readers

Updated docs now explain:
- why a new cmux pane is weaker than the current Pi session
- why `oh-my-pi` restores PATH explicitly
- why fresh Pi panes launch through the current Node/Pi install
- which commands are best for persistent helper lanes
- how `PI_CLI_PATH` can override the spawned Pi launcher when necessary

## Files Changed

<details>
<summary>Runtime</summary>

- `pi-packages/oh-my-pi/extensions/oh-my-pi/cmux-core.ts` - harden Pi/shell lane launch behavior
- `pi-packages/oh-my-pi/package.json` - bump package version to `0.0.2`

</details>

<details>
<summary>Docs</summary>

- `pi-packages/oh-my-pi/README.md` - add visual mental model and launch behavior explanation
- `docs/plugins/catalog.md` - document the launch contract and override behavior

</details>

## How to Test

```bash
git diff --check
bash scripts/validate-skills.sh
jq -e . pi-packages/oh-my-pi/package.json >/dev/null
(cd pi-packages/oh-my-pi && npm pack --dry-run --json >/tmp/oh-my-pi-pack.json)

printf '{"id":"cmds","type":"get_commands"}\n' | \
  PI_OFFLINE=1 pi --mode rpc --no-session --no-context-files \
    --no-extensions -e ./pi-packages/oh-my-pi \
    --no-prompt-templates --no-skills >/tmp/oh-my-pi-commands.json
```

### Manual / interactive checks

Inside a real cmux Pi session:

```text
/reload
/omp-split-right
/omp-split-right fix the user auth module
/omp-split-right-command top
/omp-split-down-command npm run dev
```

Optional error-path check:

```text
/omp-split-right-command command-that-does-not-exist
```

Expected behavior:
- fresh Pi split opens and stays open normally
- long-running / interactive shell command lanes stay visible naturally
- failed shell/Pi launches stay open with visible error output
- short successful shell commands may still exit normally

## Notes

- No related GitHub issue was found for this follow-up.
- During local testing, spawned shells also surfaced pre-existing user shell-startup noise (`xargs: unterminated quote` and a missing `~/.cargo/env`). That is not caused by `oh-my-pi`, but it is worth fixing separately in shell config.
