### PR TITLE
Redesign pi-timestamps status UX and avoid transcript rerender churn

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ sub-package so pi can discover them from a single clone - see
 | `dev-workflow` | Pi-native daily developer workflow with 15 core workflow prompts, `/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`, XDG/project prompt config, CI analysis, PR review feedback, release PR prep, local skills, optional pi-subagents chain, and default cmux split launching for subagent-style workflow prompts when Pi runs inside cmux |
 | `image-router` | Pi-native image routing extension that describes screenshots and other image inputs with a vision-capable model when the active model is text-only |
 | `oh-my-pi` | Pi-native cmux integration with native cmux notifications (Waiting / Task Complete / Error), readable split pane commands (`/omp-split-*`) and workspace tab commands (`/omp-workspace*`), plus short aliases for faster typing. Low-level cmux primitives are shared via `@diversio/pi-cmux`. Works only inside cmux |
-| `pi-timestamps` | Pi-native subtle transcript timing rows for exact timestamps, reply-start timing, timezone-aware absolute times, and live relative-age labels |
+| `pi-timestamps` | Pi-native subtle transcript timing rows for exact timestamps and reply-start timing, plus a playful live status line for the newest turn |
 | `skills-bridge` | Auto-discovers all 21 Claude Code plugin skills from plugins/*/skills/ and registers them as pi skills. One install bridges the gap between the plugin ecosystem and pi |
 
 Helpful mental model:

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -114,7 +114,7 @@ when command files change.
 - `pi-timestamps` (pi package)
   - Purpose: adds subtle per-turn transcript timing rows so Pi sessions show
     exact timestamps, reply-start timing when available, timezone-aware
-    absolute times, and live relative-age labels.
+    absolute times, and a playful live status line for the newest turn.
   - Pi install from repo checkout:
     `pi install "$PWD/pi-packages/pi-timestamps"`
   - Package path: `pi-packages/pi-timestamps`
@@ -123,7 +123,7 @@ when command files change.
     `/timestamps hidden`, `/timestamps status`
   - Shortcut: `Ctrl+Shift+H` by default toggles timestamps on/off
   - Configuration: `PI_TIMESTAMPS_TIME_ZONE`,
-    `PI_TIMESTAMPS_TOGGLE_SHORTCUT`
+    `PI_TIMESTAMPS_TOGGLE_SHORTCUT`, `PI_TIMESTAMPS_LIVE_RELATIVE`
   - One-off local test from repo root:
     `pi --no-extensions -e ./pi-packages/pi-timestamps`
 - `skills-bridge` (pi package)

--- a/docs/runbooks/distribution.md
+++ b/docs/runbooks/distribution.md
@@ -246,7 +246,7 @@ oh-my-pi     -> explicit cmux notifications, split-pane commands,
                 and workspace-tab commands
 
 pi-timestamps -> subtle per-turn transcript timing rows for exact timestamps,
-                 timezone labels, and updating "how long ago"
+                 timezone labels, and a live newest-turn status line
 
 skills-bridge -> exposes marketplace plugin skills inside Pi
 ```
@@ -266,8 +266,8 @@ The `oh-my-pi` package provides explicit `/omp-split-*` and
 `/omp-workspace*` cmux commands plus native cmux notifications.
 
 The `pi-timestamps` package provides `/timestamps`, subtle transcript timing
-rows, timezone-aware absolute timestamps, and live relative-age labels like
-`2m ago`.
+rows, timezone-aware absolute timestamps, and a playful live status line for
+the newest turn with relative-age labels like `2m ago`.
 
 ## Codex Skill Installation
 

--- a/pi-packages/README.md
+++ b/pi-packages/README.md
@@ -10,7 +10,7 @@ Pi-native packages that extend pi with tools, commands, skills, and UI widgets.
 | [`dev-workflow`](./dev-workflow) | 15 core workflow prompts (`/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`), CI analysis, PR review feedback, release PR prep, local skills, optional pi-subagents chain, and seeded cmux split launching for subagent-style prompts |
 | [`image-router`](./image-router) | Routes image inputs through a vision-capable model when the active model is text-only, with per-model routing modes and a TUI settings panel |
 | [`oh-my-pi`](./oh-my-pi) | Pi-native cmux integration with notifications, readable split commands, and workspace tabs |
-| [`pi-timestamps`](./pi-timestamps) | Adds subtle per-turn transcript timing rows for exact timestamps, reply-start timing, timezone-aware absolute times, and live relative-age labels |
+| [`pi-timestamps`](./pi-timestamps) | Adds subtle per-turn transcript timing rows for exact timestamps and reply-start timing, plus a playful live status line for the newest turn |
 | [`skills-bridge`](./skills-bridge) | Auto-discovers all 21 Claude Code plugin skills from `plugins/*/skills/` and registers them as pi skills — one install bridges the entire plugin ecosystem into pi |
 
 ## Install

--- a/pi-packages/pi-timestamps/README.md
+++ b/pi-packages/pi-timestamps/README.md
@@ -10,7 +10,7 @@ In practice, people want simple answers to simple questions:
 - When did I send that prompt?
 - How long did the model take to start replying?
 - How long did the full turn take?
-- How long ago did this happen?
+- How long ago did the last reply happen?
 
 ## Solution
 
@@ -30,8 +30,9 @@ Current highlighting:
 
 - completion time uses a success color
 - `reply in` and `total` values use an accent color
-- live relative age like `11s ago` uses a warning color
 - the hide shortcut stays dimmer than the timing data
+- the bottom status line keeps the flavor text dimmer
+- the live relative age in the bottom status bar is the part that pops most
 
 Labeling note:
 
@@ -59,7 +60,14 @@ extension appends one tiny display-only timing row
 Example row:
 
 ```text
-2026-06-02 19:18:01 EDT · done 2026-06-02 19:18:08 EDT · reply in 3s · total 7s · 11s ago · hide row: ctrl+shift+h
+2026-06-02 19:18:01 EDT · done 2026-06-02 19:18:08 EDT · reply in 3s · total 7s · hide row: ctrl+shift+h
+```
+
+Example status line snippets:
+
+```text
+⚽ Cooking, the tin monk is. Glass, tap not.
+⚽ 11s ago · Replied, the tin monk has. Your move, captain.
 ```
 
 ## Why it works this way
@@ -90,17 +98,16 @@ The current design aims for:
 - useful timing at a glance
 - no persistent second panel competing with the conversation
 
-### Why is there still a hidden widget internally?
+### Why move the live relative age to the status bar?
 
-The extension mounts a **zero-height hidden widget** only so it can keep a TUI
-handle and request rerenders after timing rows are appended or visibility is
-toggled.
+A changing `11s ago` label inside historical transcript rows forces Pi to
+rerender old chat lines. That is fragile when you have scrolled up and are
+trying to read a long response.
 
-Users do not see that widget. The extension uses it to keep `... ago` honest:
-relative ages should update on their own, not only when the user starts typing.
+So the extension now keeps transcript rows **static** and moves only the newest
+relative age to the bottom status bar.
 
-To reduce selection/copying pain, the ticker is adaptive instead of repainting
-once per second forever:
+The ticker is still adaptive instead of repainting once per second forever:
 
 ```text
 first minute  -> update every second  -> 11s ago, 12s ago, ...
