### PR TITLE
fix(pi-timestamps): keep timing rows display-only and restore live relative ages

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ sub-package so pi can discover them from a single clone - see
 | `dev-workflow` | Pi-native daily developer workflow with 15 core workflow prompts, `/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`, XDG/project prompt config, CI analysis, PR review feedback, release PR prep, local skills, optional pi-subagents chain, and default cmux split launching for subagent-style workflow prompts when Pi runs inside cmux |
 | `image-router` | Pi-native image routing extension that describes screenshots and other image inputs with a vision-capable model when the active model is text-only |
 | `oh-my-pi` | Pi-native cmux integration with native cmux notifications (Waiting / Task Complete / Error), readable split pane commands (`/omp-split-*`) and workspace tab commands (`/omp-workspace*`), plus short aliases for faster typing. Low-level cmux primitives are shared via `@diversio/pi-cmux`. Works only inside cmux |
-| `pi-timestamps` | Pi-native subtle transcript timing rows for exact timestamps, reply-start timing, timezone-aware absolute times, and always-updating relative times |
+| `pi-timestamps` | Pi-native subtle transcript timing rows for exact timestamps, reply-start timing, timezone-aware absolute times, and live relative-age labels |
 | `skills-bridge` | Auto-discovers all 21 Claude Code plugin skills from plugins/*/skills/ and registers them as pi skills. One install bridges the gap between the plugin ecosystem and pi |
 
 Helpful mental model:

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -114,7 +114,7 @@ when command files change.
 - `pi-timestamps` (pi package)
   - Purpose: adds subtle per-turn transcript timing rows so Pi sessions show
     exact timestamps, reply-start timing when available, timezone-aware
-    absolute times, and always-updating relative times.
+    absolute times, and live relative-age labels.
   - Pi install from repo checkout:
     `pi install "$PWD/pi-packages/pi-timestamps"`
   - Package path: `pi-packages/pi-timestamps`

--- a/docs/runbooks/distribution.md
+++ b/docs/runbooks/distribution.md
@@ -266,8 +266,8 @@ The `oh-my-pi` package provides explicit `/omp-split-*` and
 `/omp-workspace*` cmux commands plus native cmux notifications.
 
 The `pi-timestamps` package provides `/timestamps`, subtle transcript timing
-rows, timezone-aware absolute timestamps, and always-updating relative times
-like `2m ago`.
+rows, timezone-aware absolute timestamps, and live relative-age labels like
+`2m ago`.
 
 ## Codex Skill Installation
 

--- a/pi-packages/README.md
+++ b/pi-packages/README.md
@@ -10,7 +10,7 @@ Pi-native packages that extend pi with tools, commands, skills, and UI widgets.
 | [`dev-workflow`](./dev-workflow) | 15 core workflow prompts (`/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`), CI analysis, PR review feedback, release PR prep, local skills, optional pi-subagents chain, and seeded cmux split launching for subagent-style prompts |
 | [`image-router`](./image-router) | Routes image inputs through a vision-capable model when the active model is text-only, with per-model routing modes and a TUI settings panel |
 | [`oh-my-pi`](./oh-my-pi) | Pi-native cmux integration with notifications, readable split commands, and workspace tabs |
-| [`pi-timestamps`](./pi-timestamps) | Adds subtle per-turn transcript timing rows for exact timestamps, reply-start timing, timezone-aware absolute times, and always-updating relative times |
+| [`pi-timestamps`](./pi-timestamps) | Adds subtle per-turn transcript timing rows for exact timestamps, reply-start timing, timezone-aware absolute times, and live relative-age labels |
 | [`skills-bridge`](./skills-bridge) | Auto-discovers all 21 Claude Code plugin skills from `plugins/*/skills/` and registers them as pi skills — one install bridges the entire plugin ecosystem into pi |
 
 ## Install

--- a/pi-packages/pi-timestamps/README.md
+++ b/pi-packages/pi-timestamps/README.md
@@ -30,7 +30,7 @@ Current highlighting:
 
 - completion time uses a success color
 - `reply in` and `total` values use an accent color
-- relative age like `11s ago` uses a warning color
+- live relative age like `11s ago` uses a warning color
 - the hide shortcut stays dimmer than the timing data
 
 Labeling note:
@@ -92,11 +92,21 @@ The current design aims for:
 
 ### Why is there still a hidden widget internally?
 
-Relative text like `11s ago` needs the TUI to re-render periodically.
 The extension mounts a **zero-height hidden widget** only so it can keep a TUI
-handle and refresh those relative timestamps once per second.
+handle and request rerenders after timing rows are appended or visibility is
+toggled.
 
-Users do not see that widget.
+Users do not see that widget. The extension uses it to keep `... ago` honest:
+relative ages should update on their own, not only when the user starts typing.
+
+To reduce selection/copying pain, the ticker is adaptive instead of repainting
+once per second forever:
+
+```text
+first minute  -> update every second  -> 11s ago, 12s ago, ...
+first hour    -> update every minute  -> 2m ago, 3m ago, ...
+after that    -> update hourly        -> 2h ago, 1d ago change slowly
+```
 
 ## What gets shown
 
@@ -107,7 +117,7 @@ Each timing row can show:
 - reply-start timing when visible text appeared
 - fallback assistant-start timing if the provider does not emit a text-start event
 - total turn duration
-- relative age like `11s ago`
+- live relative age like `11s ago`
 - inline "hide row" shortcut text
 
 Visual map:
@@ -115,7 +125,7 @@ Visual map:
 ```text
 2026-06-02 19:18:01 EDT · done 2026-06-02 19:18:08 EDT · reply in 3s · total 7s · 11s ago · hide row: ctrl+shift+h
 │                        │                              │             │          │          └─ quick hide-row hint
