### PR TITLE
Expand website into Diversio Engineering hub and add Cloudflare Pages deploys

### DIFF
--- a/.github/workflows/deploy-website-cloudflare-pages.yml
+++ b/.github/workflows/deploy-website-cloudflare-pages.yml
@@ -33,6 +33,20 @@ on:
       - "pi-packages/**/extensions/**"
       - ".github/workflows/deploy-website-cloudflare-pages.yml"
   workflow_dispatch:
+    inputs:
+      deploy_target:
+        description: "Which environment to deploy manually"
+        required: true
+        default: preview
+        type: choice
+        options:
+          - preview
+          - production
+      preview_branch:
+        description: "Preview branch name when deploy_target=preview"
+        required: false
+        default: manual
+        type: string
 
 permissions:
   contents: read
@@ -53,7 +67,9 @@ jobs:
   # failures contributors cannot fix from forks.
   deploy-preview:
     name: Deploy preview
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'preview')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: cloudflare-pages
@@ -90,18 +106,25 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          MANUAL_PREVIEW_BRANCH: ${{ github.event.inputs.preview_branch }}
         shell: bash
         run: |
           set -euo pipefail
+          branch="${GITHUB_HEAD_REF:-}"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            branch="${MANUAL_PREVIEW_BRANCH:-manual}"
+          fi
           npx --yes wrangler@4.15.2 pages deploy website/dist \
             --project-name="${CLOUDFLARE_PAGES_PROJECT}" \
-            --branch="${GITHUB_HEAD_REF}"
+            --branch="${branch}"
 
   # Production deploys only happen from main so the public site matches merged
   # repository state, not ad-hoc branch state.
   deploy-production:
     name: Deploy production
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'production')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: cloudflare-pages

--- a/.github/workflows/deploy-website-cloudflare-pages.yml
+++ b/.github/workflows/deploy-website-cloudflare-pages.yml
@@ -1,0 +1,143 @@
+# Deploy the Diversio Engineering website to Cloudflare Pages.
+#
+# First principles:
+# - production should publish automatically from merges to main
+# - preview deploys should exist for reviewable PRs from this repository
+# - the site build depends on source docs outside website/**, so deploy triggers
+#   must include those inputs as well
+# - keep the workflow repo-local and explicit; Cloudflare project creation,
+#   secrets, and custom-domain mapping are one-time setup steps
+name: Deploy Website to Cloudflare Pages
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "website/**"
+      - "plugins/**/skills/**"
+      - "plugins/**/commands/**"
+      - "pi-packages/**/README.md"
+      - "pi-packages/**/skills/**"
+      - "pi-packages/**/extensions/**"
+      - ".github/workflows/deploy-website-cloudflare-pages.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "website/**"
+      - "plugins/**/skills/**"
+      - "plugins/**/commands/**"
+      - "pi-packages/**/README.md"
+      - "pi-packages/**/skills/**"
+      - "pi-packages/**/extensions/**"
+      - ".github/workflows/deploy-website-cloudflare-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-website-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  # Keep the project name configurable so the workflow can be reused across
+  # environments without rewriting the YAML. The default matches the intended
+  # production project for this repo.
+  CLOUDFLARE_PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT || 'diversio-engineering' }}
+
+jobs:
+  # Preview deploys are limited to same-repo PRs because forked PRs do not
+  # receive repository secrets. That keeps the workflow safe and avoids noisy
+  # failures contributors cannot fix from forks.
+  deploy-preview:
+    name: Deploy preview
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: cloudflare-pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Install website dependencies
+        working-directory: website
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --package-lock=false
+
+      - name: Build website
+        working-directory: website
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run build
+
+      # We build in GitHub Actions first, then upload the finished static site.
+      # That keeps the deploy path deterministic and makes the GitHub build logs
+      # the source of truth when something breaks.
+      - name: Deploy preview to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.15.2 pages deploy website/dist \
+            --project-name="${CLOUDFLARE_PAGES_PROJECT}" \
+            --branch="${GITHUB_HEAD_REF}"
+
+  # Production deploys only happen from main so the public site matches merged
+  # repository state, not ad-hoc branch state.
+  deploy-production:
+    name: Deploy production
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: cloudflare-pages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Install website dependencies
+        working-directory: website
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --package-lock=false
+
+      - name: Build website
+        working-directory: website
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run build
+
+      - name: Deploy production to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx --yes wrangler@4.15.2 pages deploy website/dist \
+            --project-name="${CLOUDFLARE_PAGES_PROJECT}" \
+            --branch=main

--- a/.github/workflows/deploy-website-cloudflare-pages.yml
+++ b/.github/workflows/deploy-website-cloudflare-pages.yml
@@ -7,6 +7,12 @@
 #   must include those inputs as well
 # - keep the workflow repo-local and explicit; Cloudflare project creation,
 #   secrets, and custom-domain mapping are one-time setup steps
+#
+# Safety rules for manual dispatch:
+# - manual preview deploys may run from any selected ref
+# - manual production deploys must only run from main
+# - do not let a workflow_dispatch run from a feature branch publish that
+#   feature branch build to the production Pages branch
 name: Deploy Website to Cloudflare Pages
 
 on:
@@ -43,9 +49,9 @@ on:
           - preview
           - production
       preview_branch:
-        description: "Preview branch name when deploy_target=preview"
+        description: "Optional preview branch alias override. Leave blank to use the selected GitHub ref name."
         required: false
-        default: manual
+        default: ""
         type: string
 
 permissions:
@@ -112,7 +118,7 @@ jobs:
           set -euo pipefail
           branch="${GITHUB_HEAD_REF:-}"
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            branch="${MANUAL_PREVIEW_BRANCH:-manual}"
+            branch="${MANUAL_PREVIEW_BRANCH:-${GITHUB_REF_NAME}}"
           fi
           npx --yes wrangler@4.15.2 pages deploy website/dist \
             --project-name="${CLOUDFLARE_PAGES_PROJECT}" \
@@ -124,7 +130,7 @@ jobs:
     name: Deploy production
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'production')
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'production' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: cloudflare-pages

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ This repository hosts Diversio-maintained Agent Skills and plugin manifests so
 the same skills can be distributed via the Claude Code marketplace or other
 channels.
 
-It also now includes the Astro website in `website/`, which powers
-`https://agents.diversio.com`. That site is the human-facing catalog and deep
-Docs surface for marketplace plugins, individual skills, and Pi extensions.
+It also now includes the Astro website in `website/`, which targets
+`https://engineering.diversio.com`. That site is the Diversio Engineering hub,
+including the `Agentic Tools` section for marketplace plugins, individual
+skills, and Pi extensions.
 
 ## Documentation Philosophy
 
@@ -93,8 +94,8 @@ agent-skills-marketplace/
 │   ├── image-router/                  # Pi-native vision bridge for text-only models
 │   ├── oh-my-pi/                      # Pi-native cmux integration (notifications, split panes, workspace tabs)
 │   └── skills-bridge/                 # Pi-native bridge to Claude Code plugin skills
-├── website/                           # Astro site for agents.diversio.com
-│   ├── src/pages/                     # Homepage, registry, docs, /skills/*, /pi/*
+├── website/                           # Astro site for engineering.diversio.com
+│   ├── src/pages/                     # Homepage, /agentic-tools, registry, docs, /skills/*, /pi/*, /blog/*
 │   ├── src/data/site-docs.ts          # Build-time extraction from SKILL.md + package READMEs
 │   └── public/                        # Branding assets, headers, OG image
 ├── plugins/

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -19,9 +19,10 @@
   - Pi-native packages for workflows that need pi extensions, TUI components,
     or pi-local skills outside the Claude Code marketplace shape.
 - `website/`
-  - Astro static site for `agents.diversio.com`.
-  - Hosts the human-facing marketplace catalog plus deeper `/skills/*` and
-    `/pi/*` docs built from repo-local source files.
+  - Astro static site for the Diversio Engineering hub on `engineering.diversio.com`.
+  - Hosts the broader engineering homepage plus the `Agentic Tools` section,
+    deeper `/skills/*` and `/pi/*` docs, and blog scaffolding built from
+    repo-local source files.
 - `scripts/validate-skills.sh`
   - Local and CI guardrail for the `SKILL.md` line-count budget.
 - `.github/workflows/validate-marketplace.yml`

--- a/docs/quality/gates.md
+++ b/docs/quality/gates.md
@@ -56,11 +56,19 @@ skills target:
 - `Validate Website`
   - Triggered by changes under `website/**` or the website workflow file.
   - Runs a clean website dependency install and `cd website && npm run build`.
-  - This is the build gate for the Astro site at `agents.diversio.com`.
+  - This is the build gate for the Astro site that now targets `engineering.diversio.com`.
 - `Notify Marketplace Updates`
   - Triggered by pushes to `main` that touch `plugins/**` or `pi-packages/**`.
   - Diffs the full pushed range, groups changes by marketplace item, and posts
     one Slack message with separate `Plugin items` and `Pi items` sections.
+- `Deploy Website to Cloudflare Pages`
+  - Triggered by website changes and site-doc source changes.
+  - Builds the static site in GitHub Actions, then uploads `website/dist` to
+    Cloudflare Pages.
+  - PR previews run only for same-repo PRs because forked PRs do not receive
+    Cloudflare secrets.
+  - Pushes to `main` publish production automatically once the required GitHub
+    secrets are configured.
 
 Docs-only changes do not currently trigger the marketplace validation workflow,
 so run the local checks manually when you touch shared instructions.

--- a/docs/website/engineering-hub-phase-2/001-brand-domain-and-ia.md
+++ b/docs/website/engineering-hub-phase-2/001-brand-domain-and-ia.md
@@ -1,0 +1,49 @@
+# 001 - Brand, domain, and IA decision note
+
+## Locked working direction
+
+- Umbrella site name: `Diversio Engineering`
+- Primary public hostname: `engineering.diversio.com`
+- Tools section name: `Agentic Tools`
+- Legacy label handling: keep `Agent Skills Marketplace` only as historical/explanatory copy where useful; do not keep it as the top-level site brand
+
+## v1 top-level navigation
+
+- Home: `/`
+- Agentic Tools: `/agentic-tools`
+- Docs: `/docs`
+- Blog: `/blog`
+- Community: `/community`
+
+## Homepage ownership
+
+The homepage should answer:
+
+1. what Diversio Engineering publishes
+2. where Agentic Tools lives
+3. where blog posts and curated reposts live
+4. how engineers can find the repo/community surface
+
+It should not try to be the full tool registry page.
+
+## Tools surface ownership
+
+The existing PR #77 marketplace site becomes the `Agentic Tools` section:
+
+- landing page: `/agentic-tools`
+- inventory: `/registry`
+- bundle docs: `/docs/*`
+- skill docs: `/skills/*`
+- Pi package docs: `/pi/*`
+
+## Config source of truth
+
+Public site strings should come from one shared config layer:
+
+- site name
+- tools section name
+- primary hostname / canonical URL
+- GitHub URL
+- primary nav routes
+
+Implementation path: `website/site.config.mjs`

--- a/docs/website/engineering-hub-phase-2/002-cloudflare-pages-and-route53-topology.md
+++ b/docs/website/engineering-hub-phase-2/002-cloudflare-pages-and-route53-topology.md
@@ -1,0 +1,47 @@
+# 002 - Cloudflare Pages and Route53 topology
+
+## Locked working topology
+
+- DNS authority remains in AWS Route53 for `diversio.com`
+- Production site hosting uses Cloudflare Pages
+- Production hostname is `engineering.diversio.com`
+- Production deploys happen automatically from merges to `main`
+- Preview deploys stay enabled for branches and PRs
+
+## Cloudflare Pages settings
+
+- Repo: `DiversioTeam/agent-skills-marketplace`
+- Root directory: `website/`
+- Build command: `npm run build`
+- Output directory: `dist`
+- Production branch: `main`
+- Node version: `24`
+
+## DNS shape
+
+Default to the simplest Route53-managed path:
+
+- create the Cloudflare Pages project
+- attach `engineering.diversio.com` as a custom domain
+- add the required Route53 validation record(s) if prompted
+- point `engineering.diversio.com` at the Cloudflare Pages target using the record pattern Cloudflare provides
+
+Do not delegate the root zone or move `diversio.com` off Route53.
+
+## Legacy hostname behavior
+
+- `agents.diversio.com/` should redirect to `https://engineering.diversio.com/agentic-tools`
+- deep docs should preserve paths on host migration where possible:
+  - `/docs/*` -> `/docs/*`
+  - `/skills/*` -> `/skills/*`
+  - `/pi/*` -> `/pi/*`
+  - `/registry` -> `/registry`
+- same-project path aliases now live in `website/public/_redirects`; hostname migration still needs Cloudflare domain-level configuration during rollout
+
+## Rollback
+
+If the cutover needs to be reversed:
+
+1. remove or disable the custom-domain mapping in Cloudflare Pages
+2. restore the previous Route53 record target for `engineering.diversio.com`
+3. leave the apex zone and Route53 authority unchanged

--- a/docs/website/engineering-hub-phase-2/003-routes-redirects-and-sections.md
+++ b/docs/website/engineering-hub-phase-2/003-routes-redirects-and-sections.md
@@ -1,0 +1,40 @@
+# 003 - Route and redirect working map
+
+## Keep
+
+- `/docs/*`
+- `/skills/*`
+- `/pi/*`
+- `/registry`
+- `/community`
+- `/security`
+- `/terms`
+
+## New
+
+- `/` -> Diversio Engineering homepage
+- `/agentic-tools` -> tools landing page using the former homepage/tool overview content
+- `/blog` -> blog index
+- `/blog/<slug>` -> original or curated repost article pages
+
+## Move / ownership changes
+
+- the old tool-centric homepage content moves from `/` to `/agentic-tools`
+- `/` becomes the broader engineering hub homepage
+
+## Redirect strategy
+
+Use both of these rules:
+
+- app-level route preservation for pages that still exist at the same paths
+- Cloudflare redirect rules for hostname-level migration and any moved routes
+
+Implemented now:
+
+- `website/public/_redirects` provides path aliases such as `/marketplace` -> `/agentic-tools`
+- deep docs stay on their existing short routes, so no same-host redirects are needed for `/docs/*`, `/skills/*`, or `/pi/*`
+
+Still required at deploy time:
+
+- hostname-level redirect for `agents.diversio.com/*` -> `engineering.diversio.com/*`
+- homepage special case so `https://agents.diversio.com/` lands on `https://engineering.diversio.com/agentic-tools`

--- a/docs/website/engineering-hub-phase-2/004-blog-and-syndication-content-model.md
+++ b/docs/website/engineering-hub-phase-2/004-blog-and-syndication-content-model.md
@@ -1,0 +1,51 @@
+# 004 - Blog and syndication content model
+
+## v1 publishing model
+
+Use local Astro content collections inside `website/src/content/blog/`.
+
+This keeps the first version explicit, reviewable, and git-based.
+
+## Supported post types
+
+- `original` - an original Diversio Engineering post
+- `repost` - a curated repost from an external source such as `ashwch.com`
+
+## Minimum schema
+
+Defined in `website/src/content.config.ts`.
+
+Fields:
+
+- `title`
+- `slug`
+- `summary`
+- `publishDate`
+- `updatedDate`
+- `author`
+- `tags`
+- `sourceType`
+- `sourceSiteName`
+- `sourceUrl`
+- `canonicalUrl`
+- `heroImage`
+- `socialImage`
+- `socialTitle`
+- `socialDescription`
+- `draft`
+
+## Canonical and attribution rules
+
+- original posts may use the site URL as canonical
+- reposts must include both `sourceUrl` and `canonicalUrl`
+- repost pages must visibly label the source
+- repost pages should keep attribution explicit in both UI and metadata decisions
+
+## Operations note
+
+To add a post:
+
+1. add a markdown file under `website/src/content/blog/`
+2. fill in the collection schema fields
+3. use `sourceType: repost` only when source attribution and canonical URL are ready
+4. run `cd website && npm run build`

--- a/docs/website/engineering-hub-phase-2/006-launch-validate-and-ops.md
+++ b/docs/website/engineering-hub-phase-2/006-launch-validate-and-ops.md
@@ -66,6 +66,7 @@ CI/deploy checks:
 
 - open a PR from this repo and confirm the `Deploy Website to Cloudflare Pages` preview job runs
 - merge to `main` and confirm the production deploy job runs
+- use `workflow_dispatch` when you need a manual preview or production redeploy without a new commit
 - verify `engineering.diversio.com` serves the production build
 - verify `_redirects` aliases work
 - configure hostname-level redirect for `agents.diversio.com` -> `engineering.diversio.com`

--- a/docs/website/engineering-hub-phase-2/006-launch-validate-and-ops.md
+++ b/docs/website/engineering-hub-phase-2/006-launch-validate-and-ops.md
@@ -66,7 +66,9 @@ CI/deploy checks:
 
 - open a PR from this repo and confirm the `Deploy Website to Cloudflare Pages` preview job runs
 - merge to `main` and confirm the production deploy job runs