@@ -117,19 +124,24 @@ Each timing row can show:
 - reply-start timing when visible text appeared
 - fallback assistant-start timing if the provider does not emit a text-start event
 - total turn duration
-- live relative age like `11s ago`
 - inline "hide row" shortcut text
+
+The bottom status bar shows playful Yoda-ish lines for the newest turn. While the model is working it rotates through in-progress messages; after completion it rotates through replied/fumbled messages and appends the newest relative age. The flavor text stays relatively dim while the age label is the colorful part that stands out.
+
+Animations come from a pool of ten. On session start an animation is chosen, and each new human message re-rolls the animation for the next turn. The little Yoda-ish bot nickname now shuffles along with the status text itself instead of getting stuck for a whole turn. For now, the football-themed animations are weighted more heavily through July 19.
 
 Visual map:
 
 ```text
-2026-06-02 19:18:01 EDT · done 2026-06-02 19:18:08 EDT · reply in 3s · total 7s · 11s ago · hide row: ctrl+shift+h
-│                        │                              │             │          │          └─ quick hide-row hint
-│                        │                              │             │          └─ live relative age, refreshed by the adaptive ticker
+2026-06-02 19:18:01 EDT · done 2026-06-02 19:18:08 EDT · reply in 3s · total 7s · hide row: ctrl+shift+h
+│                        │                              │             │          └─ quick hide-row hint
 │                        │                              │             └─ full turn duration
 │                        │                              └─ time until the reply became visible
 │                        └─ exact completion time
 └─ exact prompt time
+
+status: 🥾⚽ Cooking, the tin monk is. Glass, tap not.
+status: ⚽ 11s ago · Replied, the tin monk has. Your move, captain.
 ```
 
 ## Quick use
@@ -206,7 +218,7 @@ What it includes:
 - exact prompt and completion timestamps
 - `reply in` timing
 - `total` timing
-- live relative age like `11s ago`
+- newest live relative age in the bottom status bar
 - one visibility toggle command and shortcut
 
 What it intentionally does **not** include:
@@ -263,7 +275,7 @@ export PI_TIMESTAMPS_TIME_ZONE="America/Toronto"
 # Change the hide/show shortcut and the inline hint text.
 export PI_TIMESTAMPS_TOGGLE_SHORTCUT="ctrl+shift+h"
 
-# Optional stable/copy mode: hide `... ago` and disable the relative-age ticker.
+# Optional stable/copy mode: disable the bottom-status relative-age ticker.
 export PI_TIMESTAMPS_LIVE_RELATIVE="false"
 ```
 
@@ -271,16 +283,16 @@ Notes:
 
 - If `PI_TIMESTAMPS_TIME_ZONE` is unset, the extension uses your local system timezone.
 - `PI_TIMESTAMPS_TOGGLE_SHORTCUT` changes both the registered shortcut and the inline hint text.
-- `PI_TIMESTAMPS_LIVE_RELATIVE=false` disables `... ago` labels and the relative-age ticker for a maximally stable transcript.
+- `PI_TIMESTAMPS_LIVE_RELATIVE=false` disables the bottom-status `... ago` ticker for a maximally stable UI.
 
 Relative-age tradeoff:
 
 ```text
-show `11s ago`
+show `11s ago` in the bottom status bar
         ↓
 must update without waiting for typing/scrolling
         ↓
-requires terminal redraws
+requires footer/status redraws
         ↓
 use adaptive redraws so the label stays honest without repainting every second forever
 ```
@@ -288,35 +300,23 @@ use adaptive redraws so the label stays honest without repainting every second f
 Adaptive ticker mental model:
 
 ```text
-newest timestamp row is 0-59s old
+newest completed turn is 0-59s old
         ↓
 relative label can change every second
         ↓
 ticker wakes every 1s
 
-newest timestamp row is 1-59m old
+newest completed turn is 1-59m old
         ↓
 relative label can change every minute
         ↓
 ticker wakes every 1m
 
-newest timestamp row is 1h+ old
+newest completed turn is 1h+ old
         ↓
 relative label changes slowly
         ↓
 ticker wakes hourly
-```
-
-Why use the newest row?
-
-```text
-newest row changes fastest
-        ↓
-older rows are already less granular
-        ↓
-if the newest row is safe at a cadence, older rows are safe too
-        ↓
-one timer is enough for the whole transcript
 ```
 
 Stable/copy mode tradeoff:
@@ -324,9 +324,9 @@ Stable/copy mode tradeoff:
 ```text
 PI_TIMESTAMPS_LIVE_RELATIVE=false
         ↓
-no relative `... ago` label
+no bottom-status `... ago` ticker
         ↓
-no ticker-driven transcript redraws
+no ticker-driven redraws
         ↓
 exact prompt/completion timestamps still remain visible
 ```
@@ -345,12 +345,14 @@ Suggested smoke test:
 1. Start Pi with the package loaded
 2. Send a prompt
 3. Confirm a subtle timing row appears immediately after the turn
-4. Confirm `done`, `reply in`, `total`, and `11s ago` are easy to spot
-5. Wait without typing and confirm `11s ago` updates on its own
-6. Press Ctrl+Shift+H
-7. Confirm timing rows disappear
-8. Press Ctrl+Shift+H again
-9. Confirm timing rows return
+4. Confirm `done`, `reply in`, and `total` are easy to spot inline
+5. While the model is responding, confirm the bottom status bar shows rotating Yoda-ish in-progress messages
+6. After completion, confirm it flips to rotating Yoda-ish replied messages with a relative age like `11s ago` near the front so it stands out
+7. Wait without typing and confirm the bottom status bar updates on its own
+8. Press Ctrl+Shift+H
+9. Confirm timing rows disappear and the status entry clears
+10. Press Ctrl+Shift+H again
+11. Confirm timing rows return and the status entry comes back
 ```
 
 Stable/copy mode smoke test:
@@ -359,7 +361,7 @@ Stable/copy mode smoke test:
 1. Restart Pi with PI_TIMESTAMPS_LIVE_RELATIVE=false
 2. Send a prompt
 3. Confirm the row still shows exact times, `reply in`, and `total`
-4. Confirm `... ago` is hidden and no ticker-driven redraws happen
+4. Confirm the bottom status bar shows the fun status text without a changing `... ago` label
 ```
 
 Provider-behavior smoke test:
@@ -380,32 +382,18 @@ C. Tool-call-only / no visible assistant reply
 A few implementation choices may look unusual when you first read the code.
 Here is the simple why behind each one.
 
-### Hidden zero-height widget
+### Bottom-status relative-age ticker
 
 Why it exists:
 
 ```text
-timing rows are appended after the agent returns to idle
+historical transcript rows should stay stable
         ↓
-visibility can be toggled later
+the newest turn still benefits from a live `11s ago` label
         ↓
-`... ago` needs occasional redraws to stay honest
+move only that newest relative age into the status bar
         ↓