-│                        │                              │             │          └─ relative age, kept live
+│                        │                              │             │          └─ live relative age, refreshed by the adaptive ticker
 │                        │                              │             └─ full turn duration
 │                        │                              └─ time until the reply became visible
 │                        └─ exact completion time
@@ -247,14 +257,79 @@ Then run `/reload` in Pi.
 Optional environment variables:
 
 ```bash
+# Render absolute times in a known timezone instead of the machine default.
 export PI_TIMESTAMPS_TIME_ZONE="America/Toronto"
+
+# Change the hide/show shortcut and the inline hint text.
 export PI_TIMESTAMPS_TOGGLE_SHORTCUT="ctrl+shift+h"
+
+# Optional stable/copy mode: hide `... ago` and disable the relative-age ticker.
+export PI_TIMESTAMPS_LIVE_RELATIVE="false"
 ```
 
 Notes:
 
 - If `PI_TIMESTAMPS_TIME_ZONE` is unset, the extension uses your local system timezone.
 - `PI_TIMESTAMPS_TOGGLE_SHORTCUT` changes both the registered shortcut and the inline hint text.
+- `PI_TIMESTAMPS_LIVE_RELATIVE=false` disables `... ago` labels and the relative-age ticker for a maximally stable transcript.
+
+Relative-age tradeoff:
+
+```text
+show `11s ago`
+        ↓
+must update without waiting for typing/scrolling
+        ↓
+requires terminal redraws
+        ↓
+use adaptive redraws so the label stays honest without repainting every second forever
+```
+
+Adaptive ticker mental model:
+
+```text
+newest timestamp row is 0-59s old
+        ↓
+relative label can change every second
+        ↓
+ticker wakes every 1s
+
+newest timestamp row is 1-59m old
+        ↓
+relative label can change every minute
+        ↓
+ticker wakes every 1m
+
+newest timestamp row is 1h+ old
+        ↓
+relative label changes slowly
+        ↓
+ticker wakes hourly
+```
+
+Why use the newest row?
+
+```text
+newest row changes fastest
+        ↓
+older rows are already less granular
+        ↓
+if the newest row is safe at a cadence, older rows are safe too
+        ↓
+one timer is enough for the whole transcript
+```
+
+Stable/copy mode tradeoff:
+
+```text
+PI_TIMESTAMPS_LIVE_RELATIVE=false
+        ↓
+no relative `... ago` label
+        ↓
+no ticker-driven transcript redraws
+        ↓
+exact prompt/completion timestamps still remain visible
+```
 
 ## Local testing
 
@@ -271,10 +346,20 @@ Suggested smoke test:
 2. Send a prompt
 3. Confirm a subtle timing row appears immediately after the turn
 4. Confirm `done`, `reply in`, `total`, and `11s ago` are easy to spot
-5. Press Ctrl+Shift+H
-6. Confirm timing rows disappear
-7. Press Ctrl+Shift+H again
-8. Confirm timing rows return
+5. Wait without typing and confirm `11s ago` updates on its own
+6. Press Ctrl+Shift+H
+7. Confirm timing rows disappear
+8. Press Ctrl+Shift+H again
+9. Confirm timing rows return
+```
+
+Stable/copy mode smoke test:
+
+```text
+1. Restart Pi with PI_TIMESTAMPS_LIVE_RELATIVE=false
+2. Send a prompt
+3. Confirm the row still shows exact times, `reply in`, and `total`
+4. Confirm `... ago` is hidden and no ticker-driven redraws happen
 ```
 
 Provider-behavior smoke test:
@@ -300,14 +385,66 @@ Here is the simple why behind each one.
 Why it exists:
 
 ```text
-relative age text changes over time
+timing rows are appended after the agent returns to idle
         ↓
-UI must rerender periodically
+visibility can be toggled later
         ↓
-extension needs a stable TUI handle
+`... ago` needs occasional redraws to stay honest
         ↓