-- use `workflow_dispatch` when you need a manual preview or production redeploy without a new commit
+- use `workflow_dispatch` when you need a manual redeploy without a new commit:
+  - preview can run from any selected ref
+  - production should only be dispatched from `main`
 - verify `engineering.diversio.com` serves the production build
 - verify `_redirects` aliases work
 - configure hostname-level redirect for `agents.diversio.com` -> `engineering.diversio.com`
@@ -87,7 +89,7 @@ npx wrangler pages deploy website/dist \
   --project-name=diversio-engineering \
   --branch=<branch-name>
 
-# Production-style deploy
+# Production-style deploy (use code from main)
 npx wrangler pages deploy website/dist \
   --project-name=diversio-engineering \
   --branch=main

--- a/docs/website/engineering-hub-phase-2/006-launch-validate-and-ops.md
+++ b/docs/website/engineering-hub-phase-2/006-launch-validate-and-ops.md
@@ -1,0 +1,99 @@
+# 006 - Launch, validate, and ops
+
+## Goal
+
+Publish the Diversio Engineering site to Cloudflare Pages, keep `diversio.com`
+under Route53, and make production deploy automatically from merges to `main`.
+
+## Repo-side setup completed here
+
+- Shared site config points at `https://engineering.diversio.com`
+- Static redirects live in `website/public/_redirects`
+- Static headers live in `website/public/_headers`
+- GitHub Actions deploy workflow lives in `.github/workflows/deploy-website-cloudflare-pages.yml`
+- Preview deploys run for same-repo PRs
+- Production deploys run for pushes to `main`
+
+## One-time Cloudflare setup
+
+```text
+GitHub Actions builds website/dist
+  -> Wrangler uploads website/dist
+  -> Cloudflare Pages serves the static site
+  -> Route53 points engineering.diversio.com at that Pages project
+```
+
+1. Create a Cloudflare Pages project.
+   - recommended project name: `diversio-engineering`
+   - if you use a different name, set repo variable `CLOUDFLARE_PAGES_PROJECT`
+2. Create a Cloudflare API token with Pages deploy permissions for the target account.
+3. Add GitHub repo secrets:
+   - `CLOUDFLARE_API_TOKEN`
+   - `CLOUDFLARE_ACCOUNT_ID`
+4. Add the custom domain in Cloudflare Pages:
+   - `engineering.diversio.com`
+5. Add the required Route53 DNS record(s) and validation record(s) if Cloudflare prompts for them.
+
+## GitHub setup
+
+Optional repo variable:
+
+- `CLOUDFLARE_PAGES_PROJECT`
+
+Required repo secrets:
+
+- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_ACCOUNT_ID`
+
+Useful verification commands:
+
+```bash
+gh secret list -R DiversioTeam/agent-skills-marketplace | rg 'CLOUDFLARE_(API_TOKEN|ACCOUNT_ID)'
+gh variable list -R DiversioTeam/agent-skills-marketplace | rg '^CLOUDFLARE_PAGES_PROJECT\s'
+```
+
+## Validation checklist
+
+Local build:
+
+```bash
+cd website
+npm install --package-lock=false
+npm run build
+```
+
+CI/deploy checks:
+
+- open a PR from this repo and confirm the `Deploy Website to Cloudflare Pages` preview job runs
+- merge to `main` and confirm the production deploy job runs
+- verify `engineering.diversio.com` serves the production build
+- verify `_redirects` aliases work
+- configure hostname-level redirect for `agents.diversio.com` -> `engineering.diversio.com`
+- validate HTTPS and social previews
+
+Helpful smoke checks:
+
+```bash
+curl -I https://engineering.diversio.com
+curl -I https://engineering.diversio.com/agentic-tools
+```
+
+Manual deploy examples with Wrangler:
+
+```bash
+# Preview-style branch deploy
+npx wrangler pages deploy website/dist \
+  --project-name=diversio-engineering \
+  --branch=<branch-name>
+
+# Production-style deploy
+npx wrangler pages deploy website/dist \
+  --project-name=diversio-engineering \
+  --branch=main
+```
+
+## Notes
+
+- PR previews are intentionally limited to PRs whose head repo is this repo, so forked PRs do not fail because Cloudflare secrets are unavailable.
+- The deploy workflow builds locally in GitHub Actions and uploads the built static output to Cloudflare Pages via Wrangler.
+- This keeps production deploys deterministic and repo-owned.

--- a/docs/website/engineering-hub-phase-2/PLAN.md
+++ b/docs/website/engineering-hub-phase-2/PLAN.md
@@ -1,0 +1,34 @@
+# Engineering Hub Phase 2
+
+## Status
+
+- [x] Branch created from `main`: `feature/engineering-hub-phase-2`
+- [x] Lock working direction for brand, domain, and IA
+- [x] Lock working Cloudflare Pages + Route53 topology
+- [x] Preserve PR #77 site as the implementation baseline
+- [x] Add shared website config for brand/domain strings
+- [x] Split the broader hub homepage from the tools-specific landing page
+- [x] Add initial blog scaffolding for original posts and curated reposts
+- [x] Add initial redirect rules and path aliases in `website/public/_redirects`
+- [ ] Configure hostname-level redirect behavior for `agents.diversio.com`
+- [ ] Add first real blog/repost content entries
+- [x] Add GitHub Actions deploy pipeline for Cloudflare Pages
+- [ ] Configure the Cloudflare Pages project, repo secrets, and Route53 records
+- [ ] Validate production deploy, TLS, redirects, and social previews
+
+## Working Decisions
+
+- Umbrella site: `Diversio Engineering`
+- Primary production hostname: `https://engineering.diversio.com`
+- Tools section name: `Agentic Tools`
+- Existing marketplace repo/site content is preserved and extended, not rebuilt
+- Deep docs stay on short routes for now: `/docs/*`, `/skills/*`, `/pi/*`
+- New hub section routes begin with `/agentic-tools` and `/blog`
+
+## Implementation Notes
+
+- Shared site config now lives in `website/site.config.mjs`
+- The former marketplace homepage content now lives on `website/src/pages/agentic-tools.astro`
+- The broader engineering homepage now lives on `website/src/pages/index.astro`
+- Blog collection schema lives in `website/src/content.config.ts`
+- Blog routes live in `website/src/pages/blog/`

--- a/website/README.md
+++ b/website/README.md
@@ -606,10 +606,15 @@ pull request from this repo
 
 push to main
   -> production deployment on Cloudflare Pages