-extension needs a stable TUI handle to request rerenders
-        ↓
-hidden widget keeps that handle available
-```
-
-Why it renders nothing:
-
-```text
-widget exists for a TUI handle, not user content
-        ↓
-render() returns []
-        ↓
-no bottom panel, no visual noise
-        ↓
-transcript rows remain the only visible UI
+status updates stay local to the footer instead of mutating old chat rows
 ```
 
 ### Adaptive relative-age ticker
@@ -425,12 +413,12 @@ good behavior
   -> truthful without constant repainting forever
 ```
 
-The implementation tracks `latestRelativeTimestamp`:
+The implementation tracks the newest timing row details:
 
 ```text
 new row appended
         ↓
-latestRelativeTimestamp = row completion time
+latestStatusDetails = newest row details
         ↓
 restartTicker()
         ↓
@@ -443,8 +431,8 @@ Stable/copy mode disables this entire path:
 export PI_TIMESTAMPS_LIVE_RELATIVE=false
 ```
 
-In that mode exact absolute timestamps remain visible, but `... ago` is hidden
-so the transcript does not repaint just for timestamp freshness.
+In that mode exact absolute timestamps remain visible, but the bottom-status
+relative label stops ticking.
 
 ### Deferred timing-row append
 
@@ -578,10 +566,11 @@ We read both so existing sessions do not lose their saved hide/show state.
 
 - Timing rows are stored as display-only custom messages and filtered out of LLM context.
 - Timing rows are appended only after `ctx.isIdle()` is true, with `{ triggerTurn: false }`, so they do not get delivered as steering messages during the active model turn.
-- Visibility mode is stored as a session custom entry, so `/reload` preserves it inside the current session branch.
-- Relative-time live updates are enabled by default and use an adaptive ticker: every second for fresh rows, every minute after the first minute, hourly after the first hour.
-- `PI_TIMESTAMPS_LIVE_RELATIVE=false` hides `... ago` and disables ticker-driven redraws for stable/copy mode.
-- The hidden zero-height widget exists only to keep a TUI handle for timestamp-row rerenders.
+- Visibility mode and the current status animation are stored as session custom state, so `/reload` preserves them inside the current session branch.
+- Relative-time live updates are enabled by default and use an adaptive ticker in the bottom status bar: every second for fresh turns, every minute after the first minute, hourly after the first hour.
+- `PI_TIMESTAMPS_LIVE_RELATIVE=false` disables the bottom-status `... ago` ticker for stable/copy mode.
+- Transcript rows stay static; only the newest relative age is dynamic.
+- The status animation comes from a pool of ten and re-rolls on each new human message. The Yoda-ish bot nickname rotates with the status text itself. Football-themed animations get extra weight through July 19.
 
 Troubleshooting map:
 
@@ -598,13 +587,13 @@ Assistant seems to respond to the timing row
   -> confirm the append path waits for ctx.isIdle()
   -> confirm sendMessage uses { triggerTurn: false }
 
-No "11s ago" label appears
+No bottom-status "11s ago" label appears
   -> check PI_TIMESTAMPS_LIVE_RELATIVE is not set to false/off/0/no
-  -> exact prompt and completion timestamps are still shown
+  -> exact prompt and completion timestamps are still shown inline
 
-Rows stop updating "11s ago"
-  -> inspect the hidden widget mount
+Bottom-status age stops updating
   -> inspect syncTicker()
+  -> inspect syncStatusBar()
   -> remember updates become minute-based after the first minute
 
 Rows are hard to copy/select around
@@ -613,7 +602,7 @@ Rows are hard to copy/select around
 
 Rows do not preserve hidden/visible state after /reload
   -> inspect restoreStateFromSession()
-  -> inspect persistVisibilityMode()
+  -> inspect persistSettings()
 
 Rows appear after /reload from an old turn
   -> inspect runtimeActive guards in scheduleTimingRowAppend()
@@ -627,7 +616,7 @@ restoreStateFromSession()
   -> load visible/hidden mode from session
 
 syncTicker()
-  -> start/stop the adaptive relative-time rerender loop
+  -> start/stop the adaptive bottom-status relative-time loop
 
 message_end(role=user)
   -> start the turn clock