-hidden widget keeps that handle alive
+extension needs a stable TUI handle to request rerenders
+        ↓
+hidden widget keeps that handle available
 ```
+
+Why it renders nothing:
+
+```text
+widget exists for a TUI handle, not user content
+        ↓
+render() returns []
+        ↓
+no bottom panel, no visual noise
+        ↓
+transcript rows remain the only visible UI
+```
+
+### Adaptive relative-age ticker
+
+The relative label is useful only when it updates by itself.
+
+```text
+bad behavior
+  `11s ago` sits still
+  user starts typing
+  label jumps to `2m ago`
+  -> looks stale and misleading
+
+good behavior
+  `11s ago` updates on its own
+  redraw cadence slows as the label becomes less precise
+  -> truthful without constant repainting forever
+```
+
+The implementation tracks `latestRelativeTimestamp`:
+
+```text
+new row appended
+        ↓
+latestRelativeTimestamp = row completion time
+        ↓
+restartTicker()
+        ↓
+nextTickerDelayMs() chooses 1s / 1m / 1h cadence
+```
+
+Stable/copy mode disables this entire path:
+
+```bash
+export PI_TIMESTAMPS_LIVE_RELATIVE=false
+```
+
+In that mode exact absolute timestamps remain visible, but `... ago` is hidden
+so the transcript does not repaint just for timestamp freshness.
 
 ### Deferred timing-row append
 
@@ -318,18 +455,108 @@ append too early
   -> row can behave like part of the active model turn
   -> assistant may appear to reply to it
 
-append one event-loop tick later
+wait until Pi reports idle, then append with triggerTurn: false
   -> current run settles first
-  -> row still appears immediately to the user
+  -> row appears without queueing a steering/follow-up LLM turn
+```
+
+The important Pi behavior is:
+
+```text
+inside agent_end
+        ↓
+Pi is still streaming
+        ↓
+pi.sendMessage(...) uses the streaming path
+        ↓
+default streaming delivery is "steer"
+        ↓
+the LLM may continue and respond to the timing row
+```
+
+So the extension uses this safer shape:
+
+```text
+agent_end computes timing data
+        ↓
+schedule a tiny callback
+        ↓
+callback polls ctx.isIdle()
+        ↓
+only when idle: pi.sendMessage(..., { triggerTurn: false })
+        ↓
+row is saved/rendered, but no LLM turn starts
 ```
 
 In code, that is this pattern:
 
 ```ts
-setTimeout(() => {
-  pi.sendMessage({ ...timingRow });
-}, 0);
+const deadline = Date.now() + 10 * 60 * 1_000;
+const appendWhenIdle = () => {
+  if (!runtimeActive) return;
+
+  if (!ctx.isIdle()) {
+    if (Date.now() < deadline) setTimeout(appendWhenIdle, 50);
+    return;
+  }
+
+  if (!runtimeActive) return;
+  pi.sendMessage({ ...timingRow }, { triggerTurn: false });
+};
+setTimeout(appendWhenIdle, 0);
 ```
+
+Why the 10 minute deadline?
+
+```text
+normal case: Pi becomes idle almost immediately
+edge case: another extension opens post-turn UI and waits for a human
+bad case: Pi gets stuck streaming forever
+
+10 minute cap
+  -> does not drop rows during normal human-paced post-turn UI
+  -> still prevents an infinite timer loop if something breaks
+```
+
+Why `runtimeActive`?
+
+```text
+old runtime schedules callback
+        ↓
+user runs /reload or switches sessions
+        ↓
+old runtime shuts down
+        ↓
+old callback wakes up later
+        ↓
+runtimeActive=false, so it exits without writing stale rows
+```
+
+### Why not `deliverAs: "nextTurn"`?
+
+`nextTurn` sounds tempting, but it means something different in Pi:
+
+```text
+deliverAs: "nextTurn"
+        ↓
+wait for the next user prompt
+        ↓
+inject the custom message alongside that prompt
+        ↓
+the timestamp becomes next-turn context, not an immediate transcript row
+```
+
+For timestamps we want:
+
+```text
+current turn finishes
+        ↓
+append display-only transcript row now
+        ↓
+do not start or steer the LLM
+```
+
+That is why the extension waits for idle and uses `{ triggerTurn: false }`.
 
 ### Backward-compatible visibility restore
 
@@ -350,10 +577,11 @@ We read both so existing sessions do not lose their saved hide/show state.
 ## Notes for maintainers
 
 - Timing rows are stored as display-only custom messages and filtered out of LLM context.
-- Timing rows are appended with a tiny deferred `pi.sendMessage(...)` call after the current run settles, so they still appear in the live transcript without being treated as part of the active model turn.
+- Timing rows are appended only after `ctx.isIdle()` is true, with `{ triggerTurn: false }`, so they do not get delivered as steering messages during the active model turn.
 - Visibility mode is stored as a session custom entry, so `/reload` preserves it inside the current session branch.