+
+manual workflow_dispatch run
+  -> preview or production, chosen explicitly at dispatch time
 ```
 
 This split exists for a simple reason: reviewers need a safe preview URL, while
-production should only change after merge.
+production should only change after merge. Manual dispatch still exists so the
+team can re-run a preview or production deploy without manufacturing a new code
+change.
 
 The canonical site URL is:
 

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
-# Agent Skills Marketplace — Website
+# Diversio Engineering — Website
 
-Astro static site for [agents.diversio.com](https://agents.diversio.com).
+Astro static site for the Diversio Engineering hub at [engineering.diversio.com](https://engineering.diversio.com).
 
 This README is for maintainers of the **website code**, not just visitors of the
 site.
@@ -19,27 +19,27 @@ Node requirement: Astro 6 in this site currently needs Node `>=22.12.0`.
 
 ## The Big Idea
 
-The website has **two jobs**:
+The website now has **three roles**:
 
-1. **Catalog job** — show the marketplace at a glance
-   - plugins
-   - Pi packages
-   - counts
-   - summaries
+1. **Hub** — present Diversio Engineering as the umbrella site
+   - homepage
+   - section routing
+   - shared brand + canonical metadata
 
-2. **Deep docs job** — explain the thing itself
-   - individual skills
-   - Pi extension surfaces
-   - runtime-specific install/invoke examples
-   - commands, tools, env vars, references, scripts
+2. **Agentic Tools** — power the open tools section
+   - `/agentic-tools`
+   - `/registry`
+   - `/docs/*`
+   - `/skills/*`
+   - `/pi/*`
 
-The first version of the site did the catalog job well enough.
-It did a much worse job on deep docs.
+3. **Editorial** — support engineering writing and curated reposts
+   - `/blog`
+   - `/blog/*`
+   - original posts
+   - reposts with explicit attribution and canonical handling
 
-So the site now has two extra route families:
-
-- `/skills/*` — individual skill pages
-- `/pi/*` — Pi package / extension pages
+The current implementation extends the PR #77 Astro baseline instead of replacing it.
 
 ## First-Principles Mental Model
 
@@ -59,7 +59,7 @@ src/data/site-docs.ts
   -> readable website pages built from the real repo docs
 ```
 
-Why do it this way?
+Why this shape works
 
 Because the repo already has a source of truth.
 We do **not** want a second website-only documentation schema that drifts.
@@ -68,10 +68,12 @@ We do **not** want a second website-only documentation schema that drifts.
 
 | Website surface | Source of truth | Why |
 |---|---|---|
+| Shared site name, primary hostname, nav routes | `site.config.mjs` | one place for public brand/domain strings |
 | Homepage counts, registry cards, package summaries | `src/data/marketplace.json` | stable catalog metadata |
-| Individual marketplace skill pages | `plugins/*/skills/*/SKILL.md` | the skill itself is the canonical behavior |
+| Individual plugin skill pages | `plugins/*/skills/*/SKILL.md` | the skill itself is the canonical behavior |
 | Pi-local skill pages | `pi-packages/*/skills/*/SKILL.md` | same reason: skill behavior lives in markdown |
 | Pi extension pages | `pi-packages/*/README.md` | commands/tools/env vars already live there |
+| Blog posts and repost metadata | `src/content/blog/*` + `src/content.config.ts` | explicit editorial schema with reviewable markdown |
 | Contributor grid | git history via `src/data/contributors.ts` | community data should age with the repo |
 
 ## Project Structure
@@ -80,10 +82,12 @@ We do **not** want a second website-only documentation schema that drifts.
 website/
 ├── astro.config.mjs
 ├── package.json
+├── site.config.mjs
 ├── tsconfig.json
 ├── README.md
 ├── public/
 │   ├── _headers
+│   ├── _redirects
 │   ├── diversio-logo.svg
 │   ├── favicon.svg
 │   └── og-default.png
@@ -108,12 +112,16 @@ website/
     │   ├── SectionHeader.astro
     │   ├── Tag.astro
     │   └── Button.astro
+    ├── content/
+    │   └── blog/
+    ├── content.config.ts
     ├── data/
     │   ├── marketplace.json
     │   ├── site-docs.ts
     │   └── contributors.ts
     └── pages/
         ├── index.astro
+        ├── agentic-tools.astro
         ├── registry.astro
         ├── community.astro
         ├── security.astro
@@ -126,9 +134,12 @@ website/
         ├── skills/
         │   ├── index.astro
         │   └── [skill].astro
-        └── pi/
+        ├── pi/
+        │   ├── index.astro
+        │   └── [package].astro
+        └── blog/
             ├── index.astro
-            └── [package].astro
+            └── [slug].astro
 ```
 
 ## Why the New Files Exist
@@ -145,7 +156,7 @@ It exists because:
 
 It intentionally does **simple extraction**, not clever parsing.
 
-That is a feature, not a bug.
+That simplicity is intentional.
 
 If something breaks, a future maintainer should be able to read the file and say:
 
@@ -194,11 +205,88 @@ It keeps the logic simple:
 - infer GitHub profiles from noreply addresses when possible
 - fall back to a small static list if git metadata is unavailable
 
+### `site.config.mjs`
+
+This file is the **single source of truth for site identity**.
+
+It exists because the rebrand touched several things at once:
+
+- site name
+- primary hostname
+- top-level nav labels
+- top-level route names
+
+Without a shared config file, those strings drift into layouts, headers,
+footers, metadata, and docs.
+
+Mental model:
+
+```text
+page copy          -> explains the content on one page
+site.config.mjs    -> explains what the site is called and where sections live
+```
+
+If a future change renames a section or moves a top-level route, start there.
+
+### `src/content.config.ts`
+
+This file defines the **editorial contract** for blog content.
+
+It exists because original posts and curated reposts have different rules.
+
+```text
+original post
+  -> can be owned entirely by this site
+
+repost
+  -> must keep source attribution
+  -> must keep canonical URL information
+```
+
+That is why reposts are validated more strictly than original posts.
+
+### `public/_redirects`
+
+This file exists to preserve **human entrypoints** after the site rebrand.
+
+It handles simple aliases such as:
+
+```text
+/marketplace               -> /agentic-tools
+/tools                     -> /agentic-tools
+/agent-skills-marketplace  -> /agentic-tools
+```
+
+Why keep the rules exact instead of using broad wildcards?
+
+- the tools landing page moved
+- the deep docs routes mostly did not
+- exact aliases are easier to reason about and harder to misconfigure
+
+### `.github/workflows/deploy-website-cloudflare-pages.yml`
+
+This workflow exists so deployment stays **repo-owned and repeatable**.
+
+Mental model:
+
+```text
+GitHub Actions
+  -> install dependencies
+  -> build website/dist
+  -> upload the finished static output to Cloudflare Pages
+```
+
+Why not rely on an opaque remote build only?
+
+- build logs stay in GitHub where the change happened
+- the same build command runs locally and in CI
+- deployment is easier to audit when the upload step is explicit
+
 ## How Deep Docs Get Built
 
 ### Skill pages
 
-Marketplace skill pages come from:
+Plugin skill pages come from:
 
 ```text
 plugins/<plugin>/skills/<skill>/SKILL.md
@@ -238,7 +326,7 @@ That means:
 
 ## Practical Maintainer Workflows
 
-### 1. You changed a marketplace skill
+### 1. You changed a plugin skill
 
 Edit the real skill docs first:
 
@@ -295,6 +383,49 @@ That order matters.
 
 Do not start by patching the final page template if the real docs are missing.
 
+### 4. You added or edited blog content
+
+The blog now supports two content types:
+
+```text
+sourceType: original   -> written for this site
+sourceType: repost     -> mirrored/curated content with source attribution
+```
+
+A minimal original post looks like this:
+
+```md
+---
+title: Example post
+summary: Short summary for cards and metadata.
+publishDate: 2026-05-03
+author:
+  name: Diversio Engineering
+sourceType: original
+---
+
+Hello world.
+```
+
+A repost must carry more metadata:
+
+```md
+---
+title: Example repost
+summary: Why this external piece matters here.
+publishDate: 2026-05-03
+author:
+  name: Original Author
+sourceType: repost
+sourceSiteName: Example Site
+sourceUrl: https://example.com/post
+canonicalUrl: https://example.com/post
+---
+```
+
+That extra metadata is not optional ceremony. It exists so future readers and
+social crawlers can tell where the piece came from.
+
 ## Commands Worth Remembering
 
 ### Rebuild the site
@@ -311,7 +442,7 @@ cd website
 npm run dev
 ```
 
-### Check the marketplace repo sources that feed the site
+### Check the repo sources that feed the site
 
 ```bash
 cd ..
@@ -329,20 +460,29 @@ rg -n '/skills/|/pi/' dist
 
 ## Route Guide
 
+### Hub pages
+
+- `/`
+- `/agentic-tools`
+- `/blog`
+- `/community`
+
+Use these when you want the high-level engineering hub, tools landing page, editorial index, or collaboration entrypoints.
+
 ### Bundle-level pages
 
 - `/docs/<plugin-or-package>`
 - `/registry`
 
-Use these when you want the overview.
+Use these when you want the tools overview for a specific bundle or the full registry inventory.
 
 ### Deep docs pages
 
 - `/skills/<skill>`
 - `/pi/<package>`
+- `/blog/<slug>`
 
-Use these when you want the actual behavior, commands, tools, references,
-installation flow, or extension surface.
+Use these when you want the actual behavior, commands, tools, references, installation flow, extension surface, or article body.
 
 ## Social Sharing Metadata
 
@@ -361,6 +501,7 @@ That includes:
 
 The logic lives in:
 
+- `site.config.mjs`
 - `src/layouts/BaseLayout.astro`
 
 First principles:
@@ -411,19 +552,68 @@ not as normal background noise.
 
 The site is fully static and deploys cleanly to Cloudflare Pages.
 
+Current deploy shape:
+
+- `Validate Website` remains the read-only build gate
+- `.github/workflows/deploy-website-cloudflare-pages.yml` builds the site in GitHub Actions and uploads `website/dist` to Cloudflare Pages
+- PR previews run for same-repo PRs
+- production deploys run automatically on pushes to `main`
+
+Current redirect split:
+
+- `public/_redirects` handles same-project path aliases such as `/marketplace` -> `/agentic-tools`
+- hostname migration from `agents.diversio.com` to `engineering.diversio.com` still needs host-level redirect configuration during rollout
+
+Required GitHub secrets:
+
+- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_ACCOUNT_ID`
+
+Optional GitHub repo variable:
+
+- `CLOUDFLARE_PAGES_PROJECT` (defaults to `diversio-engineering` in the workflow)
+
 Recommended settings:
 
 | Setting | Value |
 |---|---|
-| Framework preset | Astro |
-| Build command | `npm run build` |
-| Build output directory | `dist` |
-| Root directory | `website/` |
-| Node.js version | 22.12+ |
+| Pages project name | `diversio-engineering` |
+| Deploy path | `website/dist` |
+| Production branch | `main` |
+| Node.js version | 24 |
+
+### Local deploy-minded checks
+
+Before you trust CI, run the same core steps locally:
+
+```bash
+cd website
+npm install --package-lock=false
+npm run build
+```
+
+Then sanity-check the output:
+
+```bash
+rg -n '/agentic-tools|/blog|/skills|/pi' dist
+```
+
+### What preview vs production means here
+
+```text
+pull request from this repo
+  -> preview deployment on Cloudflare Pages
+
+push to main
+  -> production deployment on Cloudflare Pages
+```
+
+This split exists for a simple reason: reviewers need a safe preview URL, while
+production should only change after merge.
 
 The canonical site URL is:
 
-- `https://agents.diversio.com`
+- `https://engineering.diversio.com`
 
 ## Branding Notes
 

--- a/website/README.md
+++ b/website/README.md
@@ -608,13 +608,15 @@ push to main
   -> production deployment on Cloudflare Pages
 
 manual workflow_dispatch run
-  -> preview or production, chosen explicitly at dispatch time
+  -> preview from any selected ref
+  -> production only when dispatched from main
 ```
 
 This split exists for a simple reason: reviewers need a safe preview URL, while
 production should only change after merge. Manual dispatch still exists so the
 team can re-run a preview or production deploy without manufacturing a new code
-change.
+change, but the workflow guards against deploying a feature-branch build to the
+production Pages branch.
 
 The canonical site URL is:
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,8 +1,9 @@
 import { defineConfig } from "astro/config";
+import { siteConfig } from "./site.config.mjs";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://agents.diversio.com",
+  site: siteConfig.siteUrl,
   output: "static",
   build: {
     // Cloudflare-friendly: no inline assets > 4KB

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-skills-marketplace-website",
   "version": "1.0.0",
-  "description": "Agent Skills Marketplace — the extensible layer for AI agents. Discover, integrate, and deploy composable skills with schematic precision.",
+  "description": "Diversio Engineering website with Agentic Tools, deep docs, and blog scaffolding for original posts and curated reposts.",
   "type": "module",
   "scripts": {
     "dev": "astro dev",

--- a/website/public/_redirects
+++ b/website/public/_redirects
@@ -1,0 +1,17 @@
+# Legacy path aliases for the engineering hub rollout.
+#
+# Why these are exact aliases instead of wildcard rewrites:
+# - the tools landing page moved from the old product framing to /agentic-tools
+# - deep docs already kept their short stable routes (/docs, /skills, /pi)
+# - wildcard rewrites can quietly send users to routes that do not really exist
+#
+# Rule of thumb:
+# - use exact aliases here for renamed top-level entrypoints
+# - use page routes for real content
+# - use host-level redirect config for agents.diversio.com -> engineering.diversio.com
+/marketplace /agentic-tools 301
+/marketplace/ /agentic-tools 301
+/tools /agentic-tools 301
+/tools/ /agentic-tools 301
+/agent-skills-marketplace /agentic-tools 301
+/agent-skills-marketplace/ /agentic-tools 301

--- a/website/site.config.mjs
+++ b/website/site.config.mjs
@@ -1,0 +1,43 @@
+// Central website configuration.
+//
+// Why this file exists:
+// - brand/domain strings were starting to drift across layouts, pages, and docs
+// - the site is no longer a single landing page; it now has multiple sections
+// - future changes like a hostname move or nav rename should happen in one place
+//
+// Mental model:
+// - content pages decide *what they say*
+// - this file decides *what the site is called* and *where sections live*
+//
+// If you rename a section or move a top-level route, update this file first,
+// then update any page copy that refers to the old name.
+export const siteConfig = {
+  siteName: "Diversio Engineering",
+  siteUrl: "https://engineering.diversio.com",
+  toolsSectionName: "Agentic Tools",
+  blogSectionName: "Blog",
+  githubUrl: "https://github.com/DiversioTeam/agent-skills-marketplace",
+  defaultDescription:
+    "Diversio Engineering shares agentic tools, deep docs, and engineering writing.",
+  routes: {
+    home: "/",
+    tools: "/agentic-tools",
+    docs: "/docs",
+    registry: "/registry",
+    skills: "/skills",
+    pi: "/pi",
+    blog: "/blog",
+    community: "/community",
+    security: "/security",
+    terms: "/terms",
+  },
+  navItems: [
+    { label: "Home", href: "/", key: "home" },
+    { label: "Agentic Tools", href: "/agentic-tools", key: "tools" },
+    { label: "Docs", href: "/docs", key: "docs" },
+    { label: "Blog", href: "/blog", key: "blog" },
+    { label: "Community", href: "/community", key: "community" },
+  ],
+};
+
+export default siteConfig;

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -1,5 +1,6 @@
 ---
 // Footer.astro — Site footer
+import { siteConfig } from "../../site.config.mjs";
 ---
 <footer class="footer">
   <div class="footer-inner">
@@ -19,13 +20,14 @@
           height="20"
         />
       </a>
-      <span class="footer-product">Agent Skills Marketplace</span>
+      <span class="footer-product">{siteConfig.siteName}</span>
     </div>
     <nav class="footer-links" aria-label="Footer navigation">
-      <a href="https://github.com/DiversioTeam/agent-skills-marketplace" target="_blank" rel="noopener">GitHub</a>
-      <a href="/docs">Docs</a>
-      <a href="/security">Security</a>
-      <a href="/terms">Terms</a>
+      <a href={siteConfig.githubUrl} target="_blank" rel="noopener">GitHub</a>
+      <a href={siteConfig.routes.tools}>{siteConfig.toolsSectionName}</a>
+      <a href={siteConfig.routes.blog}>{siteConfig.blogSectionName}</a>
+      <a href={siteConfig.routes.security}>Security</a>
+      <a href={siteConfig.routes.terms}>Terms</a>
     </nav>
     <div class="footer-copy">
       Built by <a href="https://www.diversio.com" target="_blank" rel="noopener">Diversio.com</a>

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -1,22 +1,18 @@
 ---
 // Header.astro — Top navigation bar
+import { siteConfig } from "../../site.config.mjs";
+
 export interface Props {
-  currentNav?: "marketplace" | "docs" | "registry" | "community";
+  currentNav?: "home" | "tools" | "docs" | "blog" | "community";
 }
 
-const { currentNav = "marketplace" } = Astro.props;
-
-const navItems = [
-  { label: "Marketplace", href: "/", key: "marketplace" },
-  { label: "Documentation", href: "/docs", key: "docs" },
-  { label: "Registry", href: "/registry", key: "registry" },
-  { label: "Community", href: "/community", key: "community" },
-];
+const { currentNav = "home" } = Astro.props;
+const navItems = siteConfig.navItems;
 ---
 <header class="header">
   <div class="header-inner">
     <div class="header-left">
-      <a href="/" class="header-brand" aria-label="Agent Skills Marketplace Home">
+      <a href={siteConfig.routes.home} class="header-brand" aria-label={`${siteConfig.siteName} Home`}>
         <img
           src="/diversio-logo.svg"
           alt="Diversio"
@@ -25,13 +21,14 @@ const navItems = [
           height="20"
         />
         <span class="header-brand-divider" aria-hidden="true"></span>
-        <span class="header-brand-product">Agent Skills Marketplace</span>
+        <span class="header-brand-product">{siteConfig.siteName}</span>
       </a>
       <nav class="header-nav" aria-label="Main navigation">
         {navItems.map((item) => (
           <a
             href={item.href}
             class={`header-nav-link${item.key === currentNav ? " header-nav-link--active" : ""}`}
+            aria-current={item.key === currentNav ? "page" : undefined}
           >
             {item.label}
           </a>
@@ -39,13 +36,13 @@ const navItems = [
       </nav>
     </div>
     <div class="header-right">
-      <a href="https://github.com/DiversioTeam/agent-skills-marketplace" class="header-icon-btn" aria-label="GitHub Repository" target="_blank" rel="noopener">
+      <a href={siteConfig.githubUrl} class="header-icon-btn" aria-label="GitHub Repository" target="_blank" rel="noopener">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
         </svg>
       </a>
-      <a href="/docs" class="btn btn-primary header-cta">
-        Get Started
+      <a href={siteConfig.routes.tools} class="btn btn-primary header-cta">
+        Explore Tools
       </a>
     </div>
   </div>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -1,7 +1,8 @@
 ---
-// Hero.astro — Homepage hero. Real content about the Agent Skills Marketplace.
+// Hero.astro — Agentic Tools hero.
 import Terminal from "./Terminal.astro";
 import { plugins, piPackages } from "../data/marketplace.json";
+import { siteConfig } from "../../site.config.mjs";
 
 const totalSkills = plugins.reduce((sum, p) => sum + p.skills.length, 0);
 ---
@@ -18,16 +19,14 @@ const totalSkills = plugins.reduce((sum, p) => sum + p.skills.length, 0);
         />
         <span class="label-caps hero-brand-note">Engineering</span>
       </div>
-      <h1 class="hero-title">Agent Skills Marketplace</h1>
+      <h1 class="hero-title">{siteConfig.toolsSectionName}</h1>
       <p class="body-lg hero-desc">
-        A configuration-only registry of reusable agent skills. Markdown files with YAML frontmatter
-        that teach coding agents how to do specific tasks — from pedantic Django code review to
-        structured release management. Portable across Claude Code, Codex, and Pi.
+        Open source tools, reusable skills, and Pi extensions from Diversio Engineering for Claude Code, Codex, and Pi.
       </p>
       <div class="hero-actions">
-        <a href="/docs" class="btn btn-primary btn-md">Get Started</a>
-        <a href="/registry" class="btn btn-secondary btn-md">Browse Registry</a>
-        <a href="https://github.com/DiversioTeam/agent-skills-marketplace" class="btn btn-ghost btn-md" target="_blank" rel="noopener">GitHub</a>
+        <a href={siteConfig.routes.docs} class="btn btn-primary btn-md">Read the Docs</a>
+        <a href={siteConfig.routes.registry} class="btn btn-secondary btn-md">Browse Registry</a>
+        <a href={siteConfig.githubUrl} class="btn btn-ghost btn-md" target="_blank" rel="noopener">GitHub</a>
       </div>
       <div class="hero-terminal">
         <Terminal

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -1,0 +1,62 @@
+import { glob } from "astro/loaders";
+import { defineCollection, z } from "astro:content";
+
+// Blog content collection.
+//
+// Why this file exists:
+// - the engineering hub now needs a real editorial surface, not just tool docs
+// - original posts and curated reposts need one explicit schema
+// - reposts need guardrails so we do not lose attribution or canonical URLs
+//
+// First principles:
+// - keep v1 simple: local markdown in git, reviewed like code
+// - make the important publishing rules machine-checkable
+// - fail early when a repost is missing source metadata
+//
+// Example mental model:
+//   original post -> published here, canonical can default to this site
+//   repost        -> published here, but must still point back to the source
+const blog = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/blog" }),
+  schema: z
+    .object({
+      title: z.string(),
+      slug: z.string().optional(),
+      summary: z.string(),
+      publishDate: z.coerce.date(),
+      updatedDate: z.coerce.date().optional(),
+      author: z.object({
+        name: z.string(),
+        url: z.string().url().optional(),
+      }),
+      tags: z.array(z.string()).default([]),
+      sourceType: z.enum(["original", "repost"]),
+      sourceSiteName: z.string().optional(),
+      sourceUrl: z.string().url().optional(),
+      canonicalUrl: z.string().url().optional(),
+      heroImage: z.string().optional(),
+      socialImage: z.string().optional(),
+      socialTitle: z.string().optional(),
+      socialDescription: z.string().optional(),
+      draft: z.boolean().default(false),
+    })
+    .superRefine((data, ctx) => {
+      if (data.sourceType === "repost" && !data.sourceUrl) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Reposts must include sourceUrl.",
+          path: ["sourceUrl"],
+        });
+      }
+
+      if (data.sourceType === "repost" && !data.canonicalUrl) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Reposts must include canonicalUrl.",
+          path: ["canonicalUrl"],
+        });
+      }
+    }),
+});
+
+export const collections = { blog };

--- a/website/src/content/blog/draft-placeholder.md
+++ b/website/src/content/blog/draft-placeholder.md
@@ -1,0 +1,14 @@
+---
+title: Draft placeholder
+slug: draft-placeholder
+summary: Placeholder draft entry so the blog collection exists before the first real published post.
+publishDate: 2026-05-03
+author:
+  name: Diversio Engineering
+tags:
+  - draft
+sourceType: original
+draft: true
+---
+
+This file is intentionally unpublished.

--- a/website/src/content/blog/introducing-diversio-engineering-hub.md
+++ b/website/src/content/blog/introducing-diversio-engineering-hub.md
@@ -1,0 +1,44 @@
+---
+title: Introducing the Diversio Engineering hub
+slug: introducing-diversio-engineering-hub
+summary: Diversio's website foundation now expands from a tools-focused marketplace into a broader engineering home with Agentic Tools, deep docs, and blog support.
+publishDate: 2026-05-03
+author:
+  name: Diversio Engineering
+tags:
+  - launch
+  - website
+  - agentic-tools
+sourceType: original
+---
+
+The website baseline from PR #77 is now the foundation for a broader **Diversio Engineering** hub.
+
+## What changed
+
+The site is no longer treated as a single-product microsite.
+
+Instead, it now has three clear responsibilities:
+
+- a broader engineering homepage
+- an **Agentic Tools** section that preserves the existing marketplace and deep docs work
+- a blog surface for original posts and curated reposts
+
+## What stayed the same
+
+The existing Astro site remains the implementation baseline.
+
+That means the following surfaces continue to work as the core tools/docs layer:
+
+- `/docs/*`
+- `/skills/*`
+- `/pi/*`
+- `/registry`
+
+## What comes next
+
+The next phase focuses on:
+
+- finalizing redirects and legacy-host handling
+- adding curated repost support for external writing
+- publishing more engineering writing alongside the tools/docs experience

--- a/website/src/data/open-source-projects.ts
+++ b/website/src/data/open-source-projects.ts
@@ -1,0 +1,30 @@
+// Additional open-source projects to highlight outside the main Agentic Tools
+// registry.
+//
+// Why a separate data file instead of hardcoding the cards in a page?
+// - the homepage and community page both need the same list
+// - project order is intentional and should be easy to review
+// - adding/removing a repo should be a small data edit, not a page rewrite
+export const openSourceProjects = [
+  {
+    name: "clickup-mcp",
+    repo: "DiversioTeam/clickup-mcp",
+    category: "MCP",
+    description: "Connect ClickUp tasks and workspace context to MCP-enabled tools.",
+    url: "https://github.com/DiversioTeam/clickup-mcp",
+  },
+  {
+    name: "gemini-cli-mcp",
+    repo: "DiversioTeam/gemini-cli-mcp",
+    category: "MCP",
+    description: "Expose Gemini CLI workflows through MCP for research and automation.",
+    url: "https://github.com/DiversioTeam/gemini-cli-mcp",
+  },
+  {
+    name: "pi-cmux",
+    repo: "DiversioTeam/pi-cmux",
+    category: "Shared runtime",
+    description: "Shared cmux utilities used in Pi-powered terminal workflows.",
+    url: "https://github.com/DiversioTeam/pi-cmux",
+  },
+];

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -8,11 +8,13 @@
 // - the same metadata should work across Open Graph consumers like Slack,
 //   Facebook, LinkedIn, and iMessage, while also covering X/Twitter cards
 import "../styles/global.css";
+import { siteConfig } from "../../site.config.mjs";
 
 export interface Props {
   title: string;
   description?: string;
   ogImage?: string;
+  canonicalUrl?: string;
   socialTitle?: string;
   socialDescription?: string;
   socialImageAlt?: string;
@@ -21,11 +23,12 @@ export interface Props {
   ogImageHeight?: number;
 }
 
-const siteName = "Agent Skills Marketplace";
+const siteName = siteConfig.siteName;
 const {
   title,
-  description = "Reusable agent skills from Diversio for Claude Code, Codex, and Pi.",
+  description = siteConfig.defaultDescription,
   ogImage = "/og-default.png",
+  canonicalUrl,
   socialTitle,
   socialDescription,
   socialImageAlt,
@@ -37,7 +40,7 @@ const {
 const fullTitle = title === siteName ? siteName : `${title} — ${siteName}`;
 const resolvedDescription = socialDescription ?? description;
 const resolvedSocialTitle = socialTitle ?? fullTitle;
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
+const resolvedCanonicalUrl = canonicalUrl ?? new URL(Astro.url.pathname, Astro.site).href;
 const ogImageUrl = new URL(ogImage, Astro.site).href;
 const resolvedSocialImageAlt = socialImageAlt ?? `${resolvedSocialTitle} social preview`;
 const ogImageType = ogImage.endsWith(".png")
@@ -61,7 +64,7 @@ const ogImageType = ogImage.endsWith(".png")
   <meta property="og:type" content={socialType} />
   <meta property="og:site_name" content={siteName} />
   <meta property="og:locale" content="en_US" />
-  <meta property="og:url" content={canonicalUrl} />
+  <meta property="og:url" content={resolvedCanonicalUrl} />
   <meta property="og:image" content={ogImageUrl} />
   <meta property="og:image:secure_url" content={ogImageUrl} />
   {ogImageType && <meta property="og:image:type" content={ogImageType} />}
@@ -77,7 +80,7 @@ const ogImageType = ogImage.endsWith(".png")
   <meta name="twitter:image:alt" content={resolvedSocialImageAlt} />
 
   <!-- Canonical -->
-  <link rel="canonical" href={canonicalUrl} />
+  <link rel="canonical" href={resolvedCanonicalUrl} />
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/website/src/layouts/PageLayout.astro
+++ b/website/src/layouts/PageLayout.astro
@@ -4,23 +4,27 @@ import BaseLayout from "./BaseLayout.astro";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 
+export type HeaderNavKey = "home" | "tools" | "docs" | "blog" | "community";
+
 export interface Props {
   title: string;
   description?: string;
   ogImage?: string;
+  canonicalUrl?: string;
   socialTitle?: string;
   socialDescription?: string;
   socialImageAlt?: string;
   socialType?: "website" | "article";
   ogImageWidth?: number;
   ogImageHeight?: number;
-  currentNav?: "marketplace" | "docs" | "registry" | "community";
+  currentNav?: HeaderNavKey;
 }
 
 const {
   title,
   description,
   ogImage,
+  canonicalUrl,
   socialTitle,
   socialDescription,
   socialImageAlt,
@@ -34,6 +38,7 @@ const {
   {title}
   {description}
   {ogImage}
+  {canonicalUrl}
   {socialTitle}
   {socialDescription}
   {socialImageAlt}

--- a/website/src/pages/agentic-tools.astro
+++ b/website/src/pages/agentic-tools.astro
@@ -1,0 +1,357 @@
+---
+// Public landing page for the Agentic Tools section.
+//
+// Why this page exists:
+// - the old homepage was tools-first, but the overall site is now broader
+// - we still want one obvious place where visitors can understand the tools
+// - this page preserves the original strengths of the site: registry, runtime
+//   examples, and deep docs entrypoints
+//
+// Rule of thumb:
+// - homepage (`/`) explains the whole engineering hub
+// - this page (`/agentic-tools`) explains the open tools section in depth
+import PageLayout from "../layouts/PageLayout.astro";
+import Hero from "../components/Hero.astro";
+import SectionHeader from "../components/SectionHeader.astro";
+import Card from "../components/Card.astro";
+import CardGrid from "../components/CardGrid.astro";
+import CodeBlock from "../components/CodeBlock.astro";
+import RuntimeCodeTabs from "../components/RuntimeCodeTabs.astro";
+import { plugins, piPackages } from "../data/marketplace.json";
+import { siteConfig } from "../../site.config.mjs";
+
+const featured = plugins.filter((p) =>
+  ["monty-code-review", "backend-atomic-commit", "backend-release",
+   "visual-explainer", "plan-directory", "clickup-ticket"].includes(p.name)
+);
+const totalSkills = plugins.reduce((sum, p) => sum + p.skills.length, 0);
+const categories = [...new Set(plugins.map((p) => p.category))];
+
+const claudePluginInstallCode = `claude plugin marketplace add DiversioTeam/agent-skills-marketplace
+claude plugin install monty-code-review@diversiotech`;
+
+const codexPluginInstallCode = `CODEX_HOME="\${CODEX_HOME:-$HOME/.codex}"
+python3 "$CODEX_HOME/skills/.system/skill-installer/scripts/install-skill-from-github.py" \\
+  --repo DiversioTeam/agent-skills-marketplace \\
+  --path plugins/monty-code-review/skills/monty-code-review`;
+
+const claudeInvokeCode = `/monty-code-review:code-review
+/backend-atomic-commit:commit`;
+
+const codexInvokeCode = `name: monty-code-review
+name: backend-atomic-commit`;
+---
+
+<PageLayout
+  title={siteConfig.toolsSectionName}
+  description={`Explore ${siteConfig.toolsSectionName}: ${plugins.length} plugins, ${piPackages.length} pi packages, and ${totalSkills} reusable skills from Diversio.`}
+  currentNav="tools"
+>
+  <Hero />
+
+  <section class="page-section">
+    <SectionHeader
+      label={siteConfig.toolsSectionName}
+      title="How Agentic Tools is organized"
+      description="Three layers work together: reusable skills, installable plugin bundles, and Pi-native extensions."
+    />
+    <div class="layers-grid">
+      <div class="layer-card layer-skills">
+        <div class="layer-card-header">
+          <span class="label-caps">Layer 1</span>
+          <span class="code-text-sm" style="color: var(--color-text-muted)">{totalSkills} skills</span>
+        </div>
+        <div class="layer-card-body">
+          <h3 class="headline-sm">Skills</h3>
+          <p class="body-md">The core unit. Each skill is a single <code>SKILL.md</code> — a Markdown file with YAML frontmatter that teaches an agent how to perform one task well.</p>
+          <div class="layer-example">
+            <CodeBlock
+              lang="yaml"
+              filename="monty-code-review/SKILL.md"
+              code={`---
+name: monty-code-review
+description: >-
+  Hyper-pedantic Django code review with
+  correctness-first, multi-tenant-safe,
+  harness-aware review style.
+---`}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div class="layer-card layer-plugins">
+        <div class="layer-card-header">
+          <span class="label-caps">Layer 2</span>
+          <span class="code-text-sm" style="color: var(--color-text-muted)">{plugins.length} plugins</span>
+        </div>
+        <div class="layer-card-body">
+          <h3 class="headline-sm">Plugins</h3>
+          <p class="body-md">The distribution layer. Each plugin packages one or more related skills with slash-command wrappers for Claude Code, while Codex users install exact skill directories from the repo.</p>
+          <div class="layer-example">
+            <RuntimeCodeTabs
+              tabs={[
+                { label: "Claude Code", code: claudePluginInstallCode },
+                { label: "Codex", code: codexPluginInstallCode },
+              ]}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div class="layer-card layer-pi">
+        <div class="layer-card-header">
+          <span class="label-caps">Layer 3</span>
+          <span class="code-text-sm" style="color: var(--color-text-muted)">{piPackages.length} packages</span>
+        </div>
+        <div class="layer-card-body">
+          <h3 class="headline-sm">Pi Packages</h3>
+          <p class="body-md">Extensions for the <a href="https://pi.dev">Pi</a> coding agent harness. These packages add tools, TUI widgets, notifications, and runtime behavior to Pi itself, while Skills Bridge exposes plugin skills inside Pi.</p>
+          <div class="layer-example">
+            <CodeBlock
+              lang="bash"
+              code={`pi install git:github.com/DiversioTeam/agent-skills-marketplace
+# installs all pi packages at once:
+# dev-workflow, skills-bridge, ci-status, oh-my-pi, image-router`}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="page-section">
+    <div class="catalog-header">
+      <SectionHeader
+        label="Registry"
+        title="Popular tools"
+        description={`${plugins.length} plugins across ${categories.join(", ")}.`}
+      />
+      <a href={siteConfig.routes.registry} class="catalog-view-all label-caps">View all {plugins.length} →</a>
+    </div>
+    <CardGrid cols={3}>
+      {featured.map((p) => (
+        <Card
+          category={p.category}
+          packageId={p.name}
+          title={p.title}
+          description={p.description}
+          version={p.version}
+          runtimes={["CC", "CODEX"]}
+          href={`/docs/${p.name}`}
+        />
+      ))}
+    </CardGrid>
+  </section>
+
+  <section class="page-section">
+    <SectionHeader
+      label="Pi Packages"
+      title="Pi extensions"
+      description={`${piPackages.length} packages that extend the Pi agent harness.`}
+    />
+    <CardGrid cols={3}>
+      {piPackages.map((p) => (
+        <Card
+          category="Pi Package"
+          packageId={p.name}
+          title={p.title}
+          description={p.description}
+          version={p.version}
+          href={`/pi/${p.name}`}
+        />
+      ))}
+    </CardGrid>
+  </section>
+
+  <section class="page-section">
+    <SectionHeader
+      label="Quickstart"
+      title="Get started quickly"
+      description="Pick a runtime, copy the right command, and start using the tool you need."
+    />
+    <div class="quickstart-grid">
+      <div class="quickstart-step">
+        <span class="quickstart-num code-text">01</span>
+        <h3 class="headline-sm">Install the tool</h3>
+        <p class="body-md">Pick your runtime, then copy the install command that matches it.</p>
+        <RuntimeCodeTabs
+          tabs={[
+            { label: "Claude Code", code: claudePluginInstallCode },
+            { label: "Codex", code: codexPluginInstallCode },
+          ]}
+        />
+      </div>
+      <div class="quickstart-step">
+        <span class="quickstart-num code-text">02</span>
+        <h3 class="headline-sm">Invoke a skill</h3>
+        <p class="body-md">Switch between Claude Code and Codex so copy-to-clipboard gives you the right invocation.</p>
+        <RuntimeCodeTabs
+          tabs={[
+            { label: "Claude Code", code: claudeInvokeCode },
+            { label: "Codex", code: codexInvokeCode },
+          ]}
+        />
+      </div>
+      <div class="quickstart-step">
+        <span class="quickstart-num code-text">03</span>
+        <h3 class="headline-sm">Ship with confidence</h3>
+        <p class="body-md">Skills enforce repo-local conventions and pre-commit hooks. CI validates every change.</p>
+        <CodeBlock lang="bash" code={"/backend-pr-workflow:check-pr\n# branch → migration safety → PR hygiene"} />
+      </div>
+    </div>
+  </section>
+
+  <section class="page-section contribute-section">
+    <div class="contribute-card">
+      <h2 class="headline-md contribute-title">Built on an open standard</h2>
+      <p class="body-lg contribute-desc">
+        {siteConfig.toolsSectionName} follows the{" "}
+        <a href="https://agentskills.io/specification">Agent Skills standard</a>{" "}
+        — an open, tool-agnostic format. Every skill is a directory with a required{" "}
+        <code>SKILL.md</code>, optional <code>references/</code>, <code>scripts/</code>, and{" "}
+        <code>assets/</code>. That keeps the format portable across Claude Code, Codex, and Pi.
+      </p>
+      <div class="contribute-actions">
+        <a href={siteConfig.githubUrl} class="btn btn-primary btn-md" target="_blank" rel="noopener">
+          View on GitHub
+        </a>
+        <a href={siteConfig.routes.docs} class="btn btn-secondary btn-md">
+          Read the Docs
+        </a>
+      </div>
+    </div>
+  </section>
+</PageLayout>
+
+<style>
+  .page-section {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: var(--space-3xl) var(--space-margin);
+  }
+  .page-section + .page-section {
+    border-top: var(--border-hairline);
+  }
+
+  .layers-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-xl);
+  }
+  @media (min-width: 1024px) {
+    .layers-grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .layer-card {
+    background: var(--color-surface);
+    border: var(--border-hairline);
+    display: flex;
+    flex-direction: column;
+  }
+  .layer-skills { border-top: 3px solid var(--color-primary); }
+  .layer-plugins { border-top: 3px solid var(--color-primary); }
+  .layer-pi { border-top: 3px solid var(--color-accent); }
+
+  .layer-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: var(--space-xs) var(--space-md);
+    background: var(--color-surface-low);
+    border-bottom: var(--border-hairline);
+  }
+  .layer-card-body {
+    padding: var(--space-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+  .layer-card-body h3 { margin: 0; }
+  .layer-card-body p { color: var(--color-text-secondary); margin: 0; }
+  .layer-card-body code {
+    font-family: var(--font-code);
+    font-size: var(--text-code-sm);
+    background: var(--color-surface-low);
+    padding: 1px 5px;
+    border-radius: var(--radius-sm);
+    color: var(--color-primary);
+  }
+  .layer-example { margin-top: var(--space-sm); }
+  .layer-example :global(.code-block) { margin-bottom: 0; }
+
+  .catalog-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    margin-bottom: var(--space-xl);
+    flex-wrap: wrap;
+    gap: var(--space-md);
+  }
+  .catalog-view-all {
+    color: var(--color-primary);
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  .catalog-view-all:hover { text-decoration: underline; }
+
+  .quickstart-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-xl);
+  }
+  @media (min-width: 768px) {
+    .quickstart-grid { grid-template-columns: repeat(3, 1fr); }
+  }
+  .quickstart-step {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+  .quickstart-num {
+    font-size: var(--text-headline-lg);
+    font-weight: 700;
+    color: var(--color-primary-container);
+    line-height: 1;
+  }
+  .quickstart-step p { color: var(--color-text-secondary); }
+  .quickstart-step :global(.code-block) { margin-top: auto; }
+
+  .contribute-section { border-top: var(--border-hairline); }
+  .contribute-card {
+    background: var(--color-surface);
+    border: var(--border-hairline);
+    border-radius: var(--radius-md);
+    padding: var(--space-2xl);
+    box-shadow: var(--shadow-block);
+    text-align: center;
+  }
+  .contribute-title { margin-bottom: var(--space-md); }
+  .contribute-desc {
+    color: var(--color-text-secondary);
+    max-width: 36rem;
+    margin: 0 auto var(--space-xl);
+  }
+  .contribute-desc code {
+    font-family: var(--font-code);
+    font-size: var(--text-code-sm);
+    background: var(--color-surface-low);
+    padding: 1px 6px;
+    border-radius: var(--radius-sm);
+    color: var(--color-primary);
+  }
+  .contribute-actions {
+    display: flex;
+    justify-content: center;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+  }
+
+  @media (max-width: 640px) {
+    .page-section {
+      padding: var(--space-2xl) var(--space-md);
+    }
+  }
+</style>

--- a/website/src/pages/blog/[slug].astro
+++ b/website/src/pages/blog/[slug].astro
@@ -1,0 +1,179 @@
+---
+// Individual blog post page.
+//
+// Why this page exists:
+// - original posts and curated reposts share one layout and metadata system
+// - reposts sometimes need a canonical URL that points to the original source
+// - the content body should stay plain markdown while the page handles the
+//   surrounding attribution and social metadata rules
+import { getCollection, render } from "astro:content";
+import PageLayout from "../../layouts/PageLayout.astro";
+
+export async function getStaticPaths() {
+  const posts = (await getCollection("blog")).filter((post) => !post.data.draft);
+
+  return posts.map((post) => ({
+    params: { slug: (post.data.slug ?? post.id).replace(/\.md$/, "") },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await render(post);
+const isRepost = post.data.sourceType === "repost";
+---
+
+<PageLayout
+  title={post.data.title}
+  description={post.data.summary}
+  ogImage={post.data.socialImage ?? post.data.heroImage}
+  canonicalUrl={post.data.canonicalUrl}
+  socialTitle={post.data.socialTitle ?? post.data.title}
+  socialDescription={post.data.socialDescription ?? post.data.summary}
+  socialType="article"
+  currentNav="blog"
+>
+  <section class="post-shell">
+    <header class="post-header">
+      <div class="post-kicker-row">
+        <span class={`label-caps post-kind${isRepost ? " post-kind--repost" : ""}`}>
+          {isRepost ? "Curated repost" : "Original post"}
+        </span>
+        <time class="code-text-sm post-date" datetime={post.data.publishDate.toISOString()}>
+          {post.data.publishDate.toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}
+        </time>
+      </div>
+      <h1 class="headline-xl post-title">{post.data.title}</h1>
+      <p class="body-lg post-summary">{post.data.summary}</p>
+      <div class="post-byline body-md">
+        <span>By {post.data.author.name}</span>
+        {post.data.author.url && (
+          <a href={post.data.author.url} target="_blank" rel="noopener">author link</a>
+        )}
+      </div>
+      {isRepost && (
+        <div class="source-note">
+          <strong>Source:</strong>{" "}
+          {post.data.sourceUrl ? (
+            <a href={post.data.sourceUrl} target="_blank" rel="noopener">
+              {post.data.sourceSiteName ?? post.data.sourceUrl}
+            </a>
+          ) : (
+            post.data.sourceSiteName ?? "External source"
+          )}
+          {post.data.canonicalUrl && (
+            <>
+              {" "}· <strong>Canonical:</strong>{" "}
+              <a href={post.data.canonicalUrl} target="_blank" rel="noopener">
+                {post.data.canonicalUrl}
+              </a>
+            </>
+          )}
+        </div>
+      )}
+    </header>
+
+    <article class="post-content prose">
+      <Content />
+    </article>
+  </section>
+</PageLayout>
+
+<style>
+  .post-shell {
+    max-width: 48rem;
+    margin: 0 auto;
+    padding: var(--space-3xl) var(--space-margin);
+  }
+
+  .post-header {
+    margin-bottom: var(--space-2xl);
+  }
+
+  .post-kicker-row,
+  .post-byline {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+  }
+
+  .post-kind {
+    color: var(--color-primary);
+  }
+
+  .post-kind--repost {
+    color: var(--color-accent);
+  }
+
+  .post-date,
+  .post-summary,
+  .post-byline,
+  .source-note,
+  .prose {
+    color: var(--color-text-secondary);
+  }
+
+  .post-title {
+    margin: var(--space-sm) 0;
+  }
+
+  .post-summary {
+    max-width: 40rem;
+  }
+
+  .post-byline a,
+  .source-note a {
+    color: var(--color-primary);
+  }
+
+  .source-note {
+    margin-top: var(--space-lg);
+    padding: var(--space-md);
+    border: var(--border-hairline);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-low);
+  }
+
+  .post-content :global(h2),
+  .post-content :global(h3),
+  .post-content :global(h4) {
+    color: var(--color-text);
+    margin-top: var(--space-2xl);
+    margin-bottom: var(--space-sm);
+  }
+
+  .post-content :global(p),
+  .post-content :global(ul),
+  .post-content :global(ol),
+  .post-content :global(blockquote) {
+    margin-bottom: var(--space-md);
+  }
+
+  .post-content :global(a) {
+    color: var(--color-primary);
+  }
+
+  .post-content :global(code) {
+    font-family: var(--font-code);
+    font-size: var(--text-code-sm);
+    background: var(--color-surface-low);
+    padding: 1px 6px;
+    border-radius: var(--radius-sm);
+    color: var(--color-primary);
+  }
+
+  .post-content :global(pre) {
+    margin: var(--space-lg) 0;
+  }
+
+  @media (max-width: 640px) {
+    .post-shell {
+      padding: var(--space-2xl) var(--space-md);
+    }
+  }
+</style>

--- a/website/src/pages/blog/[slug].astro
+++ b/website/src/pages/blog/[slug].astro
@@ -8,6 +8,7 @@
 //   surrounding attribution and social metadata rules
 import { getCollection, render } from "astro:content";
 import PageLayout from "../../layouts/PageLayout.astro";
+import { formatEditorialDate } from "../../utils/format-date";
 
 export async function getStaticPaths() {
   const posts = (await getCollection("blog")).filter((post) => !post.data.draft);
@@ -40,11 +41,7 @@ const isRepost = post.data.sourceType === "repost";
           {isRepost ? "Curated repost" : "Original post"}
         </span>
         <time class="code-text-sm post-date" datetime={post.data.publishDate.toISOString()}>
-          {post.data.publishDate.toLocaleDateString("en-US", {
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-          })}
+          {formatEditorialDate(post.data.publishDate, "long")}
         </time>
       </div>
       <h1 class="headline-xl post-title">{post.data.title}</h1>
@@ -52,7 +49,9 @@ const isRepost = post.data.sourceType === "repost";
       <div class="post-byline body-md">
         <span>By {post.data.author.name}</span>
         {post.data.author.url && (
-          <a href={post.data.author.url} target="_blank" rel="noopener">author link</a>
+          <a href={post.data.author.url} target="_blank" rel="noopener">
+            {post.data.author.name} profile
+          </a>
         )}
       </div>
       {isRepost && (

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -1,0 +1,213 @@
+---
+// Blog index for the engineering hub.
+//
+// Why this page exists:
+// - engineering writing needs a first-class home alongside the tools section
+// - original posts should be easy to publish from markdown
+// - curated reposts should be visible, but clearly labeled and attributable
+//
+// This page intentionally handles both post types in one list so readers do not
+// have to learn two different content surfaces.
+import { getCollection } from "astro:content";
+import PageLayout from "../../layouts/PageLayout.astro";
+import SectionHeader from "../../components/SectionHeader.astro";
+import { siteConfig } from "../../../site.config.mjs";
+
+const posts = (await getCollection("blog"))
+  .filter((post) => !post.data.draft)
+  .sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime());
+const hasReposts = posts.some((post) => post.data.sourceType === "repost");
+const blogDescription = hasReposts
+  ? "Original Diversio Engineering posts and curated reposts, with clear attribution and canonical metadata."
+  : "Original Diversio Engineering posts are live now, and curated reposts will be added with clear attribution and canonical metadata.";
+
+function getPostSlug(post: { id: string; data: { slug?: string } }) {
+  return (post.data.slug ?? post.id).replace(/\.md$/, "");
+}
+---
+
+<PageLayout
+  title={siteConfig.blogSectionName}
+  description={blogDescription}
+  currentNav="blog"
+>
+  <section class="page-section page-hero">
+    <SectionHeader
+      label={siteConfig.blogSectionName}
+      title="Engineering writing"
+      description={hasReposts
+        ? "Original posts from Diversio Engineering and curated reposts live in one place, with clear source labeling and canonical URL support."
+        : "Original posts from Diversio Engineering are live now. Curated reposts are coming soon, with clear source labeling and canonical URL support."
+      }
+    />
+  </section>
+
+  <section class="page-section">
+    {!hasReposts && (
+      <div class="status-banner">
+        <span class="status-chip">Coming soon</span>
+        <p class="body-md status-copy">
+          Curated reposts are not published yet. When they arrive, they’ll appear here with clear attribution and links back to the original source.
+        </p>
+      </div>
+    )}
+    {posts.length > 0 ? (
+      <div class="posts-grid">
+        {posts.map((post) => {
+          const href = `/blog/${getPostSlug(post)}`;
+          const isRepost = post.data.sourceType === "repost";
+          return (
+            <article class="post-card">
+              <div class="post-meta-row">
+                <span class={`label-caps post-kind${isRepost ? " post-kind--repost" : ""}`}>
+                  {isRepost ? "Curated repost" : "Original post"}
+                </span>
+                <time class="code-text-sm post-date" datetime={post.data.publishDate.toISOString()}>
+                  {post.data.publishDate.toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </time>
+              </div>
+              <h2 class="headline-sm"><a href={href}>{post.data.title}</a></h2>
+              <p class="body-md post-summary">{post.data.summary}</p>
+              <div class="post-footer">
+                <span class="body-md post-author">{post.data.author.name}</span>
+                {isRepost && post.data.sourceSiteName && (
+                  <span class="code-text-sm post-source">Source: {post.data.sourceSiteName}</span>
+                )}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    ) : (
+      <div class="empty-state">
+        <h2 class="headline-sm">No posts published yet</h2>
+        <p class="body-md empty-copy">
+          The blog scaffolding is ready for original Diversio Engineering posts and curated reposts. Add markdown entries under <code>website/src/content/blog/</code> using the collection schema in <code>website/src/content.config.ts</code>.
+        </p>
+      </div>
+    )}
+  </section>
+</PageLayout>
+
+<style>
+  .page-section {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 0 var(--space-margin) var(--space-3xl);
+  }
+
+  .page-hero {
+    padding-top: var(--space-3xl);
+  }
+
+  .page-section + .page-section {
+    border-top: var(--border-hairline);
+    padding-top: var(--space-3xl);
+  }
+
+  .posts-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-lg);
+  }
+
+  .status-banner,
+  .post-card,
+  .empty-state {
+    background: var(--color-surface);
+    border: var(--border-hairline);
+    border-radius: var(--radius-md);
+    padding: var(--space-lg);
+    box-shadow: var(--shadow-block-sm);
+  }
+
+  .status-banner {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    flex-wrap: wrap;
+    margin-bottom: var(--space-lg);
+  }
+
+  .post-meta-row,
+  .post-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+  }
+
+  .status-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.1875rem 0.5rem;
+    border: var(--border-hairline);
+    border-radius: 999px;
+    background: var(--color-surface-low);
+    color: var(--color-text-secondary);
+    font-family: var(--font-code);
+    font-size: var(--text-code-sm);
+    white-space: nowrap;
+  }
+
+  .post-kind {
+    color: var(--color-primary);
+  }
+
+  .post-kind--repost {
+    color: var(--color-accent);
+  }
+
+  .post-date,
+  .post-source,
+  .post-author,
+  .status-copy,
+  .empty-copy {
+    color: var(--color-text-secondary);
+  }
+
+  .post-card h2 {
+    margin: var(--space-sm) 0;
+  }
+
+  .post-card h2 a {
+    color: var(--color-text);
+    text-decoration: none;
+  }
+
+  .post-card h2 a:hover {
+    color: var(--color-primary);
+  }
+
+  .post-summary {
+    color: var(--color-text-secondary);
+    margin-bottom: var(--space-md);
+  }
+
+  .status-banner code,
+  .empty-state code {
+    font-family: var(--font-code);
+    font-size: var(--text-code-sm);
+    background: var(--color-surface-low);
+    padding: 1px 6px;
+    border-radius: var(--radius-sm);
+    color: var(--color-primary);
+  }
+
+  @media (max-width: 640px) {
+    .page-section {
+      padding: 0 var(--space-md) var(--space-2xl);
+    }
+
+    .page-hero,
+    .page-section + .page-section {
+      padding-top: var(--space-2xl);
+    }
+  }
+</style>

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -11,6 +11,7 @@
 import { getCollection } from "astro:content";
 import PageLayout from "../../layouts/PageLayout.astro";
 import SectionHeader from "../../components/SectionHeader.astro";
+import { formatEditorialDate } from "../../utils/format-date";
 import { siteConfig } from "../../../site.config.mjs";
 
 const posts = (await getCollection("blog"))
@@ -63,11 +64,7 @@ function getPostSlug(post: { id: string; data: { slug?: string } }) {
                   {isRepost ? "Curated repost" : "Original post"}
                 </span>
                 <time class="code-text-sm post-date" datetime={post.data.publishDate.toISOString()}>
-                  {post.data.publishDate.toLocaleDateString("en-US", {
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                  })}
+                  {formatEditorialDate(post.data.publishDate, "short")}
                 </time>
               </div>
               <h2 class="headline-sm"><a href={href}>{post.data.title}</a></h2>

--- a/website/src/pages/community.astro
+++ b/website/src/pages/community.astro
@@ -5,6 +5,7 @@ import FeatureList from "../components/FeatureList.astro";
 import CodeBlock from "../components/CodeBlock.astro";
 import { plugins, piPackages } from "../data/marketplace.json";
 import { contributors } from "../data/contributors";
+import { openSourceProjects } from "../data/open-source-projects";
 
 const totalSkills = plugins.reduce((sum, p) => sum + p.skills.length, 0);
 const totalContributorCommits = contributors.reduce((sum, contributor) => sum + contributor.commits, 0);
@@ -16,14 +17,14 @@ jq -e . pi-packages/<package>/package.json >/dev/null`;
 
 <PageLayout
   title="Community"
-  description="GitHub-first contribution workflow for the Agent Skills Marketplace: source, issues, PRs, guardrails, and support."
+  description="How Diversio Engineering collaborates in public: repos, issues, pull requests, guardrails, and support."
   currentNav="community"
 >
   <section class="page-section community-hero">
     <SectionHeader
       label="Community"
-      title="GitHub-first collaboration"
-      description={`The marketplace is maintained in the open: ${plugins.length} plugins, ${totalSkills} plugin skills, and ${piPackages.length} pi packages, all reviewed through standard GitHub issues and pull requests.`}
+      title="Contribute in public"
+      description={`Diversio Engineering builds these tools in the open: ${plugins.length} plugins, ${totalSkills} plugin skills, and ${piPackages.length} pi packages, all reviewed through standard GitHub issues and pull requests.`}
     />
     <div class="stats-grid">
       <div class="stat-card">
@@ -49,7 +50,7 @@ jq -e . pi-packages/<package>/package.json >/dev/null`;
     <SectionHeader
       label="Get Involved"
       title="Where the work happens"
-      description="There is no separate forum layer today. Use GitHub for bugs, proposals, reviews, and contribution docs."
+      description="Use GitHub for bugs, proposals, reviews, and contribution docs."
     />
     <div class="community-grid">
       <a href="https://github.com/DiversioTeam/agent-skills-marketplace" class="community-card" target="_blank" rel="noopener">
@@ -66,8 +67,7 @@ jq -e . pi-packages/<package>/package.json >/dev/null`;
         <span class="label-caps community-kicker">Issues</span>
         <h2 class="headline-sm">Bugs, proposals, and docs drift</h2>
         <p class="body-md community-copy">
-          Open issues when command behavior, install docs, or marketplace metadata drift
-          from the actual repo.
+          Open issues when command behavior, install docs, or repo metadata drift from the actual codebase.
         </p>
         <span class="label-caps community-link">View issues →</span>
       </a>
@@ -94,11 +94,30 @@ jq -e . pi-packages/<package>/package.json >/dev/null`;
     </div>
   </section>
 
+  <section class="page-section">
+    <SectionHeader
+      label="Open Source"
+      title="More from Diversio Engineering"
+      description="Beyond Agentic Tools, we maintain a few other open source repos worth exploring."
+    />
+    <div class="community-grid">
+      {openSourceProjects.map((project) => (
+        <a href={project.url} class="community-card" target="_blank" rel="noopener">
+          <span class="label-caps community-kicker">{project.category}</span>
+          <h2 class="headline-sm">{project.name}</h2>
+          <p class="body-md community-copy">{project.description}</p>
+          <span class="code-text-sm" style="color: var(--color-text-muted)">{project.repo}</span>
+          <span class="label-caps community-link">Open GitHub →</span>
+        </a>
+      ))}
+    </div>
+  </section>
+
   <section class="page-section contributors-section">
     <SectionHeader
       label="Contributors"
-      title="Humans behind the marketplace"
-      description={`${contributors.length} contributors in git history, excluding bots. Current history shows ${totalContributorCommits} total authored commits across the marketplace repository.`}
+      title="People behind the work"
+      description={`${contributors.length} contributors in git history, excluding bots. Current history shows ${totalContributorCommits} total authored commits across the Agentic Tools repository.`}
     />
     <div class="contributors-grid">
       {contributors.map((contributor) => (
@@ -128,7 +147,7 @@ jq -e . pi-packages/<package>/package.json >/dev/null`;
     <SectionHeader
       label="Workflow"
       title="How a good contribution moves"
-      description="The repo is configuration-only, so the bar is less about application runtime behavior and more about shape, sync, and guardrails."
+      description="This repo is configuration-heavy, so a strong contribution is mostly about shape, sync, and guardrails."
     />
     <div class="workflow-grid">
       <div class="workflow-step">
@@ -157,14 +176,14 @@ jq -e . pi-packages/<package>/package.json >/dev/null`;
   <section class="page-section quality-section">
     <SectionHeader
       label="Quality Gates"
-      title="What maintainers expect before review"
+      title="What to check before review"
       description="Most repeated failures in this repo are sync failures: versions, docs, wrappers, and package metadata drifting apart."
     />
     <div class="quality-grid">
       <FeatureList
         features={[
-          { label: "Version sync", description: "Plugin changes should update both the plugin manifest and the top-level marketplace manifest." },
-          { label: "Wrapper coverage", description: "Every changed marketplace skill should still have at least one command wrapper." },
+          { label: "Version sync", description: "Plugin changes should update both the plugin manifest and the top-level registry manifest in `.claude-plugin/marketplace.json`." },
+          { label: "Wrapper coverage", description: "Every changed Claude Code skill should still have at least one command wrapper." },
           { label: "Skill size budget", description: "Changed SKILL.md files stay at or below 500 lines." },
           { label: "Doc accuracy", description: "README, catalog, and distribution docs should stay aligned with install and invoke behavior." },
           { label: "Pi package checks", description: "When a pi package changes, validate its package.json and smoke-test command discovery." },
@@ -185,7 +204,7 @@ jq -e . pi-packages/<package>/package.json >/dev/null`;
         <span class="label-caps community-kicker">General Help</span>
         <h3 class="headline-sm">tech@diversio.com</h3>
         <p class="body-md community-copy">
-          Use email for maintainer contact when GitHub alone is not the right path.
+          Use email when GitHub alone is not the right path.
         </p>
       </div>
       <a href="/security" class="support-card support-card--link">

--- a/website/src/pages/community.astro
+++ b/website/src/pages/community.astro
@@ -6,6 +6,7 @@ import CodeBlock from "../components/CodeBlock.astro";
 import { plugins, piPackages } from "../data/marketplace.json";
 import { contributors } from "../data/contributors";
 import { openSourceProjects } from "../data/open-source-projects";
+import { siteConfig } from "../../site.config.mjs";
 
 const totalSkills = plugins.reduce((sum, p) => sum + p.skills.length, 0);
 const totalContributorCommits = contributors.reduce((sum, contributor) => sum + contributor.commits, 0);
@@ -13,6 +14,10 @@ const guardrailsCode = `bash scripts/validate-skills.sh
 jq -e . .claude-plugin/marketplace.json >/dev/null
 jq -e . plugins/<plugin>/.claude-plugin/plugin.json >/dev/null
 jq -e . pi-packages/<package>/package.json >/dev/null`;
+const repoUrl = siteConfig.githubUrl;
+const issuesUrl = `${repoUrl}/issues`;
+const pullsUrl = `${repoUrl}/pulls`;
+const contributingUrl = `${repoUrl}/blob/main/CONTRIBUTING.md`;
 ---
 
 <PageLayout
@@ -53,7 +58,7 @@ jq -e . pi-packages/<package>/package.json >/dev/null`;
       description="Use GitHub for bugs, proposals, reviews, and contribution docs."
     />
     <div class="community-grid">
-      <a href="https://github.com/DiversioTeam/agent-skills-marketplace" class="community-card" target="_blank" rel="noopener">
+      <a href={repoUrl} class="community-card" target="_blank" rel="noopener">
         <span class="label-caps community-kicker">Repository</span>
         <h2 class="headline-sm">Source, catalog, and release history</h2>
         <p class="body-md community-copy">
@@ -63,7 +68,7 @@ jq -e . pi-packages/<package>/package.json >/dev/null`;
         <span class="label-caps community-link">Open GitHub →</span>
       </a>
 
-      <a href="https://github.com/DiversioTeam/agent-skills-marketplace/issues" class="community-card" target="_blank" rel="noopener">
+      <a href={issuesUrl} class="community-card" target="_blank" rel="noopener">
         <span class="label-caps community-kicker">Issues</span>
         <h2 class="headline-sm">Bugs, proposals, and docs drift</h2>
         <p class="body-md community-copy">
@@ -72,7 +77,7 @@ jq -e . pi-packages/<package>/package.json >/dev/null`;
         <span class="label-caps community-link">View issues →</span>
       </a>
 
-      <a href="https://github.com/DiversioTeam/agent-skills-marketplace/pulls" class="community-card" target="_blank" rel="noopener">
+      <a href={pullsUrl} class="community-card" target="_blank" rel="noopener">
         <span class="label-caps community-kicker">Pull Requests</span>
         <h2 class="headline-sm">Reviewable changes only</h2>
         <p class="body-md community-copy">
@@ -82,7 +87,7 @@ jq -e . pi-packages/<package>/package.json >/dev/null`;
         <span class="label-caps community-link">Browse PRs →</span>
       </a>
 
-      <a href="https://github.com/DiversioTeam/agent-skills-marketplace/blob/main/CONTRIBUTING.md" class="community-card" target="_blank" rel="noopener">
+      <a href={contributingUrl} class="community-card" target="_blank" rel="noopener">
         <span class="label-caps community-kicker">Contributor Guide</span>
         <h2 class="headline-sm">The repo’s working agreement</h2>
         <p class="body-md community-copy">

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -5,6 +5,7 @@ import CodeBlock from "../../components/CodeBlock.astro";
 import FeatureList from "../../components/FeatureList.astro";
 import { plugins, piPackages } from "../../data/marketplace.json";
 import { skillDocs, piPackageDocs } from "../../data/site-docs";
+import { siteConfig } from "../../../site.config.mjs";
 
 const totalSkills = skillDocs.length;
 const marketplaceSkillCount = skillDocs.filter((skill) => skill.kind === "plugin-skill").length;
@@ -59,7 +60,7 @@ name: repo-docs-generator`;
 const piCode = `pi install git:github.com/DiversioTeam/agent-skills-marketplace
 /reload
 
-# skills-bridge makes marketplace skills available in Pi`;
+# skills-bridge makes plugin skills available in Pi`;
 
 const validationCode = `bash scripts/validate-skills.sh
 bash scripts/validate-skills.sh --all
@@ -87,24 +88,23 @@ open http://localhost:4321/pi`;
 
 <PageLayout
   title="Documentation"
-  description="Authoring, packaging, distribution, and validation guidance for the Agent Skills Marketplace."
+  description="Maintainer docs for Agentic Tools: authoring, packaging, distribution, and validation."
   currentNav="docs"
 >
   <section class="docs-hero">
     <SectionHeader
       label="Documentation"
-      title="Authoring and shipping marketplace artifacts"
-      description={`${plugins.length} plugins, ${marketplaceSkillCount} marketplace skills, ${piLocalSkillCount} Pi-local skills, and ${piPackages.length} pi packages. The homepage explains the ecosystem; this page focuses on the file layout, authoring rules, command wrappers, and release checks.`}
+      title="Build and maintain Agentic Tools"
+      description={`${plugins.length} plugins, ${marketplaceSkillCount} plugin skills, ${piLocalSkillCount} Pi-local skills, and ${piPackages.length} pi packages. This page focuses on repo structure, authoring rules, command wrappers, and release checks.`}
     />
     <div class="intro-card">
       <p class="body-md intro-copy">
-        Need the high-level overview first? Start on the
-        <a href="/">homepage</a>. Need a specific plugin or package? Jump to the
-        <a href="/registry">registry</a>. This page is the practical guide for editing
-        the repo itself.
+        Need the public overview first? Start on the
+        <a href={siteConfig.routes.tools}>{siteConfig.toolsSectionName} page</a>. Need a specific plugin or package? Jump to the
+        <a href="/registry">registry</a>. This page is the maintainer guide for working in the open-source repo.
       </p>
       <div class="intro-actions">
-        <a href="/" class="btn btn-secondary btn-md">Marketplace Overview</a>
+        <a href={siteConfig.routes.tools} class="btn btn-secondary btn-md">{siteConfig.toolsSectionName} Overview</a>
         <a href="/registry" class="btn btn-secondary btn-md">Browse Registry</a>
         <a
           href="https://github.com/DiversioTeam/agent-skills-marketplace/blob/main/CONTRIBUTING.md"
@@ -178,7 +178,7 @@ open http://localhost:4321/pi`;
         <SectionHeader
           label="Slash Commands"
           title="Wrappers are thin and namespaced"
-          description="Every Claude Code marketplace skill needs at least one wrapper in plugins/<plugin>/commands/. The wrapper provides command-specific context; the real behavior stays in the skill."
+          description="Every Claude Code skill needs at least one wrapper in plugins/<plugin>/commands/. The wrapper provides task-specific entrypoints; the real behavior stays in the skill."
         />
         <div class="split-grid">
           <CodeBlock lang="md" filename="plugins/monty-code-review/commands/code-review.md" code={wrapperCode} />
@@ -198,7 +198,7 @@ open http://localhost:4321/pi`;
         <SectionHeader
           label="Deep Docs"
           title="Browse by skill or Pi extension"
-          description={`Go deeper than plugin/package summaries: ${marketplaceSkillCount} marketplace skills, ${piLocalSkillCount} Pi-local skills, and ${piPackageDocs.length} Pi extension pages now have dedicated docs.`}
+          description={`Go deeper than bundle summaries: ${marketplaceSkillCount} plugin skills, ${piLocalSkillCount} Pi-local skills, and ${piPackageDocs.length} Pi extension pages now have dedicated docs.`}
         />
         <div class="runtime-grid">
           <div class="runtime-card">
@@ -233,8 +233,8 @@ open http://localhost:4321/pi`;
       <section class="doc-block" id="docs-pipeline">
         <SectionHeader
           label="Docs Pipeline"
-          title="Why the site now has skill and Pi extension pages"
-          description="First principles: the old plugin/package pages answered bundle-level questions, but they did not explain individual skills or Pi extension surfaces well enough. The newer routes read from the repo’s real docs instead of inventing a second website-only truth."
+          title="How docs become pages"
+          description="The high-level pages explain bundles, while the deeper routes explain individual skills and Pi extension surfaces. Those pages are generated from the repo’s real docs instead of a second website-only schema."
         />
         <div class="split-grid">
           <CodeBlock lang="text" filename="docs-pipeline.txt" code={docsPipelineCode} />
@@ -242,7 +242,7 @@ open http://localhost:4321/pi`;
             <ul class="section-list">
               <li><strong>One source of truth:</strong> skill behavior still lives in <code>SKILL.md</code>; Pi extension behavior still lives in each package README.</li>
               <li><strong>Website pages are extracted views:</strong> <code>src/data/site-docs.ts</code> turns those repo files into structured data for <code>/skills/*</code> and <code>/pi/*</code>.</li>
-              <li><strong>Why this matters:</strong> maintainers only need to update the repo docs they were already supposed to maintain, then rebuild the site.</li>
+              <li><strong>Why this matters:</strong> maintainers update the same repo docs they already own, then rebuild the site.</li>
               <li><strong>Keep it explainable:</strong> the extraction logic is deliberately conservative. If a page looks wrong, fix the source docs first, then teach the extractor the new pattern.</li>
             </ul>
             <div class="link-box">
@@ -260,7 +260,7 @@ open http://localhost:4321/pi`;
         <SectionHeader
           label="Distribution"
           title="How the same repo reaches three runtimes"
-          description="The marketplace ships the same underlying content through different installation surfaces for Claude Code, Codex, and Pi."
+          description="The same underlying content reaches Claude Code, Codex, and Pi through different installation surfaces."
         />
         <div class="runtime-grid">
           <div class="runtime-card">
@@ -269,8 +269,7 @@ open http://localhost:4321/pi`;
               <span class="code-text-sm">plugin bundle</span>
             </div>
             <p class="body-md runtime-copy">
-              Install a plugin from the marketplace, then invoke its namespaced slash
-              commands.
+              Install a plugin, then invoke its namespaced slash commands inside Claude Code.
             </p>
             <CodeBlock lang="bash" code={claudeCode} />
           </div>
@@ -292,7 +291,7 @@ open http://localhost:4321/pi`;
             </div>
             <p class="body-md runtime-copy">
               Pi packages extend the harness directly. The <code>skills-bridge</code>
-              package auto-discovers marketplace skills and exposes them inside Pi.
+              package auto-discovers plugin skills and exposes them inside Pi.
               See <a href="https://pi.dev">pi.dev</a> for the Pi project.
             </p>
             <CodeBlock lang="bash" code={piCode} />
@@ -304,7 +303,7 @@ open http://localhost:4321/pi`;
         <SectionHeader
           label="Validation"
           title="Run the guardrails before opening a PR"
-          description="Docs-only changes do not currently trigger every marketplace workflow, so run the matching local checks when you touch shared instructions or metadata."
+          description="Some docs-only changes do not trigger every workflow, so run the matching local checks when you touch shared instructions or metadata."
         />
         <div class="split-grid split-grid--reverse">
           <CodeBlock lang="bash" code={validationCode} />
@@ -323,8 +322,8 @@ open http://localhost:4321/pi`;
       <section class="doc-block" id="contribute">
         <SectionHeader
           label="Contribute"
-          title="Add a skill safely"
-          description="The happy path is still markdown-first: skill, wrapper, manifest sync, validation, PR."
+          title="Contribute safely"
+          description="Recommended flow: skill, wrapper, manifest sync, validation, PR."
         />
         <FeatureList
           features={[

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,255 +1,288 @@
 ---
+// Homepage for the broader Diversio Engineering hub.
+//
+// Why this page exists:
+// - `/` should now explain the whole engineering site, not just the tools repo
+// - the tools catalog moved to `/agentic-tools`
+// - the homepage should help visitors choose between tools, writing, and community
+//
+// Keep this page high-level.
+// Detailed install flows, package docs, and skill docs belong deeper in the site.
+import { getCollection } from "astro:content";
 import PageLayout from "../layouts/PageLayout.astro";
-import Hero from "../components/Hero.astro";
 import SectionHeader from "../components/SectionHeader.astro";
 import Card from "../components/Card.astro";
 import CardGrid from "../components/CardGrid.astro";
-import CodeBlock from "../components/CodeBlock.astro";
-import RuntimeCodeTabs from "../components/RuntimeCodeTabs.astro";
 import { plugins, piPackages } from "../data/marketplace.json";
+import { contributors } from "../data/contributors";
+import { openSourceProjects } from "../data/open-source-projects";
+import { siteConfig } from "../../site.config.mjs";
 
-const featured = plugins.filter((p) =>
-  ["monty-code-review", "backend-atomic-commit", "backend-release",
-   "visual-explainer", "plan-directory", "clickup-ticket"].includes(p.name)
+const featuredTools = plugins.filter((p) =>
+  ["monty-code-review", "backend-atomic-commit", "visual-explainer"].includes(p.name)
 );
 const totalSkills = plugins.reduce((sum, p) => sum + p.skills.length, 0);
-const categories = [...new Set(plugins.map((p) => p.category))];
-
-// Code strings computed in frontmatter to avoid template literal escaping issues
-const claudePluginInstallCode = `claude plugin marketplace add DiversioTeam/agent-skills-marketplace
-claude plugin install monty-code-review@diversiotech`;
-
-const codexPluginInstallCode = `CODEX_HOME="\${CODEX_HOME:-$HOME/.codex}"
-python3 "$CODEX_HOME/skills/.system/skill-installer/scripts/install-skill-from-github.py" \\
-  --repo DiversioTeam/agent-skills-marketplace \\
-  --path plugins/monty-code-review/skills/monty-code-review`;
-
-const claudeInvokeCode = `/monty-code-review:code-review
-/backend-atomic-commit:commit`;
-
-const codexInvokeCode = `name: monty-code-review
-name: backend-atomic-commit`;
+const publishedPosts = (await getCollection("blog"))
+  .filter((post) => !post.data.draft)
+  .sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime());
+const hasReposts = publishedPosts.some((post) => post.data.sourceType === "repost");
+const contributorCount = contributors.length;
 ---
 
 <PageLayout
-  title="Agent Skills Marketplace"
-  description={`A configuration-only registry of reusable agent skills. ${plugins.length} plugins, ${piPackages.length} pi packages, ${totalSkills} skills. Portable across Claude Code, Codex, and Pi.`}
+  title={siteConfig.siteName}
+  description={siteConfig.defaultDescription}
+  currentNav="home"
 >
-  <Hero />
-
-  <!-- What is this? -->
-  <section class="page-section">
-    <SectionHeader
-      label="The Marketplace"
-      title="Skills, Plugins, and Pi Packages"
-      description="Three layers. Each with a distinct role in the agent ecosystem."
-    />
-    <div class="layers-grid">
-      <div class="layer-card layer-skills">
-        <div class="layer-card-header">
-          <span class="label-caps">Layer 1</span>
-          <span class="code-text-sm" style="color: var(--color-text-muted)">{totalSkills} skills</span>
+  <section class="home-hero">
+    <div class="home-hero-grid">
+      <div class="home-hero-copy">
+        <div class="home-brand-row">
+          <img
+            src="/diversio-logo.svg"
+            alt="Diversio"
+            class="home-brand-logo"
+            width="116"
+            height="20"
+          />
+          <span class="label-caps home-brand-note">Engineering</span>
         </div>
-        <div class="layer-card-body">
-          <h3 class="headline-sm">Skills</h3>
-          <p class="body-md">The atomic unit. Each skill is a single <code>SKILL.md</code> — a Markdown file with YAML frontmatter. No compiled code, no runtime. Teaches an agent how to do one specific task well.</p>
-          <div class="layer-example">
-            <CodeBlock
-              lang="yaml"
-              filename="monty-code-review/SKILL.md"
-              code={`---
-name: monty-code-review
-description: >-
-  Hyper-pedantic Django code review with
-  correctness-first, multi-tenant-safe,
-  harness-aware review style.
----`}
-            />
-          </div>
+        <h1 class="home-title">{siteConfig.siteName}</h1>
+        <p class="body-lg home-desc">
+          Open tools, deep docs, and engineering writing from Diversio. Explore {siteConfig.toolsSectionName.toLowerCase()}, dive into implementation details, and follow new writing as the site grows.
+        </p>
+        <div class="home-actions">
+          <a href={siteConfig.routes.tools} class="btn btn-primary btn-md">Explore {siteConfig.toolsSectionName}</a>
+          <a href={siteConfig.routes.blog} class="btn btn-secondary btn-md">Visit the Blog</a>
+          <a href={siteConfig.githubUrl} class="btn btn-ghost btn-md" target="_blank" rel="noopener">GitHub</a>
         </div>
       </div>
 
-      <div class="layer-card layer-plugins">
-        <div class="layer-card-header">
-          <span class="label-caps">Layer 2</span>
-          <span class="code-text-sm" style="color: var(--color-text-muted)">{plugins.length} plugins</span>
+      <div class="home-summary-card">
+        <div class="summary-header">
+          <span class="label-caps">At a glance</span>
+          <span class="code-text-sm summary-id">OVERVIEW</span>
         </div>
-        <div class="layer-card-body">
-          <h3 class="headline-sm">Plugins</h3>
-          <p class="body-md">The distribution bundle. Each plugin packages one or more related skills with slash-command wrappers. Installed via <code>claude plugin install &lt;name&gt;@diversiotech</code> in Claude Code. Codex users install individual skill directories from the repo.</p>
-          <div class="layer-example">
-            <RuntimeCodeTabs
-              tabs={[
-                { label: "Claude Code", code: claudePluginInstallCode },
-                { label: "Codex", code: codexPluginInstallCode },
-              ]}
-            />
+        <div class="summary-grid">
+          <div class="summary-stat">
+            <span class="summary-stat-num">{plugins.length}</span>
+            <span class="label-caps summary-stat-label">Plugins</span>
+          </div>
+          <div class="summary-stat">
+            <span class="summary-stat-num">{piPackages.length}</span>
+            <span class="label-caps summary-stat-label">Pi Packages</span>
+          </div>
+          <div class="summary-stat">
+            <span class="summary-stat-num">{totalSkills}</span>
+            <span class="label-caps summary-stat-label">Skills</span>
+          </div>
+          <div class="summary-stat">
+            <span class="summary-stat-num">{publishedPosts.length}</span>
+            <span class="label-caps summary-stat-label">Blog Posts</span>
           </div>
         </div>
-      </div>
-
-      <div class="layer-card layer-pi">
-        <div class="layer-card-header">
-          <span class="label-caps">Layer 3</span>
-          <span class="code-text-sm" style="color: var(--color-text-muted)">{piPackages.length} packages</span>
-        </div>
-        <div class="layer-card-body">
-          <h3 class="headline-sm">Pi Packages</h3>
-          <p class="body-md">Extensions for the <a href="https://pi.dev">Pi</a> coding agent harness. Not skills — these are code packages that add tools, TUI widgets, notifications, and runtime behavior to Pi itself. The Skills Bridge package auto-discovers plugin skills and registers them as Pi skills.</p>
-          <div class="layer-example">
-            <CodeBlock
-              lang="bash"
-              code={`pi install git:github.com/DiversioTeam/agent-skills-marketplace
-# installs all pi packages at once:
-# dev-workflow, skills-bridge, ci-status, oh-my-pi, image-router`}
-            />
-          </div>
+        <div class="summary-note body-md">
+          Open tools, Pi extensions, and engineering writing in one place.
         </div>
       </div>
     </div>
   </section>
 
-  <!-- Featured plugins -->
+  <section class="page-section">
+    <SectionHeader
+      label="Sections"
+      title="Explore the site"
+      description="From open tools and Pi extensions to engineering writing and community, this hub brings together the main public surfaces from Diversio Engineering."
+    />
+    <div class="section-grid">
+      <article class="section-card">
+        <div class="section-card-header">
+          <span class="label-caps">01</span>
+          <span class="code-text-sm">{plugins.length} plugins · {totalSkills} skills</span>
+        </div>
+        <h3 class="headline-sm">{siteConfig.toolsSectionName}</h3>
+        <p class="body-md">
+          Browse the registry, read deep docs, and find runtime-specific guides for Claude Code, Codex, and Pi.
+        </p>
+        <div class="section-card-actions">
+          <a href={siteConfig.routes.tools} class="btn btn-secondary btn-md">Open {siteConfig.toolsSectionName}</a>
+          <a href={siteConfig.routes.registry} class="text-link">Registry →</a>
+        </div>
+      </article>
+
+      <article class="section-card">
+        <div class="section-card-header">
+          <span class="label-caps">02</span>
+          <span class="code-text-sm">{publishedPosts.length} post{publishedPosts.length === 1 ? "" : "s"} live · curated reposts {hasReposts ? "live" : "coming soon"}</span>
+        </div>
+        <h3 class="headline-sm">Engineering blog</h3>
+        <p class="body-md">
+          Read original posts from Diversio Engineering today. Curated reposts are marked <span class="status-chip">Coming soon</span> until the first syndicated entry lands.
+        </p>
+        <div class="section-card-actions">
+          <a href={siteConfig.routes.blog} class="btn btn-secondary btn-md">Browse the Blog</a>
+        </div>
+      </article>
+
+      <article class="section-card">
+        <div class="section-card-header">
+          <span class="label-caps">03</span>
+          <span class="code-text-sm">{contributorCount} contributors</span>
+        </div>
+        <h3 class="headline-sm">Open collaboration</h3>
+        <p class="body-md">
+          Follow the repos, contribution guides, and review workflows that keep Diversio Engineering projects open and maintainable.
+        </p>
+        <div class="section-card-actions">
+          <a href={siteConfig.routes.community} class="btn btn-secondary btn-md">Community</a>
+        </div>
+      </article>
+    </div>
+  </section>
+
   <section class="page-section">
     <div class="catalog-header">
       <SectionHeader
-        label="Registry"
-        title="Featured Plugins"
-        description={`${plugins.length} plugins across ${categories.join(", ")}.`}
+        label={siteConfig.toolsSectionName}
+        title="Featured tools"
+        description="A few representative projects from the broader Agentic Tools registry."
       />
-      <a href="/registry" class="catalog-view-all label-caps">View all {plugins.length} →</a>
+      <a href={siteConfig.routes.registry} class="catalog-view-all label-caps">View full registry →</a>
     </div>
     <CardGrid cols={3}>
-      {featured.map((p) => (
+      {featuredTools.map((tool) => (
         <Card
-          category={p.category}
-          packageId={p.name}
-          title={p.title}
-          description={p.description}
-          version={p.version}
+          category={tool.category}
+          packageId={tool.name}
+          title={tool.title}
+          description={tool.description}
+          version={tool.version}
           runtimes={["CC", "CODEX"]}
-          href={`/docs/${p.name}`}
+          href={`/docs/${tool.name}`}
         />
       ))}
     </CardGrid>
   </section>
 
-  <!-- Pi packages -->
-  <section class="page-section">
+  <section class="page-section page-section--top-border">
     <SectionHeader
-      label="Pi Packages"
-      title="Pi-Native Extensions"
-      description={`${piPackages.length} packages that extend the Pi agent harness.`}
+      label="Open Source"
+      title="Other open source projects"
+      description="A few more repos from Diversio Engineering beyond the Agentic Tools registry."
     />
-    <CardGrid cols={3}>
-      {piPackages.map((p) => (
-        <Card
-          category="Pi Package"
-          packageId={p.name}
-          title={p.title}
-          description={p.description}
-          version={p.version}
-          href={`/pi/${p.name}`}
-        />
+    <div class="project-grid">
+      {openSourceProjects.map((project) => (
+        <a href={project.url} class="project-card" target="_blank" rel="noopener">
+          <div class="project-card-header">
+            <span class="label-caps project-category">{project.category}</span>
+            <span class="code-text-sm project-repo">{project.repo}</span>
+          </div>
+          <div class="project-card-body">
+            <h3 class="headline-sm project-title">{project.name}</h3>
+            <p class="body-md project-copy">{project.description}</p>
+            <span class="label-caps project-link">Open on GitHub →</span>
+          </div>
+        </a>
       ))}
-    </CardGrid>
-  </section>
-
-  <!-- Quickstart -->
-  <section class="page-section">
-    <SectionHeader
-      label="Quickstart"
-      title="Install. Invoke. Ship."
-      description="Get a skill into your agent in under a minute."
-    />
-    <div class="quickstart-grid">
-      <div class="quickstart-step">
-        <span class="quickstart-num code-text">01</span>
-        <h3 class="headline-sm">Install the marketplace</h3>
-        <p class="body-md">Pick your runtime, then copy the install command that matches it.</p>
-        <RuntimeCodeTabs
-          tabs={[
-            { label: "Claude Code", code: claudePluginInstallCode },
-            { label: "Codex", code: codexPluginInstallCode },
-          ]}
-        />
-      </div>
-      <div class="quickstart-step">
-        <span class="quickstart-num code-text">02</span>
-        <h3 class="headline-sm">Invoke a skill</h3>
-        <p class="body-md">Switch between Claude Code and Codex so copy-to-clipboard gives you the right invocation.</p>
-        <RuntimeCodeTabs
-          tabs={[
-            { label: "Claude Code", code: claudeInvokeCode },
-            { label: "Codex", code: codexInvokeCode },
-          ]}
-        />
-      </div>
-      <div class="quickstart-step">
-        <span class="quickstart-num code-text">03</span>
-        <h3 class="headline-sm">Ship with confidence</h3>
-        <p class="body-md">Skills enforce repo-local conventions and pre-commit hooks. CI validates every change.</p>
-        <CodeBlock lang="bash" code={"/backend-pr-workflow:check-pr\n# branch → migration safety → PR hygiene"} />
-      </div>
-    </div>
-  </section>
-
-  <!-- Footer CTA -->
-  <section class="page-section contribute-section">
-    <div class="contribute-card">
-      <h2 class="headline-md contribute-title">Built on the Agent Skills Standard</h2>
-      <p class="body-lg contribute-desc">
-        This marketplace follows the{" "}
-        <a href="https://agentskills.io/specification">Agent Skills standard</a>{" "}
-        — an open, tool-agnostic format. Every skill is a directory with a required{" "}
-        <code>SKILL.md</code>, optional <code>references/</code>, <code>scripts/</code>, and{" "}
-        <code>assets/</code>. Portable across Claude Code, Codex, and Pi.
-      </p>
-      <div class="contribute-actions">
-        <a href="https://github.com/DiversioTeam/agent-skills-marketplace" class="btn btn-primary btn-md" target="_blank" rel="noopener">
-          View on GitHub
-        </a>
-        <a href="/docs" class="btn btn-secondary btn-md">
-          Read the Docs
-        </a>
-      </div>
     </div>
   </section>
 </PageLayout>
 
 <style>
+  .home-hero,
   .page-section {
     max-width: var(--max-width);
     margin: 0 auto;
     padding: var(--space-3xl) var(--space-margin);
   }
+
   .page-section + .page-section {
     border-top: var(--border-hairline);
   }
 
-  /* Three layers */
-  .layers-grid {
+  .home-hero {
+    position: relative;
+  }
+
+  .home-hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image:
+      linear-gradient(to right, var(--grid-pattern-color) 1px, transparent 1px),
+      linear-gradient(to bottom, var(--grid-pattern-color) 1px, transparent 1px);
+    background-size: var(--grid-pattern-size) var(--grid-pattern-size);
+    pointer-events: none;
+    opacity: 0.5;
+    z-index: 0;
+  }
+
+  .home-hero-grid {
+    position: relative;
+    z-index: 1;
     display: grid;
     grid-template-columns: 1fr;
     gap: var(--space-xl);
   }
