### PR TITLE
fix(dev-workflow): deepen PR review comments step 8 resolution

### DIFF
--- a/pi-packages/dev-workflow/README.md
+++ b/pi-packages/dev-workflow/README.md
@@ -34,7 +34,7 @@ package project-locally as a developer.
 | `/workflow:ci` | `workflow.ci` | CI check — `/ci`, `/ci-detail`, logs, ours-vs-flake analysis |
 | `/workflow:docs` | `workflow.docs` | Documentation pass — explain the *why* |
 | `/workflow:ship` | `workflow.ship` | Smart ship — verify CI, atomic commit, PR description, open/update PR |
-| `/workflow:pr-review-comments` | `workflow.pr-review-comments` | Address PR review comments, validate, push, resolve threads, re-request review |
+| `/workflow:pr-review-comments` | `workflow.pr-review-comments` | Address PR review comments, validate, push, resolve threads via GraphQL (explicit listing + resolveReviewThread + unaddressed flagging), re-request review |
 | `/workflow:release-prs` | `workflow.release-prs` | Prepare backend/frontend/optimo-frontend/design-system release PRs |
 
 ### Session bootstrap & handoff

--- a/pi-packages/dev-workflow/extensions/dev-workflow/index.ts
+++ b/pi-packages/dev-workflow/extensions/dev-workflow/index.ts
@@ -223,7 +223,9 @@ Once the code is ready, use the PR description writer skill to generate a review
       "Identifies one PR, inferred current PR, or multiple provided PRs",
       "Fetches unresolved threads, review summaries, issue comments, and inline comments",
       "Groups feedback by root cause and asks questions when scope or intent is ambiguous",
-      "Makes focused fixes, runs atomic/pre-commit checks, commits, pushes, resolves addressed threads, and re-requests review",
+      "Makes focused fixes, runs atomic/pre-commit checks, commits, and pushes",
+      "Queries ALL unresolved review threads via GitHub GraphQL API, lists every thread with ID / path / line / body summary / addressed status, resolves addressed threads via resolveReviewThread, and explicitly flags any thread that remains unaddressed",
+      "Re-requests review from affected reviewers once every addressed thread is resolved and every unaddressed thread is flagged",
     ],
     whenToUse: "When reviewers or bots left PR feedback that must be addressed before re-review. Supports multiple PRs when provided explicitly.",
     example: "/workflow:pr-review-comments PR #68 and PR #69",
@@ -245,7 +247,12 @@ Process:
 5. Run checks before pushing: relevant formatting, lint, type, test, build, and repo-local atomic commit or pre-commit workflows.
 6. Commit atomically: include all files required for the fix, keep commits reviewable, and keep multiple PR/repo fixes scoped appropriately.
 7. Push normally to the PR branch.
-8. Resolve review threads: resolve only threads actually addressed by pushed changes. Leave unresolved anything needing clarification or follow-up.
+8. Resolve review threads:
+   - Query ALL unresolved review threads via the GraphQL API before claiming completion.
+   - List every thread explicitly: its ID, path, line, body summary, and whether it is addressed by the current commit.
+   - For each addressed thread, call resolveReviewThread. Show the result.
+   - If any thread is NOT addressed, say so clearly — do not skip it silently.
+   - Only after every addressed thread is resolved AND every unaddressed thread is flagged, move to step 9.
 9. Re-request review: ask affected reviewers again. Trigger automation reviewers if needed.
 10. Final report: PRs handled, comments addressed, files changed, commits pushed, checks run, threads resolved, reviewers re-requested, and remaining blockers.
 

--- a/pi-packages/dev-workflow/package.json
+++ b/pi-packages/dev-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflow",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Daily developer workflow for pi — workflow prompt registry, plan review, self-review, standards, CI, PR review comments, release PR prep, docs, and shipping. 15 core prompts plus help, run, prompts, and flow.",
   "keywords": ["pi-package"],
   "files": ["extensions/", "skills/", "agents/", "README.md"],


### PR DESCRIPTION
## Summary

This PR replaces the one-line step 8 ("Resolve review threads") in the `workflow:pr-review-comments` embedded prompt with a detailed, auditable resolution process that prevents threads from slipping through unnoticed.

### What changed

The old step 8 was:
> Resolve review threads: resolve only threads actually addressed by pushed changes. Leave unresolved anything needing clarification or follow-up.

The new step 8 is an explicit, multi-step gate:

```
8. Resolve review threads:
   - Query ALL unresolved review threads via the GraphQL API before claiming completion.
   - List every thread explicitly: its ID, path, line, body summary, and whether it is addressed by the current commit.
   - For each addressed thread, call resolveReviewThread. Show the result.
   - If any thread is NOT addressed, say so clearly — do not skip it silently.
   - Only after every addressed thread is resolved AND every unaddressed thread is flagged, move to step 9.
```

### Why

The old step trusted the AI to "resolve only addressed threads" without requiring an audit trail. The new step forces an explicit inventory: every thread is queried, listed, and accounted for before the workflow proceeds to re-request review. No thread can be silently skipped.

### Files changed

<details>
<summary>3 files (click to expand)</summary>

- `pi-packages/dev-workflow/extensions/dev-workflow/index.ts` — Expanded step 8 in the embedded prompt, split `whatItDoes` metadata into focused bullets matching the new resolution depth
- `pi-packages/dev-workflow/README.md` — Updated command table description to mention GraphQL-based resolution
- `pi-packages/dev-workflow/package.json` — Version bump 0.0.3 → 0.0.4

</details>

### How to test

```bash
# Validate package JSON
jq -e . pi-packages/dev-workflow/package.json

# npm pack dry run
(cd pi-packages/dev-workflow && npm pack --dry-run)

# Validate skills
bash scripts/validate-skills.sh

# Smoke-test the workflow command (no-op registration check)
printf '{"id":"cmds","type":"get_commands"}' | \
  PI_OFFLINE=1 pi --mode rpc --no-session --no-context-files \
    --no-extensions -e ./pi-packages/dev-workflow \
    --no-prompt-templates --no-skills
```

### Notes

- No schema changes, no migrations, no breaking changes
- The `whatItDoes` array was restructured from 4 bullets to 6 to surface the new resolution depth in `/workflow:help` and the TUI prompt browser
- The `short` and `label` metadata remain unchanged — they are intentionally kept as high-level summaries