-- Relative-time updates depend on a lightweight 1s TUI re-render tick.
-- The hidden zero-height widget exists only to keep that re-render loop alive.
+- Relative-time live updates are enabled by default and use an adaptive ticker: every second for fresh rows, every minute after the first minute, hourly after the first hour.
+- `PI_TIMESTAMPS_LIVE_RELATIVE=false` hides `... ago` and disables ticker-driven redraws for stable/copy mode.
+- The hidden zero-height widget exists only to keep a TUI handle for timestamp-row rerenders.
 
 Troubleshooting map:
 
@@ -362,18 +590,34 @@ No timing row appears
   -> check timestamps are visible
   -> run /timestamps status
   -> verify the package is loaded with pi --no-extensions -e ./pi-packages/pi-timestamps
+  -> if another extension held Pi non-idle for >10 minutes, the row is intentionally dropped
 
 Assistant seems to respond to the timing row
   -> timing row append is happening too early in the active run
   -> inspect scheduleTimingRowAppend()
+  -> confirm the append path waits for ctx.isIdle()
+  -> confirm sendMessage uses { triggerTurn: false }
+
+No "11s ago" label appears
+  -> check PI_TIMESTAMPS_LIVE_RELATIVE is not set to false/off/0/no
+  -> exact prompt and completion timestamps are still shown
 
 Rows stop updating "11s ago"
   -> inspect the hidden widget mount
   -> inspect syncTicker()
+  -> remember updates become minute-based after the first minute
+
+Rows are hard to copy/select around
+  -> set PI_TIMESTAMPS_LIVE_RELATIVE=false for stable/copy mode
+  -> or use /timestamps hidden for a clean transcript
 
 Rows do not preserve hidden/visible state after /reload
   -> inspect restoreStateFromSession()
   -> inspect persistVisibilityMode()
+
+Rows appear after /reload from an old turn
+  -> inspect runtimeActive guards in scheduleTimingRowAppend()
+  -> inspect clearPendingAppendTimers()
 ```
 
 Code-reading map:
@@ -383,7 +627,7 @@ restoreStateFromSession()
   -> load visible/hidden mode from session
 
 syncTicker()
-  -> start/stop the 1s relative-time rerender loop
+  -> start/stop the adaptive relative-time rerender loop
 
 message_end(role=user)
   -> start the turn clock
@@ -401,5 +645,7 @@ agent_end()
 
 scheduleTimingRowAppend()
   -> defer one tick
-  -> append the display-only timing row safely
+  -> wait for ctx.isIdle()
+  -> guard against old runtimes with runtimeActive
+  -> append the display-only timing row safely with triggerTurn: false
 ```

--- a/pi-packages/pi-timestamps/extensions/pi-timestamps/index.ts
+++ b/pi-packages/pi-timestamps/extensions/pi-timestamps/index.ts
@@ -55,9 +55,9 @@
  *
  * Why is there a hidden widget if there is no visible bottom panel?
  * ---------------------------------------------------------------
- * Relative strings like "11s ago" only stay fresh if the TUI rerenders.
- * We mount a zero-height hidden widget purely so we can keep a TUI handle and
- * request those rerenders once per second while timestamps are visible.
+ * The zero-height hidden widget keeps a TUI handle so we can request a rerender
+ * after appending/toggling timestamp rows and keep `... ago` honest. The ticker
+ * is adaptive: quick updates while a row is new, slower updates after that.
  */
 
 import type { Message } from "@mariozechner/pi-ai";
@@ -84,17 +84,64 @@ const SETTINGS_ENTRY_TYPE = "pi-timestamps-settings";
  * Hidden widget key.
  *
  * The widget renders nothing. Its only job is to keep a live TUI handle around
- * so relative times can keep updating.
+ * so the extension can request rerenders after rows are appended/toggled.
  */
 const WIDGET_KEY = "pi-timestamps";
 
 /**
  * Re-render cadence for relative timestamps.
  *
- * One second is frequent enough to keep "11s ago" feeling live without making
- * the UI noisy or wasteful.
+ * `11s ago` is only useful if it is true. So live relative updates are enabled
+ * by default, but the ticker is adaptive so it does not repaint forever every
+ * second:
+ *
+ * - under 1 minute old: update every second (`11s ago`, `12s ago`, ...)
+ * - under 1 hour old: update every minute (`2m ago`, `3m ago`, ...)
+ * - older: update hourly (`2h ago`, `1d ago` change slowly)
  */