-  @media (min-width: 1024px) {
-    .layers-grid {
-      grid-template-columns: repeat(3, 1fr);
+
+  @media (min-width: 1100px) {
+    .home-hero-grid {
+      grid-template-columns: 3fr 2fr;
+      align-items: start;
     }
   }
 
-  .layer-card {
-    background: var(--color-surface);
-    border: var(--border-hairline);
+  .home-hero-copy {
     display: flex;
     flex-direction: column;
+    gap: var(--space-md);
   }
-  .layer-skills { border-top: 3px solid var(--color-primary); }
-  .layer-plugins { border-top: 3px solid var(--color-primary); }
-  .layer-pi { border-top: 3px solid var(--color-accent); }
 
-  .layer-card-header {
+  .home-brand-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+  }
+
+  .home-brand-logo {
+    display: block;
+    width: auto;
+    height: 1.125rem;
+  }
+
+  .home-brand-note {
+    color: var(--color-primary);
+  }
+
+  .home-title {
+    font-family: var(--font-headline);
+    font-size: var(--text-headline-xl);
+    font-weight: var(--weight-bold);
+    line-height: var(--leading-headline);
+    letter-spacing: var(--tracking-headline);
+    color: var(--color-text);
+  }
+
+  .home-desc {
+    color: var(--color-text-secondary);
+    max-width: 42rem;
+  }
+
+  .home-actions {
+    display: flex;
+    gap: var(--space-sm);
+    flex-wrap: wrap;
+  }
+
+  .home-summary-card {
+    background: var(--color-surface);
+    border: var(--border-hairline);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-block);
+    overflow: hidden;
+  }
+
+  .summary-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -257,81 +290,81 @@ description: >-
     background: var(--color-surface-low);
     border-bottom: var(--border-hairline);
   }
-  .layer-card-body {
+
+  .summary-id {
+    color: var(--color-text-muted);
+  }
+
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-sm);
     padding: var(--space-lg);
+  }
+
+  .summary-stat {
+    border: var(--border-hairline);
+    border-radius: var(--radius-md);
+    padding: var(--space-md);
+    background: var(--color-surface-low);
     display: flex;
     flex-direction: column;
-    gap: var(--space-sm);
+    gap: var(--space-2xs);
   }