--- a/pi-packages/pi-timestamps/extensions/pi-timestamps/index.ts
+++ b/pi-packages/pi-timestamps/extensions/pi-timestamps/index.ts
@@ -626,7 +626,7 @@ function buildStatusText(theme: Theme): string | undefined {
 
 /** Keep the bottom status line in sync with the latest timing row. */
 function syncStatusBar(ctx = activeCtx): void {
-  if (!ctx?.hasUI) return;
+  if (!ctx?.hasUI || ctx.mode !== "tui") return;
   ctx.ui.setStatus(STATUS_KEY, buildStatusText(ctx.ui.theme));
 }
 
@@ -645,6 +645,7 @@ function syncTicker(): void {
   if (
     !LIVE_RELATIVE_UPDATES
     || !activeCtx?.hasUI
+    || activeCtx.mode !== "tui"
     || visibilityMode !== "visible"
     || (currentTurn === undefined && latestStatusDetails === undefined)
   ) {
@@ -1110,7 +1111,9 @@ export default function (pi: ExtensionAPI) {
     currentTurn = undefined;
     clearPendingAppendTimers();
     clearTicker();
-    activeCtx?.ui.setStatus(STATUS_KEY, undefined);
+    if (activeCtx?.mode === "tui") {
+      activeCtx.ui.setStatus(STATUS_KEY, undefined);
+    }
     activeCtx = undefined;
   });
 

--- a/pi-packages/pi-timestamps/extensions/pi-timestamps/index.ts
+++ b/pi-packages/pi-timestamps/extensions/pi-timestamps/index.ts
@@ -10,7 +10,7 @@
  * - When did the reply actually finish?
  * - How long until I saw the reply start?
  * - How long did the whole turn take?
- * - How long ago did this happen?
+ * - How long ago did the last reply happen?
  *
  * First-principles design
  * -----------------------
@@ -23,8 +23,9 @@
  *
  * So this extension adds one tiny timing row after each user prompt.
  *
- * - normal visible replies show `done`, `reply in`, `total`, and `... ago`
+ * - normal visible replies show `done`, `reply in`, and `total`
  * - incomplete/non-visible replies fall back to `reply incomplete`
+ * - the live relative age for the newest turn moves to the status bar
  *
  * Mental model
  * ------------
@@ -53,15 +54,17 @@
  *   normal Pi row
  *   timing row added by this extension
  *
- * Why is there a hidden widget if there is no visible bottom panel?
- * ---------------------------------------------------------------
- * The zero-height hidden widget keeps a TUI handle so we can request a rerender
- * after appending/toggling timestamp rows and keep `... ago` honest. The ticker
- * is adaptive: quick updates while a row is new, slower updates after that.
+ * Why is the live relative age shown in the status bar instead of each row?
+ * ------------------------------------------------------------------------
+ * A changing `11s ago` label inside historical transcript rows forces Pi to
+ * rerender old chat lines. That is fragile when the user has scrolled up.
+ * Keeping transcript rows static while moving only the newest relative age to
+ * the bottom status bar preserves the per-turn timing history without causing
+ * historical rows to tick in place.
  */
 
 import type { Message } from "@mariozechner/pi-ai";
-import type { Component, TUI } from "@mariozechner/pi-tui";
+import type { Component } from "@mariozechner/pi-tui";
 import { wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import type { ExtensionAPI, ExtensionContext, Theme } from "@mariozechner/pi-coding-agent";
 
@@ -80,13 +83,8 @@ const TURN_MESSAGE_TYPE = "pi-timestamps-turn";
  */
 const SETTINGS_ENTRY_TYPE = "pi-timestamps-settings";
 
-/**
- * Hidden widget key.
- *
- * The widget renders nothing. Its only job is to keep a live TUI handle around
- * so the extension can request rerenders after rows are appended/toggled.
- */
-const WIDGET_KEY = "pi-timestamps";
+/** Footer status key for the newest live relative age. */
+const STATUS_KEY = "pi-timestamps";
 
 /**
  * Re-render cadence for relative timestamps.
@@ -113,7 +111,7 @@ const HOUR_MS = 60 * MINUTE_MS;
  * - Adaptive repainting keeps the label honest while reducing redraws after the
  *   label naturally becomes less granular.
  *
- * Users who strongly prefer a fully stable transcript can disable the relative
+ * Users who strongly prefer a fully stable UI can disable the relative
  * label and ticker with:
  *
  *   export PI_TIMESTAMPS_LIVE_RELATIVE="false"
@@ -161,6 +159,8 @@ type VisibilityMode = "visible" | "hidden";
  */
 type TurnStatus = "completed" | "aborted";
 
+type StatusAnimationId = string;
+
 /**
  * Small session-persisted settings payload.
  *
@@ -169,6 +169,7 @@ type TurnStatus = "completed" | "aborted";
  */
 type VisibilitySettings = {
   visibilityMode: VisibilityMode;
+  statusAnimationId?: StatusAnimationId;
 };
 
 /**
@@ -207,20 +208,12 @@ type LiveTurn = {
 
 let visibilityMode: VisibilityMode = DEFAULT_VISIBILITY_MODE;
 let currentTurn: LiveTurn | undefined;
-let activeTui: TUI | undefined;
+let activeCtx: ExtensionContext | undefined;
 let tickTimer: ReturnType<typeof setTimeout> | undefined;
+let statusAnimationId: StatusAnimationId | undefined;
 
-/**
- * Newest completion timestamp among rendered timing rows.
- *
- * The adaptive ticker only needs the newest row because it is the fastest-moving
- * relative label. If the newest row only needs minute-level updates, all older
- * rows are safe at that cadence too.
- *
- * Empty sessions intentionally leave this undefined so the hidden widget does
- * not schedule pointless redraws before any timing row exists.
- */
-let latestRelativeTimestamp: number | undefined;
+/** Latest persisted timing row, used for bottom-status relative age. */
+let latestStatusDetails: TurnTimingDetails | undefined;
 
 /**
  * Whether this extension runtime is still allowed to append rows.
@@ -263,7 +256,9 @@ function isTurnTimingDetails(value: unknown): value is TurnTimingDetails {
 }
 
 function nextTickerDelayMs(): number {
-  const timestamp = latestRelativeTimestamp;
+  if (currentTurn) return SECOND_MS;
+
+  const timestamp = latestStatusDetails?.assistantTimestamp;
   if (timestamp === undefined) return MINUTE_MS;
 
   const ageMs = Math.max(0, Date.now() - timestamp);
@@ -273,7 +268,7 @@ function nextTickerDelayMs(): number {
    *
    *   just now / 11s ago  -> can change every second
    *   2m ago              -> can change every minute
-   *   2h ago / 1d ago     -> hourly is enough for a subtle transcript row
+   *   2h ago / 1d ago     -> hourly is enough for a subtle status label
    */
   if (ageMs < MINUTE_MS) return SECOND_MS;
   if (ageMs < HOUR_MS) return MINUTE_MS;
@@ -287,20 +282,372 @@ function clearTicker(): void {
   }
 }
 
+const STATUS_ANIMATIONS = [
+  { id: "football-dribble", frames: ["⚽", "👟⚽", "⚽👟", "👟⚽", "⚽"] as const },
+  { id: "football-penalty", frames: ["⚽", "🦵⚽", "⚽💨", "🥅", "🥅⚽"] as const },
+  { id: "football-goal", frames: ["⚽", "⚽💨", "🥅", "🥅⚽", "🎉⚽"] as const },
+  { id: "football-bounce", frames: ["⚽", "⚽⬆️", "⚽", "⚽⬇️", "⚽"] as const },
+  { id: "rocket", frames: ["🚀", "🚀✨", "🌠", "✨🚀"] as const },
+  { id: "sparkles", frames: ["✨", "💫", "⭐", "🌟"] as const },
+  { id: "wizard", frames: ["🪄", "✨", "🪄✨", "✨"] as const },
+  { id: "dragon", frames: ["🐉", "🐉🔥", "🔥", "🐲"] as const },
+  { id: "dice", frames: ["🎲", "⚀", "⚂", "⚅"] as const },
+  { id: "moon", frames: ["🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘"] as const },
+] as const;
+
+const IN_PROGRESS_MESSAGE_BUCKET_MS = 4 * SECOND_MS;
+const REPLIED_MESSAGE_BUCKET_MS = 8 * SECOND_MS;
+const FUMBLED_MESSAGE_BUCKET_MS = 12 * SECOND_MS;
+
+const STATUS_ALIASES = [
+  "tin monk",
+  "syntax goblin",
+  "little droid",
+  "toaster sage",
+  "wire wizard",
+  "silicon gremlin",
+  "code sprite",
+  "pixel monk",
+  "circuit imp",
+  "tiny oracle",
+] as const;
+
+const IN_PROGRESS_MESSAGES = [
+  "Cooking, the bot is. Glass, tap not.",
+  "Thinking, the little machine is. Patience, you must keep.",
+  "Brewing replies, the bot is. Interrupt, you should not.",
+  "Stirring the word soup, I am. Wait, you will.",
+  "Into the syntax swamp, the bot has wandered.",
+  "A response, the bot is forging. Haste, abandon.",
+  "Simmering ideas, the bot is. Peek, do not.",
+  "Working the circuits are. Calm, be.",
+  "Deep in thought, the bot has become.",
+  "Gathering cleverness, the bot is. A moment, grant.",
+  "In the oven, your answer is.",
+  "Humming softly, the machine mind is.",
+  "Reply-crafting, the bot remains.",
+  "Pondering strange things, the bot is.",
+  "Through the data mist, the bot now walks.",
+  "Composing, the bot is. Hover, do not.",
+  "Busy with tiny robot thoughts, the bot is.",
+  "Untangling the prompt vines, the bot is.",
+  "Working still, the bot is. Breathe, you should.",
+  "In progress, the bot remains. Rush, you must not.",
+  "A reply, the bot is seasoning well.",
+  "Inside the logic cave, the bot meditates.",
+  "Chopping tokens, the bot is.",
+  "Delicate this cooking is. Disturb it, do not.",
+  "Weaving an answer, the bot is.",
+  "From chaos, sense the bot seeks.",
+  "Polishing words, the bot is.",
+  "Busy in the thought-kitchen, the bot is.",
+  "The gears of nonsense and wisdom turn.",
+  "A tiny storm of reasoning, there is.",
+  "Still at work, the bot is.",
+  "Wrestling the prompt, the bot now is.",
+  "Measuring each word, the bot is.",
+  "On the griddle, your answer crackles.",
+  "Fermenting insight, the bot is.",
+  "A stew of logic, the bot now stirs.",
+  "Quietly plotting, the bot is.",
+  "In the workshop of sentences, the bot labors.",
+  "Taking its sweet machine time, the bot is.",
+  "Mid-thought, the bot remains.",
+  "Distilling meaning, the bot is.",
+  "A careful answer, the bot prepares.",
+  "Busy with mysterious bot business, it is.",
+  "Through the prompt fog, the bot peers.",
+  "The response cauldron bubbles, yes.",
+  "Concentrating hard, the bot is.",
+  "Little sparks of sense, the bot now gathers.",
+  "Still cooking, the answer is.",
+  "Working the word-forge, the bot is.",
+  "Not done, the bot is. Nearly, perhaps.",
+  "A sentence at a time, the bot climbs.",
+  "Patiently assembling cleverness, the bot is.",
+  "Into shape, the reply now bends.",
+  "Busy in the syntax mines, the bot is.",
+  "The machine monk is meditating.",
+  "Solving, stirring, and muttering, the bot is.",
+  "Quietly powerful work, this is.",
+  "The answer loaf rises still.",
+  "In the temple of tokens, the bot chants.",
+  "Parsing the chaos, the bot is.",
+  "Under the hood, much is happening.",
+  "The thought-pan is warm, yes.",
+  "A neat reply, the bot coaxes forth.",
+  "Reasoning noises, the bot now makes.",
+  "Progressing, the bot is. Poking, resist.",
+  "A draft, the bot now sharpens.",
+  "Through the grammar forest, the bot moves.",
+  "Busy being useful, the bot is trying.",
+  "The answer broth thickens nicely.",
+  "Almost wise enough, the bot may be.",
+  "Turning confusion into words, the bot is.",
+  "Minding the details, the bot is.",
+  "A tiny philosopher at work, the bot is.",
+  "With care, the reply is baked.",
+  "The token anvil rings again.",
+  "Hard at think, the bot is.",
+  "Brewing, chewing, and reviewing, the bot is.",
+  "Answering energy, the bot now channels.",
+  "In progress, all this still is.",
+  "Hold, you should. Replying, the bot is.",
+] as const;
+
+const REPLIED_MESSAGES = [
+  "Replied, the bot has. Your move, captain.",
+  "Done, the bot is. Your turn, it now becomes.",
+  "Spoken, the bot has. Respond, you may.",
+  "Finished, the machine has. Act, you should.",
+  "The reply arrived, yes. Yours, the next step is.",
+  "Said its piece, the bot has.",
+  "The answer is out. Move, you must.",
+  "Replied moments ago, the bot did.",
+  "Your turn now is. Spoken, the bot has.",
+  "From the bot, wisdom came. From you, action waits.",
+  "A reply, the bot delivered.",
+  "Sent, the message was. Continue, you may.",
+  "Quiet now, the bot is. Loud, you may become.",
+  "Done talking, the bot is.",
+  "The baton, to you passes now.",
+  "Answered already, the bot has.",
+  "Your move, yes. Finished, the bot is.",
+  "Completed, this reply has been.",
+  "From the machine, words came. From you, meaning follows.",
+  "A response, the bot has placed before you.",
+  "Replied just now, the bot has.",
+  "The bot has spoken. Type, you should.",
+  "Finished the little gremlin is.",
+  "Your turn begins where the bot's ended.",
+  "Released into the chat, the reply has been.",
+  "Done and dusted, the bot is.",
+  "Fresh from the forge, the answer is.",
+  "Replied recently, the bot did. Delay, you need not.",
+  "The bot rests. Your fingers, they should work.",
+  "Complete, the reply now is.",
+  "This round, the bot has finished.",
+  "The answer landed softly, yes.",
+  "Said enough, the bot has.",
+  "Handed to you, the conversation now is.",
+  "The machine has concluded. Continue, human.",
+  "Reply served hot, the bot has.",
+  "Answered, the bot has. Overthinking, begin not.",
+  "The bot has done its part.",
+  "Ready your next move, you should.",
+  "Finished replying, the bot has become.",
+  "A fresh answer behind you, the bot leaves.",
+  "Its wisdom deposited, the bot has.",
+  "Done now, the bot is. Typing, you may start.",
+  "Replied a short while ago, the bot has.",
+  "The next move belongs to you.",
+  "Said what it could, the bot has.",
+  "A message, the bot delivered neatly.",
+  "Your cue, this now is.",
+  "The bot is done. The keyboard awaits you.",
+  "Complete, the machine offering is.",
+  "The answer stands. Add to it, you may.",
+  "Replied, the bot has. Hesitate, perhaps not.",
+  "Its turn ended, the bot's has.",
+  "To the human side, the turn returns.",
+  "A response now sits before you.",
+  "Done crafting, the bot is.",
+  "The reply has cooled enough to touch.",
+  "Spoken and settled, the bot is.",
+  "The conversation ball, back in your court it is.",
+  "Finished chatting, the bot has.",
+  "Replied not long ago, the bot did.",
+  "A neat little answer, the bot made.",
+  "From bot to human, the turn has shifted.",
+  "The machine has landed its thought.",
+  "Complete, the answer cycle is.",
+  "Waiting on you now, the universe is.",
+  "The bot's work is done. Mischief, yours may begin.",
+  "Done replying, the bot has become.",
+  "The answer is here. Bold, be.",
+  "Finished, the silicon sage is.",
+  "A reply has arrived. Ponder it, or ignore it, you may.",
+  "To you, the next prompt belongs.",
+  "Done, the bot is. Destiny, your cursor now holds.",
+  "Said enough for now, the bot has.",
+  "The tiny oracle has finished.",
+  "Replied, the bot has. Continue the saga, you should.",
+  "Your move now is, captain.",
+  "The machine monk has spoken.",
+  "Concluded, the bot has. Proceed, you may.",
+  "The bot has returned the turn to you.",
+] as const;
+
+const FUMBLED_MESSAGES = [
+  "Tripped over its own wires, the bot has.",
+  "A clean landing, that was not.",
+  "Fumbled the reply, the bot did.",
+  "The thought loaf collapsed, sadly.",
+  "Lost in the syntax swamp, the bot became.",
+  "Oopsie-shaped, this turn was.",
+  "A graceful answer, this was not.",
+  "Into the logic ditch, the bot rolled.",
+  "Reply incomplete, the little machine left.",
+  "Tangled in its own thoughts, the bot was.",
+  "Dropped the answer bowl, the bot did.",
+  "Not its finest beep, this was.",
+  "A wobble in the wires, there was.",
+  "The reply escaped half-cooked.",
+  "Frowned, the circuits have.",
+  "Misfired a bit, the bot has.",
+  "A majestic stumble, this became.",
+  "The syntax goblins interfered, they did.",
+  "Finished poorly, the bot has.",
+  "Lost the thread, the bot did.",
+  "A partial answer, all we got.",
+  "Gracefully, it failed not.",
+  "In knots, the machine mind tied itself.",
+  "The reply came back limping.",
+  "A banana peel in the code path, there was.",
+  "Not complete, the answer is.",
+  "Flat on its face, the bot landed.",
+  "Somewhere mid-thought, the bot wandered off.",
+  "A strange little collapse, this was.",
+  "Half-baked and confused, the reply arrived.",
+  "The bot sneezed on the sentence.",
+  "Incomplete, this effort remains.",
+  "The thought engine coughed dramatically.",
+  "A smooth finish, the bot did not have.",
+  "Broke formation, the words did.",
+  "The reply cracked in the oven.",
+  "Off the rails, a bit, the bot went.",
+  "Fumbled its scroll, the bot has.",
+  "A noble attempt, but messy, this was.",
+  "Tripped, the bot did. Your move, captain.",
+] as const;
+
+function isStatusAnimationId(value: unknown): value is StatusAnimationId {
+  return typeof value === "string" && STATUS_ANIMATIONS.some((animation) => animation.id === value);
+}
+
+function shouldBoostFootball(now = new Date()): boolean {
+  return now < new Date(now.getFullYear(), 6, 20);
+}
+
+function isFootballAnimationId(id: StatusAnimationId): boolean {
+  return id.startsWith("football-");
+}
+
+function chooseWeightedStatusAnimationId(now = new Date()): StatusAnimationId {
+  const pool: StatusAnimationId[] = [];
+
+  for (const animation of STATUS_ANIMATIONS) {
+    const weight = isFootballAnimationId(animation.id) && shouldBoostFootball(now) ? 3 : 1;
+    for (let i = 0; i < weight; i += 1) {
+      pool.push(animation.id);
+    }
+  }
+
+  const index = Math.floor(Math.random() * pool.length);
+  return pool[index] ?? "football-dribble";
+}
+
+function hashText(text: string): number {
+  let hash = 0;
+  for (const char of text) {
+    hash = ((hash * 31) + char.charCodeAt(0)) >>> 0;
+  }
+  return hash;
+}
+
+function pickStatusAlias(bucketMs: number): string {
+  const bucket = Math.floor(Date.now() / bucketMs);
+  const salt = hashText(statusAnimationId ?? "football-dribble") ^ (currentTurn?.userTimestamp ?? latestStatusDetails?.userTimestamp ?? 0);
+  const index = Math.abs(((bucket + salt) * 2654435761) >>> 0) % STATUS_ALIASES.length;
+  return STATUS_ALIASES[index] ?? "tin monk";
+}
+
+function currentStatusFrames(): readonly string[] {
+  const selected = STATUS_ANIMATIONS.find((animation) => animation.id === statusAnimationId);
+  return selected?.frames ?? STATUS_ANIMATIONS[0].frames;
+}
+
+function currentStatusFrame(): string {
+  const frames = currentStatusFrames();
+  return frames[Math.floor(Date.now() / SECOND_MS) % frames.length] ?? frames[0] ?? "⚽";
+}
+
+function pickStatusMessage(messages: readonly string[], bucketMs: number): string {
+  const bucket = Math.floor(Date.now() / bucketMs);
+  const index = Math.abs(((bucket * 1103515245) + 12345) >>> 0) % messages.length;
+  return messages[index] ?? messages[0] ?? "Hmm.";
+}
+
+function capitalizeWord(text: string): string {
+  return text.length === 0 ? text : text[0].toUpperCase() + text.slice(1);
+}
+
+function remixBotAlias(message: string, alias: string): string {
+  const upperAlias = capitalizeWord(alias);
+
+  return message
+    .replace(/\bThe bot's\b/g, `The ${upperAlias}'s`)
+    .replace(/\bthe bot's\b/g, `the ${alias}'s`)
+    .replace(/\bThe bot\b/g, `The ${upperAlias}`)
+    .replace(/\bthe bot\b/g, `the ${alias}`)
+    .replace(/\bBot\b/g, upperAlias)
+    .replace(/\bbot\b/g, alias);
+}
+
+/** Build the bottom-status line for the newest turn state. */
+function buildStatusText(theme: Theme): string | undefined {
+  if (visibilityMode !== "visible") return undefined;
+
+  const frame = theme.fg("accent", currentStatusFrame());
+
+  if (currentTurn) {
+    const alias = pickStatusAlias(IN_PROGRESS_MESSAGE_BUCKET_MS);
+    const text = theme.fg("dim", remixBotAlias(pickStatusMessage(IN_PROGRESS_MESSAGES, IN_PROGRESS_MESSAGE_BUCKET_MS), alias));
+    return `${frame} ${text}`;
+  }
+
+  if (latestStatusDetails === undefined) return undefined;
+
+  if (latestStatusDetails.assistantTimestamp === undefined) {
+    const alias = pickStatusAlias(FUMBLED_MESSAGE_BUCKET_MS);
+    const text = theme.fg("warning", remixBotAlias(pickStatusMessage(FUMBLED_MESSAGES, FUMBLED_MESSAGE_BUCKET_MS), alias));
+    return `${frame} ${text}`;
+  }
+
+  const alias = pickStatusAlias(REPLIED_MESSAGE_BUCKET_MS);
+  const text = theme.fg("dim", remixBotAlias(pickStatusMessage(REPLIED_MESSAGES, REPLIED_MESSAGE_BUCKET_MS), alias));
+  if (!LIVE_RELATIVE_UPDATES) {
+    return `${frame} ${text}`;
+  }
+
+  const relative = theme.fg("warning", theme.bold(formatRelative(latestStatusDetails.assistantTimestamp)));
+  return `${frame} ${relative} ${theme.fg("muted", "·")} ${text}`;
+}
+
+/** Keep the bottom status line in sync with the latest timing row. */
+function syncStatusBar(ctx = activeCtx): void {
+  if (!ctx?.hasUI) return;
+  ctx.ui.setStatus(STATUS_KEY, buildStatusText(ctx.ui.theme));
+}
+
 /**
- * Start or stop the adaptive rerender tick.
+ * Start or stop the adaptive status-bar tick.
  *
  * Why adaptive?
  *
  *   11s ago  -> changes every second, so update every second
  *   12m ago  -> changes every minute, so update every minute
  *   2h ago   -> changes hourly, so hourly is enough
- *
- * This keeps the `... ago` text truthful without repainting the whole transcript
- * every second forever.
  */
 function syncTicker(): void {
-  if (!LIVE_RELATIVE_UPDATES || !activeTui || visibilityMode !== "visible" || latestRelativeTimestamp === undefined) {
+  syncStatusBar();
+
+  if (
+    !LIVE_RELATIVE_UPDATES
+    || !activeCtx?.hasUI
+    || visibilityMode !== "visible"
+    || (currentTurn === undefined && latestStatusDetails === undefined)
+  ) {
     clearTicker();
     return;
   }
@@ -309,7 +656,7 @@ function syncTicker(): void {
 
   tickTimer = setTimeout(() => {
     tickTimer = undefined;
-    activeTui?.requestRender();
+    syncStatusBar();
     syncTicker();
   }, nextTickerDelayMs());
 }
@@ -318,7 +665,7 @@ function restartTicker(): void {
   /**
    * A newly appended row may need second-level updates even if an older row had
    * already slowed the ticker to minute/hour cadence. Restarting recalculates
-   * from the fresh latestRelativeTimestamp immediately.
+   * from the fresh latest status timestamp immediately.
    */
   clearTicker();
   syncTicker();
@@ -479,10 +826,6 @@ function buildTranscriptLine(details: TurnTimingDetails, theme: Theme): string {
   if (details.assistantTimestamp !== undefined) {
     const total = details.totalDurationMs ?? Math.max(0, details.assistantTimestamp - details.userTimestamp);
     parts.push(`${theme.fg("muted", "total")} ${theme.fg("accent", formatDuration(total))}`);
-
-    if (LIVE_RELATIVE_UPDATES) {
-      parts.push(theme.fg("warning", formatRelative(details.assistantTimestamp)));
-    }
   } else {
     parts.push(theme.fg("warning", "reply incomplete"));
   }
@@ -516,13 +859,7 @@ class TurnTimingMessageComponent implements Component {
   invalidate(): void {}
 }
 
-/**
- * This component deliberately renders nothing.
- *
- * It exists only so the extension has a stable TUI handle (`activeTui`) for
- * explicit rerenders after appends/toggles and adaptive live relative updates.
- */
-class HiddenTickerComponent implements Component {
+class EmptyComponent implements Component {
   render(_width: number): string[] {
     return [];
   }
@@ -537,10 +874,12 @@ class HiddenTickerComponent implements Component {
  * session history is the source of truth for user-facing extension state.
  * On reload or resume we reconstruct from saved entries instead of guessing.
  */
-function restoreStateFromSession(ctx: ExtensionContext): void {
+function restoreStateFromSession(ctx: ExtensionContext): boolean {
+  let hadPersistedAnimation = false;
   visibilityMode = DEFAULT_VISIBILITY_MODE;
   currentTurn = undefined;
-  latestRelativeTimestamp = undefined;
+  latestStatusDetails = undefined;
+  statusAnimationId = undefined;
 
   for (const entry of ctx.sessionManager.getBranch()) {
     if (entry.type === "custom" && entry.customType === SETTINGS_ENTRY_TYPE && isRecord(entry.data)) {
@@ -553,18 +892,29 @@ function restoreStateFromSession(ctx: ExtensionContext): void {
       if (isVisibilityMode(maybeMode)) {
         visibilityMode = maybeMode;
       }
+
+      const maybeAnimationId = entry.data["statusAnimationId"];
+      if (isStatusAnimationId(maybeAnimationId)) {
+        statusAnimationId = maybeAnimationId;
+        hadPersistedAnimation = true;
+      }
       continue;
     }
 
     /**
-     * On resume/reload, existing rows may already show `... ago`. Restore the
-     * newest completed timestamp so the adaptive ticker can keep those labels
-     * moving without waiting for a brand-new turn.
+     * Restore the last timing row so the status bar can summarize the newest
+     * turn immediately on resume or reload.
      */
     if (entry.type === "custom_message" && entry.customType === TURN_MESSAGE_TYPE && isTurnTimingDetails(entry.details)) {
-      latestRelativeTimestamp = entry.details.assistantTimestamp ?? latestRelativeTimestamp;
+      latestStatusDetails = entry.details;
     }
   }
+
+  if (!statusAnimationId) {
+    statusAnimationId = chooseWeightedStatusAnimationId();
+  }
+
+  return hadPersistedAnimation;
 }
 
 /**
@@ -573,9 +923,9 @@ function restoreStateFromSession(ctx: ExtensionContext): void {
  * This is the only user preference we store today, which keeps migration logic
  * small and easy to reason about.
  */
-function persistVisibilityMode(pi: ExtensionAPI, nextMode: VisibilityMode): void {
+function persistSettings(pi: ExtensionAPI, nextMode: VisibilityMode = visibilityMode): void {
   visibilityMode = nextMode;
-  const settings: VisibilitySettings = { visibilityMode: nextMode };
+  const settings: VisibilitySettings = { visibilityMode, statusAnimationId };
   pi.appendEntry(SETTINGS_ENTRY_TYPE, settings);
   syncTicker();
 }
@@ -655,9 +1005,9 @@ function scheduleTimingRowAppend(pi: ExtensionAPI, ctx: ExtensionContext, detail
       { triggerTurn: false },
     );
 
-    latestRelativeTimestamp = details.assistantTimestamp ?? latestRelativeTimestamp;
+    latestStatusDetails = details;
     restartTicker();
-    activeTui?.requestRender();
+    syncStatusBar(ctx);
   };
 
   const timer = setTimeout(() => {
@@ -681,7 +1031,7 @@ export default function (pi: ExtensionAPI) {
      * not here at component-construction time.
      */
     if (!isTurnTimingDetails(message.details)) {
-      return new HiddenTickerComponent();
+      return new EmptyComponent();
     }
     return new TurnTimingMessageComponent(message.details, theme);
   });
@@ -700,15 +1050,16 @@ export default function (pi: ExtensionAPI) {
     handler: async (args, ctx) => {
       const input = args.trim().toLowerCase();
       if (input === "status") {
-        ctx.ui.notify(`Pi timestamps: ${visibilityMode} • ${configuredTimeZoneLabel()} • ${TOGGLE_SHORTCUT}`, "info");
+        const lastTurn = buildStatusText(ctx.ui.theme) ?? "no recent turn";
+        ctx.ui.notify(`Pi timestamps: ${visibilityMode} • ${configuredTimeZoneLabel()} • ${lastTurn} • ${TOGGLE_SHORTCUT}`, "info");
         return;
       }
 
+      activeCtx = ctx;
       const explicitMode = parseVisibilityMode(input);
       const nextMode = explicitMode ?? (visibilityMode === "hidden" ? "visible" : "hidden");
-      persistVisibilityMode(pi, nextMode);
+      persistSettings(pi, nextMode);
       ctx.ui.notify(`Pi timestamps ${nextMode}`, "info");
-      activeTui?.requestRender();
     },
   });
 
@@ -724,29 +1075,27 @@ export default function (pi: ExtensionAPI) {
   pi.registerShortcut(TOGGLE_SHORTCUT, {
     description: "Toggle Pi timestamps visibility",
     handler: async (ctx) => {
+      activeCtx = ctx;
       const nextMode: VisibilityMode = visibilityMode === "hidden" ? "visible" : "hidden";
-      persistVisibilityMode(pi, nextMode);
+      persistSettings(pi, nextMode);
       ctx.ui.notify(`Pi timestamps ${nextMode}`, "info");
-      activeTui?.requestRender();
     },
   });
 
   /**
    * Session startup:
    * - restore saved visibility
-   * - mount the hidden ticker widget
-   * - start relative-time rerenders when needed
+   * - restore the latest timing row for the bottom status line
+   * - start relative-time status updates when needed
    */
   pi.on("session_start", async (_event, ctx) => {
     runtimeActive = true;
-    restoreStateFromSession(ctx);
-
-    if (ctx.hasUI) {
-      ctx.ui.setWidget(WIDGET_KEY, (tui) => {
-        activeTui = tui;
-        syncTicker();
-        return new HiddenTickerComponent();
-      });
+    activeCtx = ctx;
+    const hadPersistedAnimation = restoreStateFromSession(ctx);
+    if (!hadPersistedAnimation) {
+      persistSettings(pi);
+    } else {
+      syncTicker();
     }
   });
 
@@ -758,10 +1107,11 @@ export default function (pi: ExtensionAPI) {
    */
   pi.on("session_shutdown", async () => {
     runtimeActive = false;
-    activeTui = undefined;
     currentTurn = undefined;
     clearPendingAppendTimers();
-    syncTicker();
+    clearTicker();
+    activeCtx?.ui.setStatus(STATUS_KEY, undefined);
+    activeCtx = undefined;
   });
 
   /** Keep timing rows out of model context. They are purely for humans. */
@@ -806,6 +1156,8 @@ export default function (pi: ExtensionAPI) {
      */
     if (event.message.role === "user") {
       currentTurn = { userTimestamp: event.message.timestamp };
+      statusAnimationId = chooseWeightedStatusAnimationId();
+      persistSettings(pi);
       return;
     }
 
@@ -894,6 +1246,6 @@ export default function (pi: ExtensionAPI) {
     scheduleTimingRowAppend(pi, ctx, details);
 
     currentTurn = undefined;
-    activeTui?.requestRender();
+    syncTicker();
   });
 }

--- a/pi-packages/pi-timestamps/package.json
+++ b/pi-packages/pi-timestamps/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-timestamps",
-  "version": "0.1.1",
-  "description": "Pi extension that adds subtle per-turn transcript timing rows with exact timestamps, reply-start timing, timezone-aware absolute times, and live relative-age labels.",
+  "version": "0.2.0",
+  "description": "Pi extension that adds subtle per-turn transcript timing rows with exact timestamps, reply-start timing, timezone-aware absolute times, and a playful live status line for the newest turn.",
   "keywords": ["pi-package", "timestamps", "observability"],
   "files": ["extensions/", "README.md"],
   "pi": {


### PR DESCRIPTION
## Summary

This PR redesigns `pi-timestamps` so transcript timing rows stay stable while the newest live timing signal moves into the bottom status bar.

### Key Features

| Feature | Description |
|---------|-------------|
| **Static transcript rows** | Keeps per-turn transcript rows focused on exact prompt/completion timestamps plus `reply in` and `total`, without live `... ago` churn in historical chat lines |
| **Live status-bar timing** | Moves the newest relative age into the bottom status bar and updates it adaptively so the freshest timing signal still feels alive |
| **Playful session UX** | Adds rotating Yoda-ish status text, per-turn animation rerolls, and weighted football animations through July 19 |
| **Docs and package refresh** | Updates package metadata and README so install, behavior, testing, and rationale match the shipped UX |

## Why this change

The previous design put live relative age labels like `11s ago` directly in historical transcript rows.
That made old chat lines mutate over time, which could cause disruptive Pi TUI rerenders when a user had scrolled up to read a long response.

Mental model:

```text
historical transcript rows contain live `... ago`
    ↓
old chat lines keep changing in place
    ↓
Pi may need to rerender historical viewport content
    ↓
reading stability suffers when the user is scrolled up
```

This PR changes the model to:

```text
transcript rows stay static
    ↓
only the newest relative age lives in the status bar
    ↓
live timing remains visible
    ↓
historical chat lines stop ticking in place
```

## What changed

---

## Transcript timing rows

The transcript rows remain visible and display-only, but they are now static after append:

- exact prompt timestamp
- exact completion timestamp
- `reply in`
- `total`
- visibility toggle hint

The live relative age is intentionally no longer rendered inline in every timing row.

---

## Status-bar redesign

The newest timing state now appears in the bottom status bar.

Behavior:
- while the model is working, the status bar shows an in-progress line
- after completion, it shows a relative age like `11s ago`
- in incomplete/fumbled cases, it shows a different failure-flavored line
- the relative age remains the most eye-catching part of the status text

The ticker is still adaptive:
- every second for fresh turns
- every minute after the first minute
- hourly after the first hour

---

## Fun status variants

This PR also adds session/turn flavor:

- a pool of 10 status animations
- football-themed variants weighted more heavily through July 19
- animation rerolls on each new human message
- Yoda-ish rotating text
- a rotating bot nickname/persona that changes with the status text instead of getting stuck

This keeps the footer/status line playful without changing the underlying timing model.

---

## Persistence and reload behavior

The package now persists the current visibility mode and current animation selection in session state so `/reload` keeps the active presentation stable.

Older sessions missing newer appearance fields are automatically backfilled on startup.

## Files Changed

<details>
<summary>Pi package implementation</summary>

- `pi-packages/pi-timestamps/extensions/pi-timestamps/index.ts` - redesign timing UX, status-bar ticker, animation rotation, nickname remixing, persistence updates
- `pi-packages/pi-timestamps/package.json` - version bump to `0.2.0`, updated package description

</details>

<details>
<summary>Package documentation</summary>

- `pi-packages/pi-timestamps/README.md` - document the status-bar redesign, rerender rationale, animation behavior, and updated smoke tests

</details>

## How to Test

```bash
jq -e . pi-packages/pi-timestamps/package.json >/dev/null
cd pi-packages/pi-timestamps && npm pack --dry-run --json >/tmp/pi-timestamps-pack.json
printf '{"id":"cmds","type":"get_commands"}\n' | PI_OFFLINE=1 pi --mode rpc --no-session --no-context-files --no-extensions -e ./pi-packages/pi-timestamps --no-prompt-templates --no-skills
```

### Manual Testing

1. Start Pi with `pi-timestamps` loaded.
2. Send a prompt.
3. Confirm a timing row appears after the turn and stays static.
4. While the model is responding, confirm the bottom status bar shows a rotating in-progress line.
5. After completion, confirm the status bar flips to a rotating replied line with a standout relative age like `11s ago`.
6. Send another prompt and confirm the animation changes for the new turn.
7. Confirm football-themed animations appear more frequently for now.
8. Run `/timestamps hidden` and confirm both the transcript rows and status entry disappear.
9. Run `/timestamps visible` and confirm they return.
10. Restart Pi with `PI_TIMESTAMPS_LIVE_RELATIVE=false` and confirm the fun status text remains but the bottom-status relative age stops ticking.

## Validation

- `jq -e . pi-packages/pi-timestamps/package.json >/dev/null` ✅
- `git diff --check` ✅
- `npm pack --dry-run --json` ✅
- `PI_OFFLINE=1 pi --mode rpc ... -e ./pi-packages/pi-timestamps` ✅
- Branch CI: `Validate Website` passed ✅
- Branch CI: `.github/workflows/deploy-website-cloudflare-pages.yml` still fails immediately due a pre-existing workflow-file issue unrelated to this change ⚠️

## CI Notes

Current branch CI is effectively green for this work.

- `Validate Website` passed for this branch.
- The failing `deploy-website-cloudflare-pages.yml` run fails at workflow-load time with GitHub reporting a workflow file issue and no job logs. The same failure pattern also appears on the current default branch, so this is treated as pre-existing / unrelated to the code in this PR.

## Notes

- No related GitHub issue was found for this work.
- This PR intentionally documents the final user-facing design and rationale, not the intermediate experiments that led here.
- The key design reason for the status-bar move is the historical-row rerender bug described above.