-const TICK_MS = 1_000;
+const SECOND_MS = 1_000;
+const MINUTE_MS = 60 * SECOND_MS;
+const HOUR_MS = 60 * MINUTE_MS;
+
+/**
+ * Live relative-age updates are enabled unless explicitly disabled.
+ *
+ * First principles:
+ * - If we show `11s ago`, it must keep moving without waiting for the user to
+ *   type, scroll, or otherwise cause a redraw.
+ * - Repainting every second forever makes copying harder.
+ * - Adaptive repainting keeps the label honest while reducing redraws after the
+ *   label naturally becomes less granular.
+ *
+ * Users who strongly prefer a fully stable transcript can disable the relative
+ * label and ticker with:
+ *
+ *   export PI_TIMESTAMPS_LIVE_RELATIVE="false"
+ */
+const LIVE_RELATIVE_UPDATES = !["0", "false", "no", "off"].includes(
+  process.env.PI_TIMESTAMPS_LIVE_RELATIVE?.trim().toLowerCase() ?? "",
+);
+
+/**
+ * Poll briefly after agent_end until Pi has fully returned to idle.
+ *
+ * Why polling at all?
+ * Pi emits `agent_end` before the run is fully idle. If we append a custom
+ * message during that window, Pi treats it as a steering/follow-up message and
+ * may ask the LLM to continue. Waiting for idle keeps this row display-only.
+ */
+const IDLE_APPEND_POLL_MS = 50;
+
+/**
+ * Safety cap so a stuck streaming state cannot leave a timer loop running
+ * forever.
+ *
+ * Keep this long enough for other `agent_end` extensions that may show post-turn
+ * UI and wait for a human before Pi becomes idle. If Pi is still not idle after
+ * this window, dropping one timing row is safer than leaking timers or nudging
+ * the model with a queued message.
+ */
+const MAX_IDLE_APPEND_WAIT_MS = 10 * 60 * 1_000;
 
 /** Timestamps are visible by default unless the session says otherwise. */
 const DEFAULT_VISIBILITY_MODE: VisibilityMode = "visible";