-  .layer-card-body h3 { margin: 0; }
-  .layer-card-body p { color: var(--color-text-secondary); margin: 0; }
-  .layer-card-body code {
-    font-family: var(--font-code);
-    font-size: var(--text-code-sm);
-    background: var(--color-surface-low);
-    padding: 1px 5px;
-    border-radius: var(--radius-sm);
-    color: var(--color-primary);
-  }
-  .layer-example { margin-top: var(--space-sm); }
-  .layer-example .code-block { margin-bottom: 0; }
 
-  /* Catalog */
-  .catalog-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-end;
-    margin-bottom: var(--space-xl);
-    flex-wrap: wrap;
-    gap: var(--space-md);
-  }
-  .catalog-view-all {
+  .summary-stat-num {
+    font-family: var(--font-headline);
+    font-size: var(--text-headline-lg);
     color: var(--color-primary);
-    text-decoration: none;
-    white-space: nowrap;
+    line-height: 1;
   }
-  .catalog-view-all:hover { text-decoration: underline; }
 
-  /* Quickstart */
-  .quickstart-grid {
+  .summary-stat-label {
+    color: var(--color-text-secondary);
+  }
+
+  .summary-note {
+    color: var(--color-text-secondary);
+    padding: 0 var(--space-lg) var(--space-lg);
+  }
+
+  .section-grid {
     display: grid;
     grid-template-columns: 1fr;
     gap: var(--space-xl);
   }
-  @media (min-width: 768px) {
-    .quickstart-grid { grid-template-columns: repeat(3, 1fr); }
+
+  @media (min-width: 960px) {
+    .section-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
   }
-  .quickstart-step {
+
+  .section-card {
+    background: var(--color-surface);
+    border: var(--border-hairline);
+    border-radius: var(--radius-md);
+    padding: var(--space-lg);
+    box-shadow: var(--shadow-block-sm);
     display: flex;
     flex-direction: column;
     gap: var(--space-sm);
   }
-  .quickstart-num {
-    font-size: var(--text-headline-lg);
-    font-weight: 700;
-    color: var(--color-primary-container);
-    line-height: 1;
-  }
-  .quickstart-step p { color: var(--color-text-secondary); }
-  .quickstart-step .code-block { margin-top: auto; }
 
-  /* Contribute */
-  .contribute-section { border-top: var(--border-hairline); }
-  .contribute-card {
-    background: var(--color-surface);
-    border: var(--border-hairline);
-    border-radius: var(--radius-md);
-    padding: var(--space-2xl);
-    box-shadow: var(--shadow-block);
-    text-align: center;
+  .section-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-sm);
+    color: var(--color-text-muted);
   }
-  .contribute-title { margin-bottom: var(--space-md); }
-  .contribute-desc {
+
+  .section-card p {
     color: var(--color-text-secondary);
-    max-width: 36rem;
-    margin: 0 auto var(--space-xl);
+    margin: 0;
   }
-  .contribute-desc code {
+
+  .section-card code {
     font-family: var(--font-code);
     font-size: var(--text-code-sm);
     background: var(--color-surface-low);
@@ -339,14 +372,123 @@ description: >-
     border-radius: var(--radius-sm);
     color: var(--color-primary);
   }
-  .contribute-actions {
+
+  .section-card-actions {
     display: flex;
-    justify-content: center;
-    gap: var(--space-sm);
     flex-wrap: wrap;
+    gap: var(--space-sm);
+    align-items: center;
+    margin-top: auto;
+  }
+
+  .text-link,
+  .catalog-view-all {
+    color: var(--color-primary);
+    text-decoration: none;
+  }
+
+  .text-link:hover,
+  .catalog-view-all:hover {
+    text-decoration: underline;
+  }
+
+  .status-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.1875rem 0.5rem;
+    border: var(--border-hairline);
+    border-radius: 999px;
+    background: var(--color-surface-low);
+    color: var(--color-text-secondary);
+    font-family: var(--font-code);
+    font-size: var(--text-code-sm);
+    white-space: nowrap;
+  }
+
+  .catalog-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: var(--space-md);
+    flex-wrap: wrap;
+    margin-bottom: var(--space-xl);
+  }
+
+  .page-section--top-border {
+    border-top: var(--border-hairline);
+  }
+
+  .project-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-xl);
+  }
+
+  @media (min-width: 960px) {
+    .project-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  .project-card {
+    background: var(--color-surface);
+    border: var(--border-hairline);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-block-sm);
+    text-decoration: none;
+    transition: border-color var(--transition-fast);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .project-card:hover,
+  .project-card:focus-visible {
+    border-color: var(--color-primary);
+  }
+
+  .project-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-xs) var(--space-md);
+    background: var(--color-surface-low);
+    border-bottom: var(--border-hairline);
+  }
+
+  .project-category {
+    color: var(--color-text-secondary);
+  }
+
+  .project-repo {
+    color: var(--color-text-muted);
+  }
+
+  .project-card-body {
+    padding: var(--space-lg);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    height: 100%;
+  }
+
+  .project-title {
+    color: var(--color-text);
+  }
+
+  .project-copy {
+    color: var(--color-text-secondary);
+  }
+
+  .project-link {
+    color: var(--color-primary);
+    margin-top: auto;
   }
 
   @media (max-width: 640px) {
+    .home-hero,
     .page-section {
       padding: var(--space-2xl) var(--space-md);
     }

--- a/website/src/pages/pi/[package].astro
+++ b/website/src/pages/pi/[package].astro
@@ -57,7 +57,7 @@ const sidebarItems = [
     <h2 class="headline-md doc-heading">Overview</h2>
     <p>{pkg.description}</p>
     <p>
-      Package docs also remain available on the marketplace package page at <a href={pkg.packageDocHref}>{pkg.packageDocHref}</a>, but this page focuses on the Pi-native extension surface: commands, tools, environment variables, packaged skills, and extension files.
+      Package docs also remain available on the package summary page at <a href={pkg.packageDocHref}>{pkg.packageDocHref}</a>, but this page focuses on the Pi-native extension surface: commands, tools, environment variables, packaged skills, and extension files.
     </p>
   </section>
 

--- a/website/src/pages/pi/index.astro
+++ b/website/src/pages/pi/index.astro
@@ -4,11 +4,12 @@ import SectionHeader from "../../components/SectionHeader.astro";
 import Card from "../../components/Card.astro";
 import CardGrid from "../../components/CardGrid.astro";
 import { piPackageDocs } from "../../data/site-docs";
+import { siteConfig } from "../../../site.config.mjs";
 ---
 
 <PageLayout
   title="Pi Extensions"
-  description={`Browse ${piPackageDocs.length} Pi package and extension docs in the Agent Skills Marketplace.`}
+  description={`Browse ${piPackageDocs.length} Pi package and extension docs in Diversio ${siteConfig.toolsSectionName}.`}
   currentNav="docs"
 >
   <section class="page-section page-hero">

--- a/website/src/pages/registry.astro
+++ b/website/src/pages/registry.astro
@@ -5,22 +5,23 @@ import Card from "../components/Card.astro";
 import CardGrid from "../components/CardGrid.astro";
 import { plugins, piPackages } from "../data/marketplace.json";
 import { skillDocs, piPackageDocs } from "../data/site-docs";
+import { siteConfig } from "../../site.config.mjs";
 
 const categories = [...new Set(plugins.map((p) => p.category))];
-const marketplaceSkills = skillDocs.filter((skill) => skill.kind === "plugin-skill");
+const pluginSkills = skillDocs.filter((skill) => skill.kind === "plugin-skill");
 const piLocalSkills = skillDocs.filter((skill) => skill.kind === "pi-skill");
 ---
 
 <PageLayout
   title="Registry"
-  description={`Browse all ${plugins.length} plugins and ${piPackages.length} pi packages in the Diversio Agent Skills Marketplace.`}
-  currentNav="registry"
+  description={`Browse all ${plugins.length} plugins and ${piPackages.length} pi packages in Diversio ${siteConfig.toolsSectionName}.`}
+  currentNav="tools"
 >
   <section class="page-section registry-hero">
     <SectionHeader
       label="Registry"
       title="Package Registry"
-      description={`${plugins.length} plugins across ${categories.length} categories, ${marketplaceSkills.length} marketplace skill pages, and ${piPackageDocs.length} Pi extension pages. Every entry links to deeper docs.`}
+      description={`${plugins.length} plugins across ${categories.length} categories, ${pluginSkills.length} plugin skill pages, and ${piPackageDocs.length} Pi extension pages. Every entry links to deeper docs.`}
     />
   </section>
 
@@ -33,8 +34,8 @@ const piLocalSkills = skillDocs.filter((skill) => skill.kind === "pi-skill");
       <Card
         category="Skills"
         packageId="/skills"
-        title="Marketplace Skill Docs"
-        description={`Browse ${marketplaceSkills.length} individual marketplace skills, including wrapper commands, references, scripts, and runtime-specific install/invoke guidance.`}
+        title="Plugin Skill Docs"
+        description={`Browse ${pluginSkills.length} individual plugin skills, including wrapper commands, references, scripts, and runtime-specific install and invoke guidance.`}
         href="/skills"
       />
       <Card

--- a/website/src/pages/security.astro
+++ b/website/src/pages/security.astro
@@ -3,21 +3,22 @@
 import PageLayout from "../layouts/PageLayout.astro";
 import SectionHeader from "../components/SectionHeader.astro";
 import FeatureList from "../components/FeatureList.astro";
+import { siteConfig } from "../../site.config.mjs";
 ---
 
 <PageLayout
   title="Security"
-  description="Security policy for the Agent Skills Marketplace website, including markdown skills and installable Pi package extensions."
+  description={`Security guidance for ${siteConfig.siteName}, including markdown skills, Pi package extensions, and published docs.`}
 >
   <section class="page-section">
     <SectionHeader
       label="Security"
       title="Security Policy"
-      description="This site documents two different artifact types: markdown skills and Pi packages that may include installable TypeScript extensions. Review both the docs and the source before installing anything into an agent harness."
+      description="This site links to two main artifact types: markdown skills and Pi packages that may include installable TypeScript extensions. Review both the docs and the source before installing anything into an agent harness."
     />
     <FeatureList
       features={[
-        { label: "Markdown-first skills", description: "Claude Code marketplace skills are primarily markdown instruction files. The harness executes tools, not the markdown itself." },
+        { label: "Markdown-first skills", description: "Claude Code skills are primarily markdown instruction files. The harness executes tools, not the markdown itself." },
         { label: "Pi packages can ship code", description: "Pi packages may include TypeScript extensions under pi-packages/**/extensions/. Treat those like installable source code, not like passive docs." },
         { label: "Build and manifest validation", description: "CI validates manifests, package structure, and website builds so broken metadata and obvious shape problems are caught before merge." },
         { label: "Inspectable source", description: "Published skills, package READMEs, and extension files live in this repository so engineers can inspect what they are installing." },

--- a/website/src/pages/skills/index.astro
+++ b/website/src/pages/skills/index.astro
@@ -4,31 +4,32 @@ import SectionHeader from "../../components/SectionHeader.astro";
 import Card from "../../components/Card.astro";
 import CardGrid from "../../components/CardGrid.astro";
 import { skillDocs } from "../../data/site-docs";
+import { siteConfig } from "../../../site.config.mjs";
 
-const marketplaceSkills = skillDocs.filter((skill) => skill.kind === "plugin-skill");
+const pluginSkills = skillDocs.filter((skill) => skill.kind === "plugin-skill");
 const piLocalSkills = skillDocs.filter((skill) => skill.kind === "pi-skill");
 ---
 
 <PageLayout
   title="Skills"
-  description={`Browse ${skillDocs.length} individual skill docs across marketplace plugins and Pi-local packages.`}
+  description={`Browse ${skillDocs.length} individual skill docs across Diversio ${siteConfig.toolsSectionName} plugins and Pi-local packages.`}
   currentNav="docs"
 >
   <section class="page-section page-hero">
     <SectionHeader
       label="Skills"
       title="Individual skill docs"
-      description={`${marketplaceSkills.length} marketplace skills and ${piLocalSkills.length} Pi-local skills. Each page documents the skill itself instead of only the parent plugin or package.`}
+      description={`${pluginSkills.length} plugin skills and ${piLocalSkills.length} Pi-local skills. Each page documents the skill itself instead of only the parent plugin or package.`}
     />
   </section>
 
   <section class="page-section">
     <div class="category-header">
-      <h2 class="headline-md">Marketplace Skills</h2>
-      <span class="code-text-sm meta-text">{marketplaceSkills.length} skills</span>
+      <h2 class="headline-md">Plugin Skills</h2>
+      <span class="code-text-sm meta-text">{pluginSkills.length} skills</span>
     </div>
     <CardGrid cols={3}>
-      {marketplaceSkills.map((skill) => (
+      {pluginSkills.map((skill) => (
         <Card
           category={skill.packageCategory}
           packageId={skill.name}

--- a/website/src/pages/terms.astro
+++ b/website/src/pages/terms.astro
@@ -2,27 +2,28 @@
 // terms.astro — Terms page
 import PageLayout from "../layouts/PageLayout.astro";
 import SectionHeader from "../components/SectionHeader.astro";
+import { siteConfig } from "../../site.config.mjs";
 ---
 
 <PageLayout
   title="Terms"
-  description="Terms of use for the Agent Skills Marketplace."
+  description={`Terms of use for ${siteConfig.siteName} and its open-source tools and docs.`}
 >
   <section class="page-section">
     <SectionHeader
       label="Legal"
       title="Terms of Use"
-      description="The Agent Skills Marketplace is an open-source, configuration-only registry. Skills are provided as-is under their respective licenses (typically MIT)."
+      description={`${siteConfig.siteName} includes open-source tools and documentation. Published skills are provided as-is under their respective licenses, typically MIT.`}
     />
     <div class="prose">
       <p class="body-lg" style="color: var(--color-text-secondary)">
-        By using the Agent Skills Marketplace, you agree that:
+        By using {siteConfig.siteName}, you agree that:
       </p>
       <ul class="body-md" style="color: var(--color-text-secondary); margin-top: var(--space-md); padding-left: var(--space-lg); display: flex; flex-direction: column; gap: var(--space-sm);">
-        <li>Skills are provided for informational and instructional purposes. The agent harness owner is responsible for validating skill behavior before deployment.</li>
-        <li>The marketplace and its maintainers are not liable for any damages arising from the use of marketplace skills.</li>
-        <li>Skills may be updated, deprecated, or removed at any time. Consumers should pin version references in production.</li>
-        <li>Contributions to the marketplace are licensed under the project's open-source license (MIT).</li>
+        <li>Published skills and docs are provided for informational and instructional purposes. The operator of any agent harness is responsible for validating behavior before deployment.</li>
+        <li>The tools section and its maintainers are not liable for damages arising from the use of published skills or extensions.</li>
+        <li>Skills, docs, and extensions may be updated, deprecated, or removed at any time. Production consumers should pin versions where appropriate.</li>
+        <li>Contributions to the repository are licensed under the project's open-source license (MIT).</li>
       </ul>
       <p class="body-md" style="color: var(--color-text-secondary); margin-top: var(--space-xl)">
         For questions, contact <a href="mailto:tech@diversio.com">tech@diversio.com</a>.

--- a/website/src/utils/format-date.ts
+++ b/website/src/utils/format-date.ts
@@ -1,0 +1,27 @@
+// Stable date formatting for editorial content.
+//
+// Why this helper exists:
+// - blog posts currently use date-only frontmatter values like `2026-05-03`
+// - those values become `Date` objects at UTC midnight
+// - formatting them in the build machine's local timezone can shift the visible
+//   calendar day backward or forward
+//
+// Example of the problem:
+//   2026-05-03 (stored as UTC midnight)
+//     -> formatted in a negative timezone
+//     -> can appear as May 2 instead of May 3
+//
+// Fix:
+// - always format editorial publish dates in UTC
+// - that keeps the rendered date stable locally, in CI, and on Cloudflare
+export function formatEditorialDate(
+  date: Date,
+  month: "short" | "long" = "short",
+): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: "UTC",
+    year: "numeric",
+    month,
+    day: "numeric",
+  }).format(date);
+}


### PR DESCRIPTION
## Summary

This PR turns the existing Astro website into a broader **Diversio Engineering** hub while preserving the strong tools/docs foundation from PR #77.

It also adds a repo-owned Cloudflare Pages deployment pipeline so the site can preview on PRs and publish from `main`.

### Key features

| Feature | Description |
|---|---|
| **Diversio Engineering hub** | Reframes the public site around a broader engineering identity instead of a single tools landing page. |
| **Agentic Tools section** | Moves the tools-focused landing experience to `/agentic-tools` while keeping deep docs on stable short routes. |
| **Blog scaffolding** | Adds Astro content collections and pages for original posts and curated reposts with canonical/source metadata rules. |
| **Open source visibility** | Highlights additional Diversio open source projects on the homepage and community page. |
| **Cloudflare deploy pipeline** | Adds GitHub Actions + Cloudflare Pages deployment flow, plus setup/runbook documentation. |
| **Shared site config** | Centralizes hostname, section labels, nav items, and canonical metadata inputs. |

## Route / site shape

```text
/                     -> Diversio Engineering homepage
/agentic-tools        -> tools landing page
/blog                 -> engineering writing
/docs/*               -> bundle-level docs
/skills/*             -> skill docs
/pi/*                 -> Pi package docs
/community            -> contribution + open source context
```

Deep docs intentionally stay on short stable routes so existing links do not churn unnecessarily.

## Deployment flow

```text
GitHub Actions
  -> install dependencies
  -> build website/dist
  -> upload dist to Cloudflare Pages

same-repo PR
  -> preview deploy

push to main
  -> production deploy
```

## Why this approach

### 1. Extend the existing site instead of rebuilding it

PR #77 already established the core website patterns:
- deep docs generation
- runtime-aware code examples
- contributor rendering
- social metadata support
- website CI

This PR builds on that foundation instead of replacing it.

### 2. Keep identity changes centralized

Public-facing site strings now live in `website/site.config.mjs` so future brand, hostname, or nav updates do not require fragile find-and-replace edits across layouts and pages.

### 3. Keep editorial rules explicit

The new blog model stays markdown-first and git-reviewed. Reposts require source and canonical metadata so attribution rules are enforced in code instead of left as tribal knowledge.

### 4. Keep deploy logic repo-owned

The new Cloudflare Pages workflow builds in GitHub Actions first, then uploads the finished static output. That makes the build logs easy to inspect right next to the code change.

## Files changed

<details>
<summary>Website structure and config</summary>

- `website/site.config.mjs`
- `website/src/layouts/BaseLayout.astro`
- `website/src/layouts/PageLayout.astro`
- `website/src/components/Header.astro`
- `website/src/components/Footer.astro`
- `website/src/components/Hero.astro`
- `website/src/pages/index.astro`
- `website/src/pages/agentic-tools.astro`

</details>

<details>
<summary>Editorial / content model</summary>

- `website/src/content.config.ts`
- `website/src/pages/blog/index.astro`
- `website/src/pages/blog/[slug].astro`
- `website/src/content/blog/introducing-diversio-engineering-hub.md`
- `website/src/content/blog/draft-placeholder.md`

</details>

<details>
<summary>Supporting pages and polish</summary>

- `website/src/pages/community.astro`
- `website/src/pages/docs/index.astro`
- `website/src/pages/registry.astro`
- `website/src/pages/skills/index.astro`
- `website/src/pages/pi/index.astro`
- `website/src/pages/pi/[package].astro`
- `website/src/pages/security.astro`
- `website/src/pages/terms.astro`
- `website/src/data/open-source-projects.ts`
- `website/public/_redirects`

</details>

<details>
<summary>CI / deploy / docs</summary>

- `.github/workflows/deploy-website-cloudflare-pages.yml`
- `website/README.md`
- `docs/quality/gates.md`
- `docs/architecture/overview.md`
- `docs/website/engineering-hub-phase-2/**`
- `README.md`

</details>

## Test plan

### Local

```bash
jq -e . website/package.json >/dev/null
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-website-cloudflare-pages.yml"); puts "workflow-yaml-ok"'
cd website
npm install --package-lock=false
npm run build
cd ..
git diff --check
```

### Cloudflare / GitHub setup verified

- created GitHub secrets:
  - `CLOUDFLARE_API_TOKEN`
  - `CLOUDFLARE_ACCOUNT_ID`
- created GitHub variable:
  - `CLOUDFLARE_PAGES_PROJECT=diversio-engineering`
- created Cloudflare Pages project:
  - `diversio-engineering`
- manual preview deployment succeeded:
  - `https://feature-engineering-hub-phas.diversio-engineering.pages.dev`

## Follow-up after merge

- add `engineering.diversio.com` custom domain mapping in Cloudflare Pages UI
- add Route53 validation / DNS records required by Cloudflare
- configure host-level redirect from `agents.diversio.com` to `engineering.diversio.com`
