### PR TITLE
Add pi-timestamps package

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ agent-skills-marketplace/
 │   ├── dev-workflow/                  # Pi-native daily developer workflow extension + skills
 │   ├── image-router/                  # Pi-native vision bridge for text-only models
 │   ├── oh-my-pi/                      # Pi-native cmux integration (notifications, split panes, workspace tabs)
+│   ├── pi-timestamps/                 # Pi-native subtle transcript timing rows
 │   └── skills-bridge/                 # Pi-native bridge to Claude Code plugin skills
 ├── website/                           # Astro site for engineering.diversio.com
 │   ├── src/pages/                     # Homepage, /agentic-tools, registry, docs, /skills/*, /pi/*, /blog/*
@@ -290,7 +291,7 @@ agent-skills-marketplace/
 
 ## Available Pi Packages
 
-All four packages are installable together from one git URL (recommended) or
+All six packages are installable together from one git URL (recommended) or
 individually from a local checkout. The root `package.json` declares every
 sub-package so pi can discover them from a single clone - see
 [Git-based install](#git-based-install-recommended) for the one-liner.
@@ -299,7 +300,9 @@ sub-package so pi can discover them from a single clone - see
 |---------|-------------|
 | `ci-status` | Pi-native CI status extension with `/ci`, `/ci-detail`, `/ci-logs`, auto-watch after pushes, widget/status rendering, GitHub Actions + CircleCI support, and LLM CI tools |
 | `dev-workflow` | Pi-native daily developer workflow with 15 core workflow prompts, `/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`, XDG/project prompt config, CI analysis, PR review feedback, release PR prep, local skills, optional pi-subagents chain, and default cmux split launching for subagent-style workflow prompts when Pi runs inside cmux |
+| `image-router` | Pi-native image routing extension that describes screenshots and other image inputs with a vision-capable model when the active model is text-only |
 | `oh-my-pi` | Pi-native cmux integration with native cmux notifications (Waiting / Task Complete / Error), readable split pane commands (`/omp-split-*`) and workspace tab commands (`/omp-workspace*`), plus short aliases for faster typing. Low-level cmux primitives are shared via `@diversio/pi-cmux`. Works only inside cmux |
+| `pi-timestamps` | Pi-native subtle transcript timing rows for exact timestamps, reply-start timing, timezone-aware absolute times, and always-updating relative times |
 | `skills-bridge` | Auto-discovers all 21 Claude Code plugin skills from plugins/*/skills/ and registers them as pi skills. One install bridges the gap between the plugin ecosystem and pi |
 
 Helpful mental model:
@@ -368,7 +371,7 @@ of the Claude Code marketplace.
 #### Git-based install (recommended)
 
 A root `package.json` at the top of this repo declares every sub-package so pi
-can discover `ci-status`, `dev-workflow`, `oh-my-pi`, and `skills-bridge` from one clone:
+can discover `ci-status`, `dev-workflow`, `image-router`, `oh-my-pi`, `pi-timestamps`, and `skills-bridge` from one clone:
 
 ```bash
 pi install git:github.com/DiversioTeam/agent-skills-marketplace
@@ -407,7 +410,9 @@ local change before pushing:
 ```bash
 pi install "$PWD/pi-packages/ci-status"
 pi install "$PWD/pi-packages/dev-workflow"
+pi install "$PWD/pi-packages/image-router"
 pi install "$PWD/pi-packages/oh-my-pi"
+pi install "$PWD/pi-packages/pi-timestamps"
 pi install "$PWD/pi-packages/skills-bridge"
 ```
 
@@ -427,7 +432,8 @@ the duplicate project package entry from `.pi/settings.json` or uninstall the
 global copy before reloading.
 
 Run `/reload` in pi after installation. See `pi-packages/ci-status/README.md`,
-`pi-packages/dev-workflow/README.md`, and `pi-packages/oh-my-pi/README.md` for
+`pi-packages/dev-workflow/README.md`, `pi-packages/image-router/README.md`,
+`pi-packages/oh-my-pi/README.md`, and `pi-packages/pi-timestamps/README.md` for
 command inventory, contribution workflow, and local testing commands.
 
 ### Monolith Review Orchestrator

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -111,6 +111,21 @@ when command files change.
     `PI_CMUX_NOTIFY_DEBOUNCE_MS`, `PI_CMUX_NOTIFY_TITLE`
   - One-off local test from repo root:
     `pi --no-extensions -e ./pi-packages/oh-my-pi`
+- `pi-timestamps` (pi package)
+  - Purpose: adds subtle per-turn transcript timing rows so Pi sessions show
+    exact timestamps, reply-start timing when available, timezone-aware
+    absolute times, and always-updating relative times.
+  - Pi install from repo checkout:
+    `pi install "$PWD/pi-packages/pi-timestamps"`
+  - Package path: `pi-packages/pi-timestamps`
+  - Extension path: `pi-packages/pi-timestamps/extensions/pi-timestamps`
+  - Slash commands: `/timestamps`, `/timestamps visible`,
+    `/timestamps hidden`, `/timestamps status`
+  - Shortcut: `Ctrl+Shift+H` by default toggles timestamps on/off
+  - Configuration: `PI_TIMESTAMPS_TIME_ZONE`,
+    `PI_TIMESTAMPS_TOGGLE_SHORTCUT`
+  - One-off local test from repo root:
+    `pi --no-extensions -e ./pi-packages/pi-timestamps`
 - `skills-bridge` (pi package)
   - Purpose: auto-discovers Claude Code plugin skills from
     `plugins/*/skills/` directories and registers them as pi

--- a/docs/runbooks/distribution.md
+++ b/docs/runbooks/distribution.md
@@ -131,7 +131,7 @@ not the Claude Code marketplace.
 ### Git-based install (recommended)
 
 The root `package.json` at the top of this repo declares every sub-package so pi
-can discover all five from a single clone. One command replaces five:
+can discover all six from a single clone. One command replaces six:
 
 ```bash
 pi install git:github.com/DiversioTeam/agent-skills-marketplace
@@ -162,8 +162,8 @@ Pinned refs are skipped by `pi update --extensions`.
 `npm install` if a `package.json` exists, and then reads the `pi` manifest to
 discover extensions, skills, prompts, and themes. The root manifest points into
 the `pi-packages/` subdirectories so pi finds `ci-status`, `dev-workflow`,
-`image-router`, `oh-my-pi`, and `skills-bridge` without any extra
-configuration.
+`image-router`, `oh-my-pi`, `pi-timestamps`, and `skills-bridge` without any
+extra configuration.
 
 **Migrating from local-path installs.** If you previously installed packages
 via local paths (e.g. `pi install "$PWD/pi-packages/ci-status"`), remove those
@@ -179,6 +179,7 @@ pi install "$PWD/pi-packages/ci-status"
 pi install "$PWD/pi-packages/dev-workflow"
 pi install "$PWD/pi-packages/image-router"
 pi install "$PWD/pi-packages/oh-my-pi"
+pi install "$PWD/pi-packages/pi-timestamps"
 pi install "$PWD/pi-packages/skills-bridge"
 ```
 
@@ -189,6 +190,7 @@ pi install "$PWD/agent-skills-marketplace/pi-packages/ci-status"
 pi install "$PWD/agent-skills-marketplace/pi-packages/dev-workflow"
 pi install "$PWD/agent-skills-marketplace/pi-packages/image-router"
 pi install "$PWD/agent-skills-marketplace/pi-packages/oh-my-pi"
+pi install "$PWD/agent-skills-marketplace/pi-packages/pi-timestamps"
 pi install "$PWD/agent-skills-marketplace/pi-packages/skills-bridge"
 ```
 
@@ -206,6 +208,7 @@ pi --no-extensions -e ./pi-packages/ci-status
 pi --no-extensions -e ./pi-packages/dev-workflow
 pi --no-extensions -e ./pi-packages/image-router
 pi --no-extensions -e ./pi-packages/oh-my-pi
+pi --no-extensions -e ./pi-packages/pi-timestamps
 pi --no-extensions -e ./pi-packages/skills-bridge
 ```
 
@@ -217,6 +220,7 @@ pi install -l ./pi-packages/ci-status
 pi install -l ./pi-packages/dev-workflow
 pi install -l ./pi-packages/image-router
 pi install -l ./pi-packages/oh-my-pi
+pi install -l ./pi-packages/pi-timestamps
 pi install -l ./pi-packages/skills-bridge
 ```
 
@@ -241,6 +245,9 @@ dev-workflow -> workflow prompts, review passes, shipping, and
 oh-my-pi     -> explicit cmux notifications, split-pane commands,
                 and workspace-tab commands
 
+pi-timestamps -> subtle per-turn transcript timing rows for exact timestamps,
+                 timezone labels, and updating "how long ago"
+
 skills-bridge -> exposes marketplace plugin skills inside Pi
 ```
 
@@ -257,6 +264,10 @@ manually.
 
 The `oh-my-pi` package provides explicit `/omp-split-*` and
 `/omp-workspace*` cmux commands plus native cmux notifications.
+
+The `pi-timestamps` package provides `/timestamps`, subtle transcript timing
+rows, timezone-aware absolute timestamps, and always-updating relative times
+like `2m ago`.
 
 ## Codex Skill Installation
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent-skills-marketplace",
   "version": "0.0.1",
   "private": true,
-  "description": "Root pi manifest for the Diversio Team agent-skills-marketplace. This file lets pi discover every sub-package (ci-status, dev-workflow, oh-my-pi, skills-bridge) from a single git clone. Without it, each sub-package needs its own fragile local-path install — which breaks across worktrees and causes duplicate extensions. One pi install git:github.com/DiversioTeam/agent-skills-marketplace now replaces four separate pi install $PWD/pi-packages/<pkg> commands.",
+  "description": "Root pi manifest for the Diversio Team agent-skills-marketplace. This file lets pi discover every sub-package (ci-status, dev-workflow, image-router, oh-my-pi, pi-timestamps, skills-bridge) from a single git clone. Without it, each sub-package needs its own fragile local-path install — which breaks across worktrees and causes duplicate extensions. One pi install git:github.com/DiversioTeam/agent-skills-marketplace now replaces six separate pi install $PWD/pi-packages/<pkg> commands.",
   "keywords": [
     "pi-package"
   ],
@@ -14,6 +14,7 @@
       "pi-packages/ci-status/extensions",
       "pi-packages/dev-workflow/extensions",
       "pi-packages/image-router/extensions",
+      "pi-packages/pi-timestamps/extensions",
       "pi-packages/skills-bridge/extensions",
       "pi-packages/oh-my-pi/extensions"
     ],

--- a/pi-packages/README.md
+++ b/pi-packages/README.md
@@ -10,6 +10,7 @@ Pi-native packages that extend pi with tools, commands, skills, and UI widgets.
 | [`dev-workflow`](./dev-workflow) | 15 core workflow prompts (`/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`), CI analysis, PR review feedback, release PR prep, local skills, optional pi-subagents chain, and seeded cmux split launching for subagent-style prompts |
 | [`image-router`](./image-router) | Routes image inputs through a vision-capable model when the active model is text-only, with per-model routing modes and a TUI settings panel |
 | [`oh-my-pi`](./oh-my-pi) | Pi-native cmux integration with notifications, readable split commands, and workspace tabs |
+| [`pi-timestamps`](./pi-timestamps) | Adds subtle per-turn transcript timing rows for exact timestamps, reply-start timing, timezone-aware absolute times, and always-updating relative times |
 | [`skills-bridge`](./skills-bridge) | Auto-discovers all 21 Claude Code plugin skills from `plugins/*/skills/` and registers them as pi skills — one install bridges the entire plugin ecosystem into pi |
 
 ## Install
@@ -24,7 +25,7 @@ pi install git:github.com/DiversioTeam/agent-skills-marketplace
 published on the public npm registry — no auth or `.npmrc` setup needed.
 
 The root `package.json` at the top of this repo tells pi where to find every
-package, so one clone discovers all five. Run `/reload` after installing.
+package, so one clone discovers all six. Run `/reload` after installing.
 
 To pull the latest updates later:
 
@@ -45,6 +46,7 @@ pi install "$PWD/pi-packages/ci-status"
 pi install "$PWD/pi-packages/dev-workflow"
 pi install "$PWD/pi-packages/image-router"
 pi install "$PWD/pi-packages/oh-my-pi"
+pi install "$PWD/pi-packages/pi-timestamps"
 pi install "$PWD/pi-packages/skills-bridge"
 ```
 
@@ -83,6 +85,10 @@ pi-packages/
 │   ├── README.md
 │   └── extensions/
 ├── oh-my-pi/
+│   ├── package.json
+│   ├── README.md
+│   └── extensions/
+├── pi-timestamps/
 │   ├── package.json
 │   ├── README.md
 │   └── extensions/

--- a/pi-packages/pi-timestamps/README.md
+++ b/pi-packages/pi-timestamps/README.md
@@ -1,0 +1,374 @@
+# Pi Timestamps
+
+## Problem
+
+Pi already knows when messages happened, but the default transcript does not
+make that timing easy for a human to scan.
+
+In practice, people want simple answers to simple questions:
+
+- When did I send that prompt?
+- How long did the model take to start replying?
+- How long did the full turn take?
+- How long ago did this happen?
+
+## Solution
+
+`pi-timestamps` adds one **small, subtle timing row** after each user prompt.
+
+Most turns show normal timing data. If no visible assistant reply arrives, the
+row falls back to `reply incomplete` instead of pretending the turn completed
+normally.
+
+Visual design principles:
+
+- keep the row quiet enough that it does not compete with the transcript
+- still make the important timing fields pop
+- use color intentionally instead of making the whole row loud
+
+Current highlighting:
+
+- completion time uses a success color
+- `reply in` and `total` values use an accent color
+- relative age like `11s ago` uses a warning color
+- the hide shortcut stays dimmer than the timing data
+
+Labeling note:
+
+- we use `reply in`, not `thought for`
+- `reply in` means: "how long until visible answer text appeared"
+- that is a user-experience metric, not an internal reasoning metric
+
+Mental model:
+
+```text
+user sends prompt
+   ↓
+extension records start time
+   ↓
+first visible assistant text appears
+   ↓
+extension records reply-start timing
+(or falls back to assistant-start timing if no text-start event arrives)
+   ↓
+turn fully ends
+   ↓
+extension appends one tiny display-only timing row
+```
+
+Example row:
+
+```text
+2026-06-02 19:18:01 EDT · done 2026-06-02 19:18:08 EDT · reply in 3s · total 7s · 11s ago · hide row: ctrl+shift+h
+```
+
+## Why it works this way
+
+### Why add a separate timing row?
+
+Because Pi's current extension API can render **custom extension messages**,
+but it does **not** let us rewrite the built-in user/assistant chat bubbles
+directly.
+
+So the extension does this instead:
+
+```text
+normal Pi transcript row
+normal Pi transcript row
+small timing row added by the extension
+```
+
+That keeps the feature reliable without patching Pi core.
+
+### Why is there no bottom panel anymore?
+
+We tried that. It felt too noisy.
+
+The current design aims for:
+
+- low visual weight
+- useful timing at a glance
+- no persistent second panel competing with the conversation
+
+### Why is there still a hidden widget internally?
+
+Relative text like `11s ago` needs the TUI to re-render periodically.
+The extension mounts a **zero-height hidden widget** only so it can keep a TUI
+handle and refresh those relative timestamps once per second.
+
+Users do not see that widget.
+
+## What gets shown
+
+Each timing row can show:
+
+- exact prompt timestamp
+- exact completion timestamp
+- reply-start timing when visible text appeared
+- fallback assistant-start timing if the provider does not emit a text-start event
+- total turn duration
+- relative age like `11s ago`
+- inline "hide row" shortcut text
+
+Visual map:
+
+```text
+2026-06-02 19:18:01 EDT · done 2026-06-02 19:18:08 EDT · reply in 3s · total 7s · 11s ago · hide row: ctrl+shift+h
+│                        │                              │             │          │          └─ quick hide-row hint
+│                        │                              │             │          └─ relative age, kept live
+│                        │                              │             └─ full turn duration
+│                        │                              └─ time until the reply became visible
+│                        └─ exact completion time
+└─ exact prompt time
+```
+
+## Commands
+
+```text
+/timestamps            toggle visible/hidden
+/timestamps visible    force visible
+/timestamps hidden     force hidden
+/timestamps status     show current mode, timezone, shortcut
+```
+
+Quick examples:
+
+```bash
+# hide timing rows
+/timestamps hidden
+
+# show them again
+/timestamps visible
+
+# check current mode + timezone + shortcut
+/timestamps status
+```
+
+## Shortcut
+
+Default shortcut:
+
+```text
+Ctrl+Shift+H
+```
+
+Inline rows also teach this shortcut with:
+
+```text
+hide row: ctrl+shift+h
+```
+
+That shortcut hides the entire timing row, not just the hint text.
+
+## Timestamp format
+
+This package intentionally avoids American month/day ordering.
+
+It renders absolute times as:
+
+```text
+YYYY-MM-DD HH:mm:ss TZ
+```
+
+Example:
+
+```text
+2026-06-02 19:18:01 EDT
+```
+
+## Design boundaries
+
+This package intentionally stays small.
+
+What it includes:
+
+- subtle transcript timing rows
+- exact prompt and completion timestamps
+- `reply in` timing
+- `total` timing
+- live relative age like `11s ago`
+- one visibility toggle command and shortcut
+
+What it intentionally does **not** include:
+
+- no bottom panel
+- no separate always-visible dashboard
+- no explicit thinking-phase metrics
+- no mutation of Pi's built-in user/assistant bubble renderer
+
+Why no explicit thinking metric?
+
+Because providers expose reasoning differently.
+A durable default UI should measure what the user actually experiences:
+
+```text
+When did I see the reply start?
+```
+
+not:
+
+```text
+When did the model begin internal reasoning?
+```
+
+Why keep the scope this small?
+
+Because the hard part is not drawing text — it is making timing feel accurate,
+quiet, and non-disruptive across different providers and streaming behaviors.
+
+## Install
+
+From the repo root:
+
+```bash
+pi install "$PWD/pi-packages/pi-timestamps"
+```
+
+Or install all Pi packages from this repo at once:
+
+```bash
+pi install git:github.com/DiversioTeam/agent-skills-marketplace
+```
+
+Then run `/reload` in Pi.
+
+## Configuration
+
+Optional environment variables:
+
+```bash
+export PI_TIMESTAMPS_TIME_ZONE="America/Toronto"
+export PI_TIMESTAMPS_TOGGLE_SHORTCUT="ctrl+shift+h"
+```
+
+Notes:
+
+- If `PI_TIMESTAMPS_TIME_ZONE` is unset, the extension uses your local system timezone.
+- `PI_TIMESTAMPS_TOGGLE_SHORTCUT` changes both the registered shortcut and the inline hint text.
+
+## Local testing
+
+```bash
+jq -e . pi-packages/pi-timestamps/package.json >/dev/null
+(cd pi-packages/pi-timestamps && npm pack --dry-run --json >/tmp/pi-timestamps-pack.json)
+pi --no-extensions -e ./pi-packages/pi-timestamps
+```
+
+Suggested smoke test:
+
+```text
+1. Start Pi with the package loaded
+2. Send a prompt
+3. Confirm a subtle timing row appears immediately after the turn
+4. Confirm `done`, `reply in`, `total`, and `11s ago` are easy to spot
+5. Press Ctrl+Shift+H
+6. Confirm timing rows disappear
+7. Press Ctrl+Shift+H again
+8. Confirm timing rows return
+```
+
+Provider-behavior smoke test:
+
+```text
+A. Normal streaming reply
+   -> expect a real `reply in` timing from visible text
+
+B. Provider with weak/no text-start events
+   -> expect a fallback `reply in` timing close to assistant-start
+
+C. Tool-call-only / no visible assistant reply
+   -> expect `reply incomplete`, not fake completion timing
+```
+
+## Implementation notes
+
+A few implementation choices may look unusual at first glance.
+Here is the simple why behind each one.
+
+### Hidden zero-height widget
+
+Why it exists:
+
+```text
+relative age text changes over time
+        ↓
+UI must rerender periodically
+        ↓
+extension needs a stable TUI handle
+        ↓
+hidden widget keeps that handle alive
+```
+
+### Deferred timing-row append
+
+Why we do not append the row immediately inside `agent_end()`:
+
+```text
+append too early
+  -> row can behave like part of the active model turn
+  -> assistant may appear to reply to it
+
+append one event-loop tick later
+  -> current run settles first
+  -> row still appears immediately to the user
+```
+
+In code, that is this pattern:
+
+```ts
+setTimeout(() => {
+  pi.sendMessage({ ...timingRow });
+}, 0);
+```
+
+### Backward-compatible visibility restore
+
+Older session entries may still contain:
+
+```text
+widgetMode
+```
+
+Newer ones write:
+
+```text
+visibilityMode
+```
+
+We read both so existing sessions do not lose their saved hide/show state.
+
+## Notes for maintainers
+
+- Timing rows are stored as display-only custom messages and filtered out of LLM context.
+- Timing rows are appended with a tiny deferred `pi.sendMessage(...)` call after the current run settles, so they still appear in the live transcript without being treated as part of the active model turn.
+- Visibility mode is stored as a session custom entry, so `/reload` preserves it inside the current session branch.
+- Relative-time updates depend on a lightweight 1s TUI re-render tick.
+- The hidden zero-height widget exists only to keep that re-render loop alive.
+
+Code-reading map:
+
+```text
+restoreStateFromSession()
+  -> load visible/hidden mode from session
+
+syncTicker()
+  -> start/stop the 1s relative-time rerender loop
+
+message_end(role=user)
+  -> start the turn clock
+
+message_start(role=assistant)
+  -> save assistant-start fallback time
+
+message_update(text_start/text_delta)
+  -> capture real reply-start timing when possible
+
+agent_end()
+  -> decide completed vs aborted
+  -> compute final durations
+  -> hand details to scheduleTimingRowAppend()
+
+scheduleTimingRowAppend()
+  -> defer one tick
+  -> append the display-only timing row safely
+```

--- a/pi-packages/pi-timestamps/extensions/pi-timestamps/index.ts
+++ b/pi-packages/pi-timestamps/extensions/pi-timestamps/index.ts
@@ -1,0 +1,704 @@
+/**
+ * Pi Timestamps
+ *
+ * What problem are we solving?
+ * ---------------------------
+ * Pi already knows when messages happen, but the default transcript does not
+ * answer the timing questions humans actually ask:
+ *
+ * - When did I send that prompt?
+ * - When did the reply actually finish?
+ * - How long until I saw the reply start?
+ * - How long did the whole turn take?
+ * - How long ago did this happen?
+ *
+ * First-principles design
+ * -----------------------
+ * We want timing to be:
+ *
+ * 1. visible by default
+ * 2. subtle enough that it does not fight the transcript
+ * 3. easy to hide with one shortcut
+ * 4. correct even when providers stream differently
+ *
+ * So this extension adds one tiny timing row after each user prompt.
+ *
+ * - normal visible replies show `done`, `reply in`, `total`, and `... ago`
+ * - incomplete/non-visible replies fall back to `reply incomplete`
+ *
+ * Mental model
+ * ------------
+ *
+ *   user prompt ends
+ *        ↓
+ *   remember prompt timestamp
+ *        ↓
+ *   assistant starts / streams visible text
+ *        ↓
+ *   remember reply-start timing
+ *        ↓
+ *   whole turn ends
+ *        ↓
+ *   append one display-only timing row
+ *   (or `reply incomplete` if no visible assistant reply arrived)
+ *
+ * Why a separate row instead of changing Pi's normal chat bubbles?
+ * ---------------------------------------------------------------
+ * Pi's extension API lets us render custom extension messages, but it does not
+ * let us directly rewrite the built-in user/assistant bubble renderer.
+ *
+ * So we do this instead:
+ *
+ *   normal Pi row
+ *   normal Pi row
+ *   timing row added by this extension
+ *
+ * Why is there a hidden widget if there is no visible bottom panel?
+ * ---------------------------------------------------------------
+ * Relative strings like "11s ago" only stay fresh if the TUI rerenders.
+ * We mount a zero-height hidden widget purely so we can keep a TUI handle and
+ * request those rerenders once per second while timestamps are visible.
+ */
+
+import type { Message } from "@mariozechner/pi-ai";
+import type { Component, TUI } from "@mariozechner/pi-tui";
+import { wrapTextWithAnsi } from "@mariozechner/pi-tui";
+import type { ExtensionAPI, ExtensionContext, Theme } from "@mariozechner/pi-coding-agent";
+
+/**
+ * Custom message type for the synthetic timing row we append after each turn.
+ *
+ * This is display-only UI data. We later strip it from model context so the LLM
+ * never wastes tokens reading its own timing metadata.
+ */
+const TURN_MESSAGE_TYPE = "pi-timestamps-turn";
+
+/**
+ * Session-persisted settings entry.
+ *
+ * We only store one thing right now: whether timestamps are visible or hidden.
+ */
+const SETTINGS_ENTRY_TYPE = "pi-timestamps-settings";
+
+/**
+ * Hidden widget key.
+ *
+ * The widget renders nothing. Its only job is to keep a live TUI handle around
+ * so relative times can keep updating.
+ */
+const WIDGET_KEY = "pi-timestamps";
+
+/**
+ * Re-render cadence for relative timestamps.
+ *
+ * One second is frequent enough to keep "11s ago" feeling live without making
+ * the UI noisy or wasteful.
+ */
+const TICK_MS = 1_000;
+
+/** Timestamps are visible by default unless the session says otherwise. */
+const DEFAULT_VISIBILITY_MODE: VisibilityMode = "visible";
+
+/** Optional explicit timezone override. */
+const CONFIGURED_TIME_ZONE = process.env.PI_TIMESTAMPS_TIME_ZONE?.trim() || undefined;
+
+/** Keyboard shortcut for hide/show. Kept text-based because the user asked for text, not icons. */
+const TOGGLE_SHORTCUT = process.env.PI_TIMESTAMPS_TOGGLE_SHORTCUT?.trim() || "ctrl+shift+h";
+
+/** Two modes only: shown or hidden. We intentionally removed extra modes. */
+type VisibilityMode = "visible" | "hidden";
+
+/**
+ * `completed` means we saw a visible assistant reply.
+ * `aborted` means the turn ended without user-visible assistant text.
+ */
+type TurnStatus = "completed" | "aborted";
+
+/**
+ * Small session-persisted settings payload.
+ *
+ * We intentionally keep this tiny because session state lasts a long time and
+ * should be easy to migrate. If we add more settings later, this is the place.
+ */
+type VisibilitySettings = {
+  visibilityMode: VisibilityMode;
+};
+
+/**
+ * What we persist on the display-only timing row.
+ *
+ * We keep this intentionally small. It only stores what the renderer needs.
+ */
+type TurnTimingDetails = {
+  version: 1;
+  userTimestamp: number;
+  assistantTimestamp?: number;
+  totalDurationMs?: number;
+  /**
+   * User-facing latency label shown as `reply in <duration>`.
+   *
+   * We persist only the duration, not the exact reply-start timestamp, because
+   * the UI does not currently need to render that absolute time. Keeping the
+   * saved payload small makes long-lived session history easier to migrate.
+   */
+  replyStartDurationMs?: number;
+  status: TurnStatus;
+};
+
+/** In-memory state for the turn currently being processed. */
+type LiveTurn = {
+  userTimestamp: number;
+  /**
+   * Coarse fallback for "assistant started replying" when we never receive a
+   * text_start/text_delta event. This is better than incorrectly making reply
+   * start equal to total duration at turn end.
+   */
+  assistantStartTimestamp?: number;
+  replyStartTimestamp?: number;
+  replyStartDurationMs?: number;
+};
+
+let visibilityMode: VisibilityMode = DEFAULT_VISIBILITY_MODE;
+let currentTurn: LiveTurn | undefined;
+let activeTui: TUI | undefined;
+let tickTimer: ReturnType<typeof setInterval> | undefined;
+
+/**
+ * Timers waiting to append timing rows after the current turn settles.
+ *
+ * We track them explicitly so reload/shutdown can cancel them and avoid stale
+ * rows from an older runtime leaking into a newer session UI.
+ */
+let pendingAppendTimers = new Set<ReturnType<typeof setTimeout>>();
+
+/** Small runtime type guard for unknown session payloads. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** Runtime guard for the only two supported visibility states. */
+function isVisibilityMode(value: unknown): value is VisibilityMode {
+  return value === "visible" || value === "hidden";
+}
+
+/** Validate timing payloads before trying to render them. */
+function isTurnTimingDetails(value: unknown): value is TurnTimingDetails {
+  if (!isRecord(value)) return false;
+  return (
+    value["version"] === 1
+    && typeof value["userTimestamp"] === "number"
+    && (value["assistantTimestamp"] === undefined || typeof value["assistantTimestamp"] === "number")
+    && (value["totalDurationMs"] === undefined || typeof value["totalDurationMs"] === "number")
+    && (value["replyStartDurationMs"] === undefined || typeof value["replyStartDurationMs"] === "number")
+    && (value["status"] === "completed" || value["status"] === "aborted")
+  );
+}
+
+/**
+ * Start or stop the periodic rerender tick.
+ *
+ * We only need live rerenders while timestamps are visible and we have a TUI
+ * handle to refresh.
+ */
+function syncTicker(): void {
+  if (activeTui && visibilityMode === "visible") {
+    if (!tickTimer) {
+      tickTimer = setInterval(() => {
+        activeTui?.requestRender();
+      }, TICK_MS);
+    }
+    return;
+  }
+
+  if (tickTimer) {
+    clearInterval(tickTimer);
+    tickTimer = undefined;
+  }
+}
+
+/**
+ * Clear any queued transcript appends.
+ *
+ * Why: if the extension runtime is torn down during reload or shutdown, we do
+ * not want old scheduled callbacks to append stale timing rows into the next
+ * runtime.
+ */
+function clearPendingAppendTimers(): void {
+  for (const timer of pendingAppendTimers) {
+    clearTimeout(timer);
+  }
+  pendingAppendTimers.clear();
+}
+
+/** Human-readable timezone label for status output. */
+function configuredTimeZoneLabel(): string {
+  if (CONFIGURED_TIME_ZONE) return CONFIGURED_TIME_ZONE;
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "local";
+}
+
+/**
+ * Use formatToParts so we control the final layout ourselves.
+ *
+ * Why: we explicitly do not want the host locale to switch us back to an
+ * American month/day order. We normalize into YYYY-MM-DD HH:mm:ss TZ.
+ */
+function absoluteFormatter(): Intl.DateTimeFormat {
+  return new Intl.DateTimeFormat("en", {
+    timeZone: CONFIGURED_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+    timeZoneName: "short",
+  });
+}
+
+/** Render absolute timestamps in a fixed non-American layout. */
+function formatAbsolute(timestamp: number): string {
+  const parts = absoluteFormatter().formatToParts(new Date(timestamp));
+  const byType = new Map(parts.map((part) => [part.type, part.value]));
+  const year = byType.get("year") ?? "0000";
+  const month = byType.get("month") ?? "00";
+  const day = byType.get("day") ?? "00";
+  const hour = byType.get("hour") ?? "00";
+  const minute = byType.get("minute") ?? "00";
+  const second = byType.get("second") ?? "00";
+  const zone = byType.get("timeZoneName") ?? "";
+  return `${year}-${month}-${day} ${hour}:${minute}:${second}${zone ? ` ${zone}` : ""}`;
+}
+
+/** Convert a timestamp into "just now", "11s ago", "3m ago", etc. */
+function formatRelative(fromTimestamp: number, toTimestamp = Date.now()): string {
+  const diffMs = Math.max(0, toTimestamp - fromTimestamp);
+  const seconds = Math.floor(diffMs / 1_000);
+
+  if (seconds < 5) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+/** Render durations compactly: 4s, 2m 10s, 1h 3m, etc. */
+function formatDuration(durationMs: number): string {
+  const totalSeconds = Math.max(0, Math.round(durationMs / 1_000));
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`;
+}
+
+/** Extract only visible text blocks from a message. */
+function extractText(content: Message["content"] | undefined): string {
+  if (!content) return "";
+  if (typeof content === "string") return content.trim();
+
+  return content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text.trim())
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+}
+
+/**
+ * We only consider an assistant reply to have "started" once visible text has
+ * appeared. Tool calls or thinking-only content should not count as reply-start
+ * timing for the user-facing timestamp row.
+ */
+function messageContainsVisibleAssistantText(message: Message): boolean {
+  if (message.role !== "assistant") return false;
+  return extractText(message.content).length > 0;
+}
+
+/**
+ * Human-readable fallback content stored on the custom message itself.
+ *
+ * The renderer uses `details`, but keeping `content` readable makes session
+ * files easier to inspect manually.
+ */
+function plainSummary(details: TurnTimingDetails): string {
+  const doneText = details.assistantTimestamp
+    ? formatAbsolute(details.assistantTimestamp)
+    : details.status === "aborted"
+      ? "no assistant reply"
+      : "waiting";
+
+  let summary = `Turn timing: user ${formatAbsolute(details.userTimestamp)} -> done ${doneText}`;
+  if (details.totalDurationMs !== undefined) {
+    summary += ` • total ${formatDuration(details.totalDurationMs)}`;
+  }
+  if (details.replyStartDurationMs !== undefined) {
+    summary += ` • reply in ${formatDuration(details.replyStartDurationMs)}`;
+  }
+  return summary;
+}
+
+/**
+ * Build the final subtle transcript row.
+ *
+ * Design goals:
+ * - mostly dim text so it feels smaller/secondary
+ * - highlight only the useful metrics (`reply in`, `total`)
+ * - keep a clear inline shortcut so the user knows it hides the whole timing row
+ */
+function buildTranscriptLine(details: TurnTimingDetails, theme: Theme): string {
+  const separator = theme.fg("dim", " · ");
+  const parts: string[] = [theme.fg("dim", formatAbsolute(details.userTimestamp))];
+
+  if (details.assistantTimestamp !== undefined) {
+    parts.push(`${theme.fg("muted", "done")} ${theme.fg("success", formatAbsolute(details.assistantTimestamp))}`);
+  }
+
+  if (details.replyStartDurationMs !== undefined) {
+    parts.push(`${theme.fg("muted", "reply in")} ${theme.fg("accent", formatDuration(details.replyStartDurationMs))}`);
+  }
+
+  if (details.assistantTimestamp !== undefined) {
+    const total = details.totalDurationMs ?? Math.max(0, details.assistantTimestamp - details.userTimestamp);
+    parts.push(`${theme.fg("muted", "total")} ${theme.fg("accent", formatDuration(total))}`);
+    parts.push(theme.fg("warning", formatRelative(details.assistantTimestamp)));
+  } else {
+    parts.push(theme.fg("warning", "reply incomplete"));
+  }
+
+  if (visibilityMode === "visible") {
+    parts.push(`${theme.fg("dim", "hide row:")} ${theme.fg("muted", TOGGLE_SHORTCUT)}`);
+  }
+
+  return parts.join(separator);
+}
+
+class TurnTimingMessageComponent implements Component {
+  constructor(
+    private readonly details: TurnTimingDetails,
+    private readonly theme: Theme,
+  ) {}
+
+  render(width: number): string[] {
+    /**
+     * Important: existing timing-row components stay mounted after they are
+     * first created. So hiding timestamps must be enforced here at render time,
+     * not only when the renderer initially chooses which component to build.
+     */
+    if (visibilityMode === "hidden") {
+      return [];
+    }
+
+    return wrapTextWithAnsi(buildTranscriptLine(this.details, this.theme), Math.max(1, width));
+  }
+
+  invalidate(): void {}
+}
+
+/**
+ * This component deliberately renders nothing.
+ *
+ * It exists only so the extension has a stable TUI handle (`activeTui`) for
+ * periodic rerenders. Without that, "11s ago" would go stale.
+ */
+class HiddenTickerComponent implements Component {
+  render(_width: number): string[] {
+    return [];
+  }
+
+  invalidate(): void {}
+}
+
+/** Restore visibility mode from the current session branch. */
+function restoreStateFromSession(ctx: ExtensionContext): void {
+  visibilityMode = DEFAULT_VISIBILITY_MODE;
+  currentTurn = undefined;
+
+  for (const entry of ctx.sessionManager.getBranch()) {
+    if (entry.type !== "custom" || entry.customType !== SETTINGS_ENTRY_TYPE || !isRecord(entry.data)) {
+      continue;
+    }
+
+    /**
+     * Backward compatibility:
+     * older session entries stored this under `widgetMode` before we renamed
+     * the field to `visibilityMode` to better reflect what it actually controls.
+     */
+    const maybeMode = entry.data["visibilityMode"] ?? entry.data["widgetMode"];
+    if (isVisibilityMode(maybeMode)) {
+      visibilityMode = maybeMode;
+    }
+  }
+}
+
+/** Persist visible/hidden mode so `/reload` and resumes keep the same state. */
+function persistVisibilityMode(pi: ExtensionAPI, nextMode: VisibilityMode): void {
+  visibilityMode = nextMode;
+  const settings: VisibilitySettings = { visibilityMode: nextMode };
+  pi.appendEntry(SETTINGS_ENTRY_TYPE, settings);
+  syncTicker();
+}
+
+/** Accept a few human-friendly command aliases. */
+function parseVisibilityMode(input: string): VisibilityMode | undefined {
+  if (input === "visible" || input === "hidden") return input;
+  if (input === "on") return "visible";
+  if (input === "off") return "hidden";
+  return undefined;
+}
+
+/**
+ * Queue a timing row after the current run settles.
+ *
+ * We intentionally do not append synchronously inside `agent_end`, because that
+ * can make the row behave like part of the active turn.
+ */
+function scheduleTimingRowAppend(pi: ExtensionAPI, details: TurnTimingDetails): void {
+  /**
+   * `setTimeout(..., 0)` means "run this on the next event-loop turn".
+   *
+   * That tiny delay is intentional. It lets the active agent lifecycle finish
+   * first, then appends the timing row as plain transcript/UI data.
+   */
+  const timer = setTimeout(() => {
+    pendingAppendTimers.delete(timer);
+    pi.sendMessage({
+      customType: TURN_MESSAGE_TYPE,
+      content: plainSummary(details),
+      display: true,
+      details,
+    });
+    activeTui?.requestRender();
+  }, 0);
+
+  pendingAppendTimers.add(timer);
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.registerMessageRenderer(TURN_MESSAGE_TYPE, (message, _options, theme) => {
+    /**
+     * Always return the real timing-row component for timing messages.
+     *
+     * Why:
+     * - timing rows created while hidden should become visible again later
+     * - timing rows created while visible should disappear when hidden
+     *
+     * That means visibility must be checked inside the component's render path,
+     * not here at component-construction time.
+     */
+    if (!isTurnTimingDetails(message.details)) {
+      return new HiddenTickerComponent();
+    }
+    return new TurnTimingMessageComponent(message.details, theme);
+  });
+
+  /**
+   * User command surface.
+   *
+   * Examples:
+   *   /timestamps
+   *   /timestamps visible
+   *   /timestamps hidden
+   *   /timestamps status
+   */
+  pi.registerCommand("timestamps", {
+    description: "Toggle or set Pi timestamps visibility (visible|hidden|status)",
+    handler: async (args, ctx) => {
+      const input = args.trim().toLowerCase();
+      if (input === "status") {
+        ctx.ui.notify(`Pi timestamps: ${visibilityMode} • ${configuredTimeZoneLabel()} • ${TOGGLE_SHORTCUT}`, "info");
+        return;
+      }
+
+      const explicitMode = parseVisibilityMode(input);
+      const nextMode = explicitMode ?? (visibilityMode === "hidden" ? "visible" : "hidden");
+      persistVisibilityMode(pi, nextMode);
+      ctx.ui.notify(`Pi timestamps ${nextMode}`, "info");
+      activeTui?.requestRender();
+    },
+  });
+
+  /**
+   * One-key hide/show for people who want timing only sometimes.
+   *
+   * This is intentionally symmetric:
+   * - visible -> hidden
+   * - hidden  -> visible
+   *
+   * That makes the shortcut easy to memorize and keeps the inline hint honest.
+   */
+  pi.registerShortcut(TOGGLE_SHORTCUT, {
+    description: "Toggle Pi timestamps visibility",
+    handler: async (ctx) => {
+      const nextMode: VisibilityMode = visibilityMode === "hidden" ? "visible" : "hidden";
+      persistVisibilityMode(pi, nextMode);
+      ctx.ui.notify(`Pi timestamps ${nextMode}`, "info");
+      activeTui?.requestRender();
+    },
+  });
+
+  /**
+   * Session startup:
+   * - restore saved visibility
+   * - mount the hidden ticker widget
+   * - start relative-time rerenders when needed
+   */
+  pi.on("session_start", async (_event, ctx) => {
+    restoreStateFromSession(ctx);
+
+    if (ctx.hasUI) {
+      ctx.ui.setWidget(WIDGET_KEY, (tui) => {
+        activeTui = tui;
+        syncTicker();
+        return new HiddenTickerComponent();
+      });
+    }
+  });
+
+  /**
+   * Tear down live UI state cleanly when the session runtime exits.
+   *
+   * This matters most during `/reload`, where old timers from the previous
+   * runtime would otherwise keep firing against the new one.
+   */
+  pi.on("session_shutdown", async () => {
+    activeTui = undefined;
+    currentTurn = undefined;
+    clearPendingAppendTimers();
+    syncTicker();
+  });
+
+  /** Keep timing rows out of model context. They are purely for humans. */
+  pi.on("context", async (event) => {
+    return {
+      messages: event.messages.filter((message) => {
+        if (!isRecord(message)) return true;
+        return message["customType"] !== TURN_MESSAGE_TYPE;
+      }),
+    };
+  });
+
+  /**
+   * Assistant message start gives us a coarse fallback for "reply started".
+   *
+   * This is only a backup. Real `reply in` timing still comes from visible
+   * text events when possible.
+   */
+  pi.on("message_start", async (event) => {
+    if (event.message.role !== "assistant" || !currentTurn) return;
+    if (currentTurn.replyStartTimestamp !== undefined) return;
+
+    /**
+     * Keep updating this fallback until we see real visible text.
+     *
+     * Why: an earlier assistant message may contain only tool calls. If the
+     * later user-visible assistant message does not emit text_start/text_delta
+     * events, we still want a fallback timestamp that is as close as possible
+     * to the start of the visible reply, not the earlier tool-call message.
+     */
+    currentTurn.assistantStartTimestamp = Date.now();
+  });
+
+  pi.on("message_end", async (event) => {
+    /**
+     * The user message ending is our clean "turn start" signal.
+     * We store that timestamp and then wait for assistant activity.
+     */
+    if (event.message.role === "user") {
+      currentTurn = { userTimestamp: event.message.timestamp };
+      return;
+    }
+
+    if (event.message.role !== "assistant" || !currentTurn) return;
+
+    if (!currentTurn.replyStartTimestamp && messageContainsVisibleAssistantText(event.message)) {
+      currentTurn.replyStartTimestamp = currentTurn.assistantStartTimestamp ?? Date.now();
+      currentTurn.replyStartDurationMs = Math.max(0, currentTurn.replyStartTimestamp - currentTurn.userTimestamp);
+    }
+  });
+
+  /**
+   * Streaming text is the best place to capture reply-start timing.
+   *
+   * Best case:
+   *   assistant text_start/text_delta arrives
+   *   -> reply-start timing is exact-ish
+   *
+   * Fallback case:
+   *   provider never emits visible text-start events
+   *   -> we later fall back to assistant message_start timing
+   */
+  pi.on("message_update", async (event) => {
+    if (!currentTurn || event.message.role !== "assistant") return;
+    if (currentTurn.replyStartTimestamp !== undefined) return;
+    if (event.assistantMessageEvent.type !== "text_start" && event.assistantMessageEvent.type !== "text_delta") {
+      return;
+    }
+
+    currentTurn.replyStartTimestamp = Date.now();
+    currentTurn.replyStartDurationMs = Math.max(0, currentTurn.replyStartTimestamp - currentTurn.userTimestamp);
+  });
+
+  /**
+   * At the end of the whole prompt, emit one display-only timing row.
+   *
+   * Important rule:
+   * We only call the turn `completed` if there was user-visible assistant text.
+   * Tool-call-only turns should not pretend they produced a visible reply.
+   *
+   * We use `Date.now()` for the final assistant timestamp because it is the
+   * closest thing to "the visible turn is fully done and back in the user's
+   * hands".
+   */
+  pi.on("agent_end", async (event) => {
+    if (!currentTurn) return;
+
+    const userMessage = event.messages.find((message) => message.role === "user");
+    const assistantMessages = event.messages.filter((message) => message.role === "assistant");
+    const hasVisibleAssistantReply = assistantMessages.some((message) => messageContainsVisibleAssistantText(message));
+    const status: TurnStatus = hasVisibleAssistantReply ? "completed" : "aborted";
+
+    const userTimestamp = userMessage?.timestamp ?? currentTurn.userTimestamp;
+    const assistantTimestamp = status === "completed" ? Date.now() : undefined;
+    const totalDurationMs = assistantTimestamp !== undefined
+      ? Math.max(0, assistantTimestamp - userTimestamp)
+      : undefined;
+
+    const replyStartTimestamp = hasVisibleAssistantReply
+      ? (currentTurn.replyStartTimestamp ?? currentTurn.assistantStartTimestamp)
+      : undefined;
+    const replyStartDurationMs = replyStartTimestamp !== undefined
+      ? Math.max(0, replyStartTimestamp - userTimestamp)
+      : undefined;
+
+    /**
+     * Persist only what the visible transcript row actually renders.
+     *
+     * If future UI needs the absolute reply-start clock time, we can add it
+     * later. For now the smaller payload keeps history cleaner.
+     */
+    const details: TurnTimingDetails = {
+      version: 1,
+      userTimestamp,
+      assistantTimestamp,
+      totalDurationMs,
+      replyStartDurationMs,
+      status,
+    };
+
+    scheduleTimingRowAppend(pi, details);
+
+    currentTurn = undefined;
+    activeTui?.requestRender();
+  });
+}

--- a/pi-packages/pi-timestamps/package.json
+++ b/pi-packages/pi-timestamps/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "pi-timestamps",
+  "version": "0.1.0",
+  "description": "Pi extension that adds subtle per-turn transcript timing rows with exact timestamps, reply-start timing, timezone-aware absolute times, and live relative-time updates.",
+  "keywords": ["pi-package", "timestamps", "observability"],
+  "files": ["extensions/", "README.md"],
+  "pi": {
+    "extensions": ["./extensions/pi-timestamps/index.ts"]
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*",
+    "@mariozechner/pi-tui": "*"
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a new Pi package, `pi-timestamps`, that shows subtle per-turn timing rows in the transcript.

### Key Features

| Feature | Description |
|---------|-------------|
| **Transcript timing rows** | Appends a small timing row after each prompt showing exact timestamps, `reply in`, `total`, and relative age |
| **Low-noise UI** | Keeps timing visible by default but subtle, color-coded, and easy to hide with a shortcut |
| **Session-aware visibility** | Persists visible/hidden state across `/reload` and session resumes |
| **Safe timing append flow** | Avoids feeding timing rows back into the active model run |
| **Package + docs wiring** | Adds the package to the root Pi manifest and updates install/catalog/distribution docs |

## Feature Flow

```text
user prompt ends
     │
     ▼
record prompt timestamp
     │
     ▼
assistant starts / visible text appears
     │
     ├─ exact path: text_start/text_delta seen
     │      └─ capture reply-start timing
     │
     └─ fallback path: no visible text-start event
            └─ use assistant message-start timing
     │
     ▼
turn fully ends
     │
     ▼
defer one event-loop tick
     │
     ▼
append one display-only timing row to transcript
```

## Package Behavior

`pi-timestamps` focuses on user-experience timing rather than model-internal phases.

It shows:
- exact prompt time
- exact completion time
- `reply in <duration>`
- `total <duration>`
- relative age like `11s ago`
- inline hide hint: `hide row: ctrl+shift+h`

It intentionally does **not** add:
- a bottom panel
- a separate dashboard
- explicit thinking-phase metrics
- mutations of Pi's built-in user/assistant bubbles

## Files Changed

<details>
<summary>New package</summary>

- `pi-packages/pi-timestamps/package.json` - package manifest, version, and explicit Pi extension entry
- `pi-packages/pi-timestamps/README.md` - user-facing docs, rationale, testing, and implementation notes
- `pi-packages/pi-timestamps/extensions/pi-timestamps/index.ts` - transcript timing extension implementation

</details>

<details>
<summary>Root + package discovery docs</summary>

- `package.json` - add `pi-timestamps` to root Pi extension discovery
- `README.md` - add package to repo-level Pi package inventory and install docs
- `pi-packages/README.md` - add package to Pi package catalog and structure docs
- `docs/plugins/catalog.md` - add canonical package catalog entry
- `docs/runbooks/distribution.md` - add install/test/distribution guidance for the package

</details>

## How to Test

```bash
jq -e . package.json >/dev/null
jq -e . pi-packages/pi-timestamps/package.json >/dev/null
(cd pi-packages/pi-timestamps && npm pack --dry-run --json >/tmp/pi-timestamps-pack.json)
printf '{"id":"cmds","type":"get_commands"}\n' | PI_OFFLINE=1 pi --mode rpc --no-session --no-context-files --no-extensions -e ./pi-packages/pi-timestamps --no-prompt-templates --no-skills
```

### Manual Testing

1. Start Pi with the package loaded:
   ```bash
   pi --no-extensions -e ./pi-packages/pi-timestamps
   ```
2. Send a prompt and confirm a subtle timing row appears after the reply.
3. Confirm the row shows:
   - exact prompt timestamp
   - exact completion timestamp
   - `reply in ...`
   - `total ...`
   - relative age like `11s ago`
4. Press `Ctrl+Shift+H` and confirm the whole timing row hides.
5. Press `Ctrl+Shift+H` again and confirm timing rows return.
6. Hide timestamps, send prompts, then show them again and confirm hidden-period rows appear correctly.
7. Confirm the assistant does **not** respond to the timing row.

## CI Status

- `Validate Website` passed on this branch.
- `.github/workflows/deploy-website-cloudflare-pages.yml` is failing, but this appears pre-existing and unrelated to this change:
  - the workflow is marked retired in-repo (`if: false`)
  - the failure also appears outside the scope of this package work

## Notes

- No related GitHub issue was found for this work.
- This PR adds a new Pi package and updates the root package manifest so git-based installs discover it automatically.
- Visibility restore is backward-compatible with older session entries that used `widgetMode` before the rename to `visibilityMode`.