@@ -161,7 +208,28 @@ type LiveTurn = {
 let visibilityMode: VisibilityMode = DEFAULT_VISIBILITY_MODE;
 let currentTurn: LiveTurn | undefined;
 let activeTui: TUI | undefined;
-let tickTimer: ReturnType<typeof setInterval> | undefined;
+let tickTimer: ReturnType<typeof setTimeout> | undefined;
+
+/**
+ * Newest completion timestamp among rendered timing rows.
+ *
+ * The adaptive ticker only needs the newest row because it is the fastest-moving
+ * relative label. If the newest row only needs minute-level updates, all older
+ * rows are safe at that cadence too.
+ *
+ * Empty sessions intentionally leave this undefined so the hidden widget does
+ * not schedule pointless redraws before any timing row exists.
+ */
+let latestRelativeTimestamp: number | undefined;
+
+/**
+ * Whether this extension runtime is still allowed to append rows.
+ *
+ * A delayed idle-poll callback can outlive `/reload` or session shutdown. This
+ * flag gives those callbacks a simple, explicit exit path so an old runtime
+ * cannot write stale timestamp rows into a new session/runtime.
+ */
+let runtimeActive = false;
 
 /**
  * Timers waiting to append timing rows after the current turn settles.
@@ -194,26 +262,66 @@ function isTurnTimingDetails(value: unknown): value is TurnTimingDetails {
   );
 }
 
+function nextTickerDelayMs(): number {
+  const timestamp = latestRelativeTimestamp;
+  if (timestamp === undefined) return MINUTE_MS;
+
+  const ageMs = Math.max(0, Date.now() - timestamp);
+
+  /**
+   * Match the visible precision of formatRelative():
+   *
+   *   just now / 11s ago  -> can change every second
+   *   2m ago              -> can change every minute
+   *   2h ago / 1d ago     -> hourly is enough for a subtle transcript row
+   */
+  if (ageMs < MINUTE_MS) return SECOND_MS;
+  if (ageMs < HOUR_MS) return MINUTE_MS;
+  return HOUR_MS;
+}
+
+function clearTicker(): void {
+  if (tickTimer) {
+    clearTimeout(tickTimer);
+    tickTimer = undefined;
+  }
+}
+
 /**
- * Start or stop the periodic rerender tick.
+ * Start or stop the adaptive rerender tick.
  *
- * We only need live rerenders while timestamps are visible and we have a TUI
- * handle to refresh.
+ * Why adaptive?
+ *
+ *   11s ago  -> changes every second, so update every second
+ *   12m ago  -> changes every minute, so update every minute
+ *   2h ago   -> changes hourly, so hourly is enough
+ *
+ * This keeps the `... ago` text truthful without repainting the whole transcript
+ * every second forever.
  */
 function syncTicker(): void {
-  if (activeTui && visibilityMode === "visible") {
-    if (!tickTimer) {
-      tickTimer = setInterval(() => {
-        activeTui?.requestRender();
-      }, TICK_MS);
-    }
+  if (!LIVE_RELATIVE_UPDATES || !activeTui || visibilityMode !== "visible" || latestRelativeTimestamp === undefined) {
+    clearTicker();
     return;
   }
 
-  if (tickTimer) {
-    clearInterval(tickTimer);
+  if (tickTimer) return;
+
+  tickTimer = setTimeout(() => {
     tickTimer = undefined;
-  }
+    activeTui?.requestRender();
+    syncTicker();
+  }, nextTickerDelayMs());
+}
+
+function restartTicker(): void {
+  /**
+   * A newly appended row may need second-level updates even if an older row had
+   * already slowed the ticker to minute/hour cadence. Restarting recalculates
+   * from the fresh latestRelativeTimestamp immediately.
+   */
+  clearTicker();
+  syncTicker();
 }
 
 /**
@@ -371,7 +479,10 @@ function buildTranscriptLine(details: TurnTimingDetails, theme: Theme): string {
   if (details.assistantTimestamp !== undefined) {
     const total = details.totalDurationMs ?? Math.max(0, details.assistantTimestamp - details.userTimestamp);
     parts.push(`${theme.fg("muted", "total")} ${theme.fg("accent", formatDuration(total))}`);
-    parts.push(theme.fg("warning", formatRelative(details.assistantTimestamp)));
+
+    if (LIVE_RELATIVE_UPDATES) {
+      parts.push(theme.fg("warning", formatRelative(details.assistantTimestamp)));
+    }
   } else {
     parts.push(theme.fg("warning", "reply incomplete"));
   }
@@ -409,7 +520,7 @@ class TurnTimingMessageComponent implements Component {
  * This component deliberately renders nothing.
  *
  * It exists only so the extension has a stable TUI handle (`activeTui`) for
- * periodic rerenders. Without that, "11s ago" would go stale.
+ * explicit rerenders after appends/toggles and adaptive live relative updates.
  */
 class HiddenTickerComponent implements Component {
   render(_width: number): string[] {
@@ -429,20 +540,29 @@ class HiddenTickerComponent implements Component {
 function restoreStateFromSession(ctx: ExtensionContext): void {
   visibilityMode = DEFAULT_VISIBILITY_MODE;
   currentTurn = undefined;
+  latestRelativeTimestamp = undefined;
 
   for (const entry of ctx.sessionManager.getBranch()) {
-    if (entry.type !== "custom" || entry.customType !== SETTINGS_ENTRY_TYPE || !isRecord(entry.data)) {
+    if (entry.type === "custom" && entry.customType === SETTINGS_ENTRY_TYPE && isRecord(entry.data)) {
+      /**
+       * Backward compatibility:
+       * older session entries stored this under `widgetMode` before we renamed
+       * the field to `visibilityMode` to better reflect what it actually controls.
+       */
+      const maybeMode = entry.data["visibilityMode"] ?? entry.data["widgetMode"];
+      if (isVisibilityMode(maybeMode)) {
+        visibilityMode = maybeMode;
+      }
       continue;
     }
 
     /**
-     * Backward compatibility:
-     * older session entries stored this under `widgetMode` before we renamed
-     * the field to `visibilityMode` to better reflect what it actually controls.
+     * On resume/reload, existing rows may already show `... ago`. Restore the
+     * newest completed timestamp so the adaptive ticker can keep those labels
+     * moving without waiting for a brand-new turn.
      */
-    const maybeMode = entry.data["visibilityMode"] ?? entry.data["widgetMode"];
-    if (isVisibilityMode(maybeMode)) {
-      visibilityMode = maybeMode;
+    if (entry.type === "custom_message" && entry.customType === TURN_MESSAGE_TYPE && isTurnTimingDetails(entry.details)) {
+      latestRelativeTimestamp = entry.details.assistantTimestamp ?? latestRelativeTimestamp;
     }
   }
 }
@@ -476,25 +596,73 @@ function parseVisibilityMode(input: string): VisibilityMode | undefined {
 /**
  * Queue a timing row after the current run settles.
  *
- * We intentionally do not append synchronously inside `agent_end`, because that
- * can make the row behave like part of the active turn.
+ * Important Pi behavior:
+ *
+ *   inside agent_end
+ *         ↓
+ *   Pi is still streaming
+ *         ↓
+ *   pi.sendMessage(...) defaults to "steer"
+ *         ↓
+ *   queued custom message can cause another LLM continuation
+ *
+ * That is exactly the bug this helper avoids. We wait until `ctx.isIdle()` is
+ * true, then append with `{ triggerTurn: false }` so the row is just transcript
+ * UI and not work for the model.
+ *
+ * The runtimeActive checks protect `/reload` and shutdown:
+ *
+ *   old runtime schedules callback
+ *         ↓
+ *   /reload tears old runtime down
+ *         ↓
+ *   callback wakes up later
+ *         ↓
+ *   runtimeActive=false, so it exits without appending stale rows
  */
-function scheduleTimingRowAppend(pi: ExtensionAPI, details: TurnTimingDetails): void {
-  /**
-   * `setTimeout(..., 0)` means "run this on the next event-loop turn".
-   *
-   * That tiny delay is intentional. It lets the active agent lifecycle finish
-   * first, then appends the timing row as plain transcript/UI data.
-   */
+function scheduleTimingRowAppend(pi: ExtensionAPI, ctx: ExtensionContext, details: TurnTimingDetails): void {
+  const deadline = Date.now() + MAX_IDLE_APPEND_WAIT_MS;
+
+  const appendWhenIdle = () => {
+    if (!runtimeActive) {
+      return;
+    }
+
+    if (!ctx.isIdle()) {
+      if (Date.now() >= deadline) {
+        return;
+      }
+
+      const nextTimer = setTimeout(() => {
+        pendingAppendTimers.delete(nextTimer);
+        appendWhenIdle();
+      }, IDLE_APPEND_POLL_MS);
+      pendingAppendTimers.add(nextTimer);
+      return;
+    }
+
+    if (!runtimeActive) {
+      return;
+    }
+
+    pi.sendMessage(
+      {
+        customType: TURN_MESSAGE_TYPE,
+        content: plainSummary(details),
+        display: true,
+        details,
+      },
+      { triggerTurn: false },
+    );
+
+    latestRelativeTimestamp = details.assistantTimestamp ?? latestRelativeTimestamp;
+    restartTicker();
+    activeTui?.requestRender();
+  };
+
   const timer = setTimeout(() => {
     pendingAppendTimers.delete(timer);
-    pi.sendMessage({
-      customType: TURN_MESSAGE_TYPE,
-      content: plainSummary(details),
-      display: true,
-      details,
-    });
-    activeTui?.requestRender();
+    appendWhenIdle();
   }, 0);
 
   pendingAppendTimers.add(timer);
@@ -570,6 +738,7 @@ export default function (pi: ExtensionAPI) {
    * - start relative-time rerenders when needed
    */
   pi.on("session_start", async (_event, ctx) => {
+    runtimeActive = true;
     restoreStateFromSession(ctx);
 
     if (ctx.hasUI) {
@@ -588,6 +757,7 @@ export default function (pi: ExtensionAPI) {
    * runtime would otherwise keep firing against the new one.
    */
   pi.on("session_shutdown", async () => {
+    runtimeActive = false;
     activeTui = undefined;
     currentTurn = undefined;
     clearPendingAppendTimers();
@@ -680,7 +850,7 @@ export default function (pi: ExtensionAPI) {
    * closest thing to "the visible turn is fully done and back in the user's
    * hands".
    */
-  pi.on("agent_end", async (event) => {
+  pi.on("agent_end", async (event, ctx) => {
     /**
      * No `currentTurn` means we have nothing to measure.
      * This can happen if the runtime resumed mid-conversation or if a command
@@ -721,7 +891,7 @@ export default function (pi: ExtensionAPI) {
       status,
     };
 
-    scheduleTimingRowAppend(pi, details);
+    scheduleTimingRowAppend(pi, ctx, details);
 
     currentTurn = undefined;
     activeTui?.requestRender();

--- a/pi-packages/pi-timestamps/package.json
+++ b/pi-packages/pi-timestamps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-timestamps",
-  "version": "0.1.0",
-  "description": "Pi extension that adds subtle per-turn transcript timing rows with exact timestamps, reply-start timing, timezone-aware absolute times, and live relative-time updates.",
+  "version": "0.1.1",
+  "description": "Pi extension that adds subtle per-turn transcript timing rows with exact timestamps, reply-start timing, timezone-aware absolute times, and live relative-age labels.",
   "keywords": ["pi-package", "timestamps", "observability"],
   "files": ["extensions/", "README.md"],
   "pi": {

--- a/website/src/data/marketplace.json
+++ b/website/src/data/marketplace.json
@@ -309,8 +309,8 @@
     {
       "name": "pi-timestamps",
       "title": "Pi Timestamps",
-      "description": "Subtle per-turn transcript timing rows for exact timestamps, reply-start timing, timezone-aware absolute times, and live relative-time updates.",
-      "version": "v0.1.0"
+      "description": "Subtle per-turn transcript timing rows for exact timestamps, reply-start timing, timezone-aware absolute times, and live relative-age labels.",
+      "version": "v0.1.1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

This PR fixes `pi-timestamps` so timing rows remain display-only transcript UI instead of accidentally steering the LLM, while keeping `... ago` labels truthful with an adaptive rerender ticker.

### Key Changes

| Area | Change |
|---|---|
| **Display-only append safety** | Defers timestamp-row `sendMessage` until Pi reports `ctx.isIdle()`, then appends with `{ triggerTurn: false }`. |
| **Adaptive `... ago` updates** | Replaces forever-1s redraws with cadence based on the newest row: 1s for fresh rows, 1m for rows under an hour, hourly after that. |
| **Reload/shutdown safety** | Adds `runtimeActive` guards and timer cleanup so old runtime callbacks cannot append stale rows after `/reload`. |
| **Stable/copy mode** | Adds `PI_TIMESTAMPS_LIVE_RELATIVE=false` to hide `... ago` and disable ticker-driven redraws for maximally stable terminal copying. |
| **Package metadata** | Bumps `pi-timestamps` from `0.1.0` to `0.1.1` and syncs marketplace / docs descriptions. |

## Problem

The shipped timestamp row used `pi.sendMessage()` from `agent_end`.

Pi still considers the agent streaming while `agent_end` handlers run, so `sendMessage()` can take the streaming `steer` path and trigger an extra LLM continuation.

```text
inside agent_end
        ↓
Pi is still streaming
        ↓
pi.sendMessage(...) defaults to "steer"
        ↓
queued custom message can cause another LLM continuation
```

Separately, the original always-1s rerender loop kept `11s ago` live, but it also repainted the transcript forever every second, which likely made mouse selection / copying harder.

## Solution

### 1. Append timing rows only after idle

The extension now computes timing details in `agent_end`, then waits until `ctx.isIdle()` is true before appending the row.

```text
agent_end computes timing data
        ↓
schedule tiny callback
        ↓
callback polls ctx.isIdle()
        ↓
only when idle: pi.sendMessage(..., { triggerTurn: false })
        ↓
row is saved/rendered, but no LLM turn starts
```

### 2. Keep `... ago`, but stop repainting forever every second

We keep relative-age labels by default, but make the ticker adaptive:

```text
newest row is 0-59s old
        ↓
update every second

newest row is 1-59m old
        ↓
update every minute

newest row is 1h+ old
        ↓
update hourly
```

This preserves the useful `... ago` label while reducing redraw pressure after the row becomes less granular.

### 3. Add stable/copy mode

For users who want a maximally stable transcript:

```bash
export PI_TIMESTAMPS_LIVE_RELATIVE=false
```

That hides `... ago` and disables ticker-driven rerenders, while keeping exact prompt/completion timestamps, `reply in`, and `total`.

### 4. Guard reload / shutdown edges

The extension now tracks `runtimeActive` and clears pending timers so an old runtime cannot wake up later and append stale rows after `/reload`.

```text
old runtime schedules callback
        ↓
user runs /reload
        ↓
old runtime shuts down
        ↓
old callback wakes up later
        ↓
runtimeActive=false, so it exits safely
```

## Files Changed

<details>
<summary>Extension + package docs</summary>

- `pi-packages/pi-timestamps/extensions/pi-timestamps/index.ts` — idle-safe append, adaptive ticker, reload/shutdown guards, expanded documentation
- `pi-packages/pi-timestamps/README.md` — first-principles docs, visual diagrams, config and troubleshooting updates
- `pi-packages/pi-timestamps/package.json` — version bump + description refresh

</details>

<details>
<summary>Marketplace/catalog metadata</summary>

- `website/src/data/marketplace.json`
- `README.md`
- `pi-packages/README.md`
- `docs/plugins/catalog.md`
- `docs/runbooks/distribution.md`

</details>

## Engineering Website Note

The engineering website renders this package from ASM content and copied marketplace metadata.

For this change:

- ASM is the source of truth and is updated in this PR.
- `engineering-website/src/data/marketplace.json` is an ignored copied artifact, not tracked source.
- I locally copied ASM metadata into `engineering-website/src/data/marketplace.json` and built the site successfully to verify `/pi/pi-timestamps/` and `/docs/pi-timestamps/` render the new content.

Recommended ship order:

```text
1. Merge this ASM PR
2. Let ASM trigger the engineering-website deploy (repository_dispatch)
3. Optionally update engineering-website/agent-skills-source.ref in a separate PR if we want to pin that merged SHA as the default website build source
4. Update monolith submodule pointers last, if needed
```

## Validation

### ASM checks run

```bash
git -C agent-skills-marketplace diff --check
jq -e . pi-packages/pi-timestamps/package.json >/dev/null
jq -e . website/src/data/marketplace.json >/dev/null
(cd pi-packages/pi-timestamps && npm pack --dry-run --json)
bash scripts/validate-skills.sh
pi --no-extensions -e ./pi-packages/pi-timestamps --list-models
```

### Engineering website verification run

```bash
cp ../agent-skills-marketplace/website/src/data/marketplace.json src/data/marketplace.json
AGENT_SKILLS_REPO_DIR=../agent-skills-marketplace npm run build
```

## CI status

Current branch push only shows a failure from ASM's retired `.github/workflows/deploy-website-cloudflare-pages.yml` workflow.

That failure is **not caused by this code**:
- the workflow is already marked `if: false` / retired
- it reports no jobs
- deploy ownership has moved to `engineering-website`

So the observed failure is pre-existing / expected workflow noise, not a product-code regression from this PR.

## Notes

- No tracked `engineering-website` source files needed changes for this content update.
- No schema changes.
- No tests were added because this package is a Pi extension + docs/metadata change.
