### PR TITLE
Update backend-pr-workflow skill for dev integration branch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -43,7 +43,7 @@
     {
       "name": "backend-pr-workflow",
       "description": "Diversio backend PR workflow plugin that follows repo-local PR docs, GitHub issue linkage, safe migrations, and downtime-safe schema changes.",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "author": {
         "name": "Diversio Devs"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -174,8 +174,8 @@
     },
     {
       "name": "backend-release",
-      "description": "Manages the full release workflow for Django4Lyfe backend - creating release PRs, version bumping (YYYY.MM.DD), conflict resolution, GitHub releases, and post-release branch sync.",
-      "version": "0.3.0",
+      "description": "Manages Django4Lyfe release workflow: dev→release promotion PRs (staging deploy), release→master production PRs, version bumping, conflict resolution, GitHub releases, and post-release branch sync.",
+      "version": "0.3.1",
       "author": {
         "name": "Diversio Devs"
       },

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -198,7 +198,10 @@ when command files change.
   - Slash commands: `/backend-atomic-commit:pre-commit`,
     `/backend-atomic-commit:atomic-commit`, `/backend-atomic-commit:commit`
 - `backend-pr-workflow`
-  - Purpose: backend PR workflow, GitHub issue linkage, and migration safety checks.
+  - Purpose: backend PR workflow for the dev→release→master branch model
+    (feature PRs target dev, promotion PRs trigger staging, release PRs deploy
+    production), GitHub issue linkage, Django migration safety, and
+    downtime-safe schema changes.
   - Claude install: `claude plugin install backend-pr-workflow@diversiotech`
   - Skill path: `plugins/backend-pr-workflow/skills/backend-pr-workflow`
   - Slash commands: `/backend-pr-workflow:check-pr`
@@ -208,7 +211,9 @@ when command files change.
   - Skill path: `plugins/process-code-review/skills/process-code-review`
   - Slash commands: `/process-code-review:process-review`
 - `backend-release`
-  - Purpose: Django4Lyfe backend release management.
+  - Purpose: Django4Lyfe two-phase release workflow — promote staging
+    (dev→release), release to production (release→master), version bumping,
+    GitHub releases, and three-branch post-release sync.
   - Claude install: `claude plugin install backend-release@diversiotech`
   - Skill path: `plugins/backend-release/skills/release-manager`
   - Slash commands: `/backend-release:check`, `/backend-release:create`,

--- a/plugins/backend-pr-workflow/.claude-plugin/plugin.json
+++ b/plugins/backend-pr-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-pr-workflow",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Follows Diversio backend repo-local PR workflow docs, GitHub issue linkage, safe Django migrations, and downtime-safe schema changes.",
   "author": {
     "name": "Diversio Devs"

--- a/plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md
+++ b/plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md
@@ -278,16 +278,20 @@ If any of these are obviously missing from the plan, emit `[SHOULD_FIX]`.
 
 For hotfixes, enforce:
 
-- The hotfix PR targets `master` (not `release`).
+- The hotfix PR targets `master` (not `release` or `dev`).
 - The title clearly indicates a hotfix, e.g.:
   - `Hotfix release: 2025-08-19`
 - After deployment:
   - Changes are merged back into `release` so it stays ahead of or equal to
     `master`.
+  - Changes are also merged or cherry-picked back into **`dev`** so the
+    integration branch does not drift from production.  Without this,
+    subsequent feature branches and the next `dev → release` promotion are
+    developed against an integration branch missing code already in production.
   - A GitHub Release is created and tagged using the same CalVer scheme.
 
 If a supposed hotfix PR is targeting `release`, or a hotfix is not planned to
-be merged back into `release`, emit `[BLOCKING]`.
+be merged back into `release` **and `dev`**, emit `[BLOCKING]`.
 
 ## Checklist 5 – Migrations: Cleanup and Regeneration
 

--- a/plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md
+++ b/plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md
@@ -60,7 +60,7 @@ Before giving a full review, this Skill should gather:
 - The **repository** and context (e.g. Django4Lyfe backend / monolith).
 - The **branch name**.
 - The **PR title** and **PR description** (or the planned ones).
-- The **base branch** (what the PR targets: `release`, `master`, etc.).
+- The **base branch** (what the PR targets: `dev`, `release`, `master`, etc.).
 - Whether the PR:
   - Includes Django model changes.
   - Adds, modifies, or deletes migrations.
@@ -174,15 +174,20 @@ If not, emit:
 Confirm the base branch matches the project’s release workflow:
 
 - **Normal feature / bugfix work**:
-  - Base branch should be `release` (for repos following the Django4Lyfe
-    pattern).
+  - Base branch should be `dev` (the integration branch).
+  - Merging into `dev` runs validation only — no staging deploy.
+- **Staging promotion**:
+  - Base branch should be `release`.
+  - A PR from `dev` → `release` is a **promotion PR** — merging deploys staging.
 - **Hotfix** that must bypass the current `release` contents:
   - Base branch should be `master`.
+- **Production release**:
+  - `release` → `master` after staging validation.
 
 If a PR targets the wrong base branch:
 
 - Emit `[BLOCKING]` and recommend the correct base, explaining whether the
-  change belongs in `release` or should be a `master` hotfix.
+  change belongs in `dev`, `release`, or should be a `master` hotfix.
 
 If the repo’s harness docs specify a different default (e.g. custom long-lived
 branches in `AGENTS.md` or a linked workflow doc), follow that instead.
@@ -242,12 +247,15 @@ generally be `[BLOCKING]` for merge readiness.
 
 This Skill enforces a clean release flow.
 
-### 4.1 Normal release flow (via `release` branch)
+### 4.1 Normal release flow (via `dev` → `release` → `master`)
 
 For normal deployments, check that:
 
-- Feature/bugfix PRs merge into `release`.
-- Before cutting a release:
+- Feature/bugfix PRs merge into `dev` (integration branch).
+- To deploy staging:
+  - A **promotion PR** is opened from `dev` → `release`.
+  - Merging this PR triggers staging deploy (run_staging_deploy=true).
+- Before releasing to production:
   - The version (e.g. in `pyproject.toml`) is bumped to the intended release
     version, using CalVer (e.g. `2025-08-19`).
   - If direct pushes to `release` are not allowed, a small PR is created to

--- a/plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md
+++ b/plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md
@@ -290,8 +290,8 @@ For hotfixes, enforce:
     developed against an integration branch missing code already in production.
   - A GitHub Release is created and tagged using the same CalVer scheme.
 
-If a supposed hotfix PR is targeting `release`, or a hotfix is not planned to
-be merged back into `release` **and `dev`**, emit `[BLOCKING]`.
+If a supposed hotfix PR is targeting `dev` or `release`, or a hotfix is not
+planned to be merged back into `release` **and `dev`**, emit `[BLOCKING]`.
 
 ## Checklist 5 – Migrations: Cleanup and Regeneration
 

--- a/plugins/backend-release/.claude-plugin/plugin.json
+++ b/plugins/backend-release/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "backend-release",
-  "version": "0.3.0",
-  "description": "Manages the full release workflow for Django4Lyfe backend - creating release PRs, version bumping, conflict resolution, GitHub releases with date-based versioning (YYYY.MM.DD), and post-release branch sync.",
+  "version": "0.3.1",
+  "description": "Manages Django4Lyfe release workflow: dev→release promotion PRs (staging deploy), release→master production PRs, version bumping, conflict resolution, GitHub releases, and post-release branch sync across all three branches.",
   "author": {
     "name": "Diversio Devs"
   }

--- a/plugins/backend-release/skills/release-manager/SKILL.md
+++ b/plugins/backend-release/skills/release-manager/SKILL.md
@@ -57,13 +57,34 @@ git push -u origin promote/YYYY.MM.DD[-N]
 gh pr create --base release --title "Promotion: DDth Month YYYY" --body "..."
 ```
 
-**Why this exists**: Routine feature PRs merge into `dev` with validation only
-— no staging deploy.  The promotion PR is the intentional gate that says
-"these changes are ready for staging."  Merging the promotion PR into
-`release` triggers `run_staging_deploy=true` in CI.
+**First principles — why two phases?**
+
+The old model deployed staging on every merge to `release`:
+
+```
+old:  feature PR → release → staging deploy (every merge!)
+```
+
+This was noisy and expensive.  The new model separates concerns:
+
+```
+new:  feature PR → dev           (validation only, cheap)
+      promotion PR → release     (staging deploy, intentional)
+```
+
+Routine feature PRs merge into `dev` where CI validates but never deploys.
+Only a human opening a `dev → release` promotion PR triggers staging deploy.
+This means:
+
+- **Fewer staging deploys** — only when someone intentionally promotes
+- **Clearer intent** — the promotion PR says "I've reviewed these changes
+  and believe they're ready for staging"
+- **Lower CI cost** — dev merges run `run_tests` (classifier-derived flags),
+  not full `run_staging_deploy`
 
 **After merge**: Validate staging.  If issues are found, fix them on `dev` and
-create a new promotion PR.  Do not fix directly on `release`.
+create a new promotion PR.  Do not fix directly on `release` — `release`
+should only receive changes through promotion PRs.
 
 ### 1. Check What Needs Releasing (release → master)
 
@@ -276,8 +297,8 @@ gh release list --limit 3
 
 ### 7. Merge Master Back Into Release AND Dev
 
-**This step is mandatory after every release PR merge.** It keeps the branches
-in sync so future releases start from a consistent baseline.
+**This step is mandatory after every release PR merge.** It keeps all three
+branches in sync so future work starts from a consistent baseline.
 
 ```bash
 git fetch origin
@@ -291,11 +312,35 @@ git merge origin/release --no-edit
 git push origin dev
 ```
 
-**Why this matters**: After a release PR merges into master, master has a merge
-commit and a version-bump commit that release and dev don't. Without merge-back,
-`git diff --stat origin/master origin/release` shows the version bump as a
-pending difference.  Without the dev sync, the integration branch drifts from
-production, and subsequent feature branches are developed against a stale base.
+**First principles — why sync all three?**
+
+After a production release, the branches look like this:
+
+```
+master   ── has: release content + version bump + merge commit
+release  ── has: release content (stale — missing version bump)
+dev      ── has: release content (stale — missing version bump)
+```
+
+The sync cascade fixes this:
+
+```
+master ─────────────────────────────┐
+  │ merge master → release          │
+  ▼                                 │
+release  (now has version bump) ────┤
+  │ merge release → dev             │
+  ▼                                 │
+dev      (now has version bump) ────┘
+```
+
+Without syncing to release: the next release PR sees a stale diff
+(`git diff --stat origin/master origin/release` shows the version bump as
+"pending") and the release merge conflicts on `pyproject.toml`/`uv.lock`.
+
+Without syncing to dev: the integration branch drifts from production, and
+subsequent feature branches are developed against code that doesn't match
+what's actually running in production.
 
 ## Pre-Release Checks
 

--- a/plugins/backend-release/skills/release-manager/SKILL.md
+++ b/plugins/backend-release/skills/release-manager/SKILL.md
@@ -161,11 +161,18 @@ correctly shows only genuinely new commits.
 ### 4. PR Title and Body Format
 
 **Title patterns:**
+- Promotion: `Promotion: 21st January 2026`
 - Regular release: `Release: 21st January 2026`
 - Multiple same-day: `Release 2: 21st January 2026`
 - Hotfix: `Hotfix Release: 21st January 2026`
 
-**Body format:**
+**Promotion PR body format:**
+```markdown
+- https://github.com/DiversioTeam/Django4Lyfe/pull/XXXX
+- https://github.com/DiversioTeam/Django4Lyfe/pull/YYYY
+```
+
+**Release/Hotfix PR body format:**
 ```markdown
 - https://github.com/DiversioTeam/Django4Lyfe/pull/XXXX
 - https://github.com/DiversioTeam/Django4Lyfe/pull/YYYY
@@ -321,6 +328,18 @@ Before creating a release PR, verify:
    ```
 
 ## Output Shape
+
+When reporting promotion PR status:
+
+```
+Created: https://github.com/DiversioTeam/Django4Lyfe/pull/XXXX
+
+**Summary:**
+- Type: Promotion (dev → release, triggers staging deploy)
+- Title: "Promotion: DDth Month YYYY"
+- Target: `release`
+- Conflicts: None / Resolved
+```
 
 When reporting release status:
 

--- a/plugins/backend-release/skills/release-manager/SKILL.md
+++ b/plugins/backend-release/skills/release-manager/SKILL.md
@@ -406,8 +406,9 @@ gh pr list --base release --state merged --limit 100 --json number,title,mergedA
 git checkout -b releases/2026.01.21 origin/master
 git merge origin/release --no-edit
 
-# 7. Bump version
-sed -i '' 's/version = ".*"/version = "2026.01.21"/' pyproject.toml
+# 7. Bump version (^ anchors to line start — only matches project-level
+#     version, not python-version or target-version under [tool.*] sections)
+sed -i '' 's/^version = ".*"/version = "2026.01.21"/' pyproject.toml
 uv lock
 git add pyproject.toml uv.lock
 git commit -m "Version bump to 2026.01.21"

--- a/plugins/backend-release/skills/release-manager/SKILL.md
+++ b/plugins/backend-release/skills/release-manager/SKILL.md
@@ -170,132 +170,16 @@ Merging preserves the original commit objects so master and release share the
 same ancestry. After the release PR merges to master, `git log master..release`
 correctly shows only genuinely new commits.
 
-### 3. Version Numbering Convention
+### 3. Version Numbering, PR Formats, Conflict Resolution, and GitHub Releases
 
-| Scenario | Version Format | Example |
-|----------|---------------|---------|
-| First release of day | `YYYY.MM.DD` | `2026.01.21` |
-| Second release | `YYYY.MM.DD-2` | `2026.01.21-2` |
-| Third release | `YYYY.MM.DD-3` | `2026.01.21-3` |
-| Hotfix release | `YYYY.MM.DD` or `YYYY.MM.DD-N` | `2026.01.21` |
+See [detailed-procedures.md](references/detailed-procedures.md) for:
 
-### 4. PR Title and Body Format
+- Version numbering conventions (`YYYY.MM.DD[-N]`)
+- PR title patterns (Promotion, Release, Hotfix)
+- Resolving merge conflicts
+- Publishing GitHub releases (merge strategy, verification, creation)
 
-**Title patterns:**
-- Promotion: `Promotion: 21st January 2026`
-- Regular release: `Release: 21st January 2026`
-- Multiple same-day: `Release 2: 21st January 2026`
-- Hotfix: `Hotfix Release: 21st January 2026`
-
-**Promotion PR body format:**
-```markdown
-- https://github.com/DiversioTeam/Django4Lyfe/pull/XXXX
-- https://github.com/DiversioTeam/Django4Lyfe/pull/YYYY
-```
-
-**Release/Hotfix PR body format:**
-```markdown
-- https://github.com/DiversioTeam/Django4Lyfe/pull/XXXX
-- https://github.com/DiversioTeam/Django4Lyfe/pull/YYYY
-```
-
-### 5. Resolve Conflicts (If Any)
-
-If the merge has conflicts:
-
-```bash
-# 1. Edit conflicted files to keep correct changes
-# 2. For uv.lock conflicts, regenerate:
-git checkout --theirs uv.lock
-uv lock
-
-# 3. Stage resolved files
-git add <resolved-files>
-
-# 4. Complete merge
-git commit -m "Merge origin/release into releases/YYYY.MM.DD"
-```
-
-### 6. Publish GitHub Release
-
-After PR is merged to master, create a GitHub release.
-
-**IMPORTANT: Merge Strategy** — Release PRs to master MUST be merged using
-**"Create a merge commit"** (not squash). Squash merging breaks commit ancestry
-and causes `master..release` to grow unboundedly. If GitHub is configured to
-allow multiple merge strategies, always select "Create a merge commit" for
-release PRs.
-
-#### Step 1: Verify PR is merged
-
-```bash
-gh pr view <PR_NUMBER> --json state,mergeCommit,mergedAt
-# Should show: "state": "MERGED"
-```
-
-#### Step 2: Check recent releases for format consistency
-
-```bash
-gh release list --limit 5
-```
-
-#### Step 3: Get PR details for release notes
-
-```bash
-# Get the PR body which contains the list of included PRs
-gh pr view <PR_NUMBER> --json body,title
-```
-
-#### Step 4: Create the GitHub release
-
-```bash
-gh release create YYYY.MM.DD[-N] \
-  --title "Release Title" \
-  --notes "$(cat <<'EOF'
-- https://github.com/DiversioTeam/Django4Lyfe/pull/XXXX
-- https://github.com/DiversioTeam/Django4Lyfe/pull/YYYY
-EOF
-)" \
-  --target master
-```
-
-#### GitHub Release Title Patterns
-
-| Release Type | Tag | Title |
-|--------------|-----|-------|
-| First of day | `2026.01.21` | `January 21st 2026` |
-| Second release | `2026.01.21-2` | `Release 2: January 21st 2026` |
-| Third release | `2026.01.21-3` | `Release 3: January 21st 2026` |
-| Hotfix | `2026.01.21` | `Hotfix Release: January 21st 2026` |
-
-#### Step 5: Verify release was created
-
-```bash
-gh release list --limit 3
-# Or view specific release:
-gh release view YYYY.MM.DD[-N]
-```
-
-#### Complete Example
-
-```bash
-# 1. Check PR is merged
-gh pr view 2608 --json state,mergeCommit,mergedAt
-
-# 2. Create release (using heredoc for multi-line notes)
-gh release create 2026.01.21 \
-  --title "January 21st 2026" \
-  --notes "$(cat <<'EOF'
-- https://github.com/DiversioTeam/Django4Lyfe/pull/2607
-EOF
-)" \
-  --target master
-
-# 3. Verify
-gh release list --limit 3
-```
-
-### 7. Merge Master Back Into Release AND Dev
+### 4. Merge Master Back Into Release AND Dev
 
 **This step is mandatory after every release PR merge.** It keeps all three
 branches in sync so future work starts from a consistent baseline.
@@ -426,84 +310,8 @@ When listing releases:
 
 ## Full End-to-End Example
 
-Here's a complete example of promoting and releasing PR #2607:
-
-```bash
-# ============================================
-# PHASE 1: Promote dev → release (staging)
-# ============================================
-
-# 1. Check what's on dev but not release
-git fetch origin dev release
-git diff --stat origin/release origin/dev
-
-# 2. Create promotion branch and merge dev
-git checkout -b promote/2026.01.21 origin/release
-git merge origin/dev --no-edit
-git push -u origin promote/2026.01.21
-gh pr create --base release \
-  --title "Promotion: 21st January 2026" \
-  --body "- https://github.com/DiversioTeam/Django4Lyfe/pull/2607"
-
-# 3. After promotion PR is merged, staging deploy triggers automatically.
-#    Validate staging before proceeding.
-
-# ============================================
-# PHASE 2: Release release → master (production)
-# ============================================
-
-# 4. Check what needs releasing
-git fetch origin master release
-git diff --stat origin/master origin/release
-# Output shows files changed — confirms there IS something to release
-
-# 5. Identify which PRs are included
-LAST_RELEASE_DATE=$(gh pr list --base master --state merged --limit 100 \
-  --json number,title,mergedAt \
-  --jq '[.[] | select(.title | test("^(Release|Hotfix)"))] | sort_by(.mergedAt) | last | .mergedAt // empty' \
-  2>/dev/null || echo "")
-gh pr list --base release --state merged --limit 100 --json number,title,mergedAt \
-  --jq "[.[] | select(.mergedAt > \"${LAST_RELEASE_DATE}\")] | sort_by(.mergedAt) | .[] | \"#\\(.number): \\(.title)\""
-# Output: #2607: #GH-4420: Include alert notifications in Slack App Home
-
-# 6. Create branch from master and merge release
-git checkout -b releases/2026.01.21 origin/master
-git merge origin/release --no-edit
-
-# 7. Bump version (^ anchors to line start — only matches project-level
-#     version, not python-version or target-version under [tool.*] sections)
-sed -i '' 's/^version = ".*"/version = "2026.01.21"/' pyproject.toml
-uv lock
-git add pyproject.toml uv.lock
-git commit -m "Version bump to 2026.01.21"
-
-# 8. Push and create release PR
-git push -u origin releases/2026.01.21
-gh pr create --base master \
-  --title "Release: 21st January 2026" \
-  --body "- https://github.com/DiversioTeam/Django4Lyfe/pull/2607"
-
-# 9. After PR is merged, publish GitHub release
-gh pr view 2608 --json state  # Verify merged
-gh release create 2026.01.21 \
-  --title "January 21st 2026" \
-  --notes "- https://github.com/DiversioTeam/Django4Lyfe/pull/2607" \
-  --target master
-
-# 10. Merge master back into release AND dev (MANDATORY)
-git fetch origin
-git checkout release
-git merge origin/master --no-edit
-git push origin release
-git checkout dev
-git merge origin/release --no-edit
-git push origin dev
-
-# 11. Verify
-gh release list --limit 3
-git diff --stat origin/master origin/release  # Should be empty
-git diff --stat origin/release origin/dev      # Should be empty
-```
+See [detailed-procedures.md](references/detailed-procedures.md#full-end-to-end-example) for a
+complete walkthrough of both phases (promotion + release) with copy-paste commands.
 
 ## Quick Reference Commands
 
@@ -554,30 +362,5 @@ gh release view <TAG> --json body,tagName,name
 
 ## Error Recovery
 
-### Merge conflict during release branch creation
-```bash
-# For uv.lock conflicts:
-git checkout --theirs uv.lock
-uv lock
-git add uv.lock
-
-# For code conflicts: resolve manually, then:
-git add <resolved-files>
-git commit  # Completes the merge
-```
-
-### Wrong version bumped
-```bash
-# Edit pyproject.toml to correct version
-uv lock
-git add pyproject.toml uv.lock
-git commit --amend -m "Version bump to correct-version"
-git push --force-with-lease  # Only if not yet reviewed
-```
-
-### PR created against wrong base
-```bash
-gh pr close <NUMBER>
-# Create new PR with correct base
-gh pr create --base master ...
-```
+See [detailed-procedures.md](references/detailed-procedures.md#error-recovery) for merge conflict
+resolution, wrong-version fixes, and wrong-base PR recovery.

--- a/plugins/backend-release/skills/release-manager/SKILL.md
+++ b/plugins/backend-release/skills/release-manager/SKILL.md
@@ -1,26 +1,71 @@
 ---
 name: release-manager
-description: "Create and manage release PRs against master branch. Use this when preparing releases, bumping versions, resolving merge conflicts, and publishing GitHub releases. Handles the full release workflow including merging release into master, version bumping in pyproject.toml, running uv lock, and creating GitHub releases."
+description: "Create and manage promotion and release PRs for Django4Lyfe. Use this when preparing staging promotion PRs (dev→release), production release PRs (release→master), bumping versions, resolving merge conflicts, and publishing GitHub releases. Handles the full three-branch workflow."
 allowed-tools: Bash Read Edit Grep Glob
-argument-hint: "[action] (e.g., create, publish, check)"
+argument-hint: "[action] (e.g., promote-staging, release-prod, publish, check)"
 ---
 
 # Release Manager Skill
 
-Manages the full release workflow for Django4Lyfe backend releases to production.
+Manages the full release workflow for Django4Lyfe backend releases.
+
+## Branch Model
+
+```
+feature PRs
+    │  merge to dev (validation only, no deploy)
+    ▼
+   dev    ── integration branch
+    │  promotion PR (dev → release) → staging deploy
+    ▼
+release   ── staging promotion branch
+    │  release PR (release → master) → production deploy
+    ▼
+master    ── production branch
+```
 
 ## When to Use This Skill
 
-- Creating release PRs against master branch
+- Creating **promotion PRs** from `dev` → `release` to deploy staging
+- Creating **release PRs** from `release` → `master` to deploy production
 - Preparing hotfix releases
 - Bumping versions in pyproject.toml
-- Resolving merge conflicts between release and master
+- Resolving merge conflicts between branches
 - Publishing GitHub releases after PRs are merged
-- Checking what commits are on release but not on master
+- Checking what commits are pending promotion or release
 
 ## Core Workflow
 
-### 1. Check What Needs Releasing
+### 0. Promotion PR: dev → release (Staging Deploy)
+
+Before a production release, promote changes from the integration branch to
+the staging branch. This is the ONLY path that triggers staging deploy.
+
+```bash
+# 1. Check what's on dev but not yet on release
+git fetch origin dev release
+git diff --stat origin/release origin/dev
+
+# 2. Create promotion branch from release
+git checkout -b promote/YYYY.MM.DD[-N] origin/release
+
+# 3. Merge dev into it
+git merge origin/dev --no-edit
+
+# 4. Push and create promotion PR
+git push -u origin promote/YYYY.MM.DD[-N]
+gh pr create --base release --title "Promotion: DDth Month YYYY" --body "..."
+```
+
+**Why this exists**: Routine feature PRs merge into `dev` with validation only
+— no staging deploy.  The promotion PR is the intentional gate that says
+"these changes are ready for staging."  Merging the promotion PR into
+`release` triggers `run_staging_deploy=true` in CI.
+
+**After merge**: Validate staging.  If issues are found, fix them on `dev` and
+create a new promotion PR.  Do not fix directly on `release`.
+
+### 1. Check What Needs Releasing (release → master)
 
 ```bash
 git fetch origin master release
@@ -222,24 +267,28 @@ EOF
 gh release list --limit 3
 ```
 
-### 7. Merge Master Back Into Release
+### 7. Merge Master Back Into Release AND Dev
 
 **This step is mandatory after every release PR merge.** It keeps the branches
-in sync so that `git diff --stat origin/master origin/release` is clean and
-future releases start from a consistent baseline.
+in sync so future releases start from a consistent baseline.
 
 ```bash
 git fetch origin
 git checkout release
 git merge origin/master --no-edit
 git push origin release
+
+# ALSO sync dev so the integration branch stays current with production
+git checkout dev
+git merge origin/release --no-edit
+git push origin dev
 ```
 
 **Why this matters**: After a release PR merges into master, master has a merge
-commit and a version-bump commit that release doesn't. Without merge-back,
+commit and a version-bump commit that release and dev don't. Without merge-back,
 `git diff --stat origin/master origin/release` shows the version bump as a
-pending difference, and the next `git merge origin/release` will conflict on
-`pyproject.toml` / `uv.lock`. The merge-back keeps both branches aligned.
+pending difference.  Without the dev sync, the integration branch drifts from
+production, and subsequent feature branches are developed against a stale base.
 
 ## Pre-Release Checks
 
@@ -307,20 +356,44 @@ When listing releases:
 6. **Verify PR is merged before publishing release** — Check with `gh pr view`
 7. **Always publish GitHub release after merge** — Every merged release PR needs a corresponding GitHub release
 8. **Tag must match version in pyproject.toml** — e.g., version `2026.01.21-2` = tag `2026.01.21-2`
-9. **Always merge master back into release after publish** — Run `git merge origin/master --no-edit` on release after every release PR merge. Without this, the version bump stays only on master, causing `git diff --stat` to show false differences and the next release merge to conflict.
+9. **Always merge master back into release AND dev after publish** — Run `git merge origin/master --no-edit` on release, then merge release into dev. Without this, the version bump stays only on master, causing stale diffs and future merge conflicts.
 10. **Never squash-merge release PRs** — Release PRs to master MUST use "Create a merge commit". Squash merging breaks commit ancestry tracking.
+11. **Staging deploy only on promotion PRs** — Only a `dev → release` promotion PR triggers staging deploy. Routine feature merges to `dev` run validation only.
 
 ## Full End-to-End Example
 
-Here's a complete example of releasing PR #2607:
+Here's a complete example of promoting and releasing PR #2607:
 
 ```bash
-# 1. Check what needs releasing (diff is the source of truth)
+# ============================================
+# PHASE 1: Promote dev → release (staging)
+# ============================================
+
+# 1. Check what's on dev but not release
+git fetch origin dev release
+git diff --stat origin/release origin/dev
+
+# 2. Create promotion branch and merge dev
+git checkout -b promote/2026.01.21 origin/release
+git merge origin/dev --no-edit
+git push -u origin promote/2026.01.21
+gh pr create --base release \
+  --title "Promotion: 21st January 2026" \
+  --body "- https://github.com/DiversioTeam/Django4Lyfe/pull/2607"
+
+# 3. After promotion PR is merged, staging deploy triggers automatically.
+#    Validate staging before proceeding.
+
+# ============================================
+# PHASE 2: Release release → master (production)
+# ============================================
+
+# 4. Check what needs releasing
 git fetch origin master release
 git diff --stat origin/master origin/release
 # Output shows files changed — confirms there IS something to release
 
-# 2. Identify which PRs are included (uses release PR merge date as cutoff)
+# 5. Identify which PRs are included
 LAST_RELEASE_DATE=$(gh pr list --base master --state merged --limit 100 \
   --json number,title,mergedAt \
   --jq '[.[] | select(.title | test("^(Release|Hotfix)"))] | sort_by(.mergedAt) | last | .mergedAt // empty' \
@@ -329,24 +402,17 @@ gh pr list --base release --state merged --limit 100 --json number,title,mergedA
   --jq "[.[] | select(.mergedAt > \"${LAST_RELEASE_DATE}\")] | sort_by(.mergedAt) | .[] | \"#\\(.number): \\(.title)\""
 # Output: #2607: #GH-4420: Include alert notifications in Slack App Home
 
-# 3. Check today's date
-date  # Wed Jan 21 2026
-
-# 4. Create branch from master and merge release
+# 6. Create branch from master and merge release
 git checkout -b releases/2026.01.21 origin/master
 git merge origin/release --no-edit
 
-# 5. Bump version
+# 7. Bump version
 sed -i '' 's/version = ".*"/version = "2026.01.21"/' pyproject.toml
-
-# 6. Update lock file
 uv lock
-
-# 7. Commit version bump
 git add pyproject.toml uv.lock
 git commit -m "Version bump to 2026.01.21"
 
-# 8. Push and create PR
+# 8. Push and create release PR
 git push -u origin releases/2026.01.21
 gh pr create --base master \
   --title "Release: 21st January 2026" \
@@ -359,30 +425,54 @@ gh release create 2026.01.21 \
   --notes "- https://github.com/DiversioTeam/Django4Lyfe/pull/2607" \
   --target master
 
-# 10. Merge master back into release (MANDATORY)
+# 10. Merge master back into release AND dev (MANDATORY)
 git fetch origin
 git checkout release
 git merge origin/master --no-edit
 git push origin release
+git checkout dev
+git merge origin/release --no-edit
+git push origin dev
 
-# 11. Verify release and branch sync
+# 11. Verify
 gh release list --limit 3
 git diff --stat origin/master origin/release  # Should be empty
+git diff --stat origin/release origin/dev      # Should be empty
 ```
 
 ## Quick Reference Commands
 
 ```bash
-# Check what's pending release (source of truth — compares actual file contents)
+# Check what's pending promotion (dev → release)
+git fetch origin dev release && git diff --stat origin/release origin/dev
+
+# Check what's pending release (release → master)
 git fetch origin master release && git diff --stat origin/master origin/release
 
-# Identify new PRs (uses last release PR's merge date as cutoff)
+# Check all three branches are in sync (should all be empty after release)
+git fetch origin dev release master && \
+  git diff --stat origin/release origin/dev && \
+  git diff --stat origin/master origin/release
+
+# Identify new PRs since last release
 LAST_RELEASE_DATE=$(gh pr list --base master --state merged --limit 100 \
   --json number,title,mergedAt \
   --jq '[.[] | select(.title | test("^(Release|Hotfix)"))] | sort_by(.mergedAt) | last | .mergedAt // empty' \
   2>/dev/null || echo "") && \
   gh pr list --base release --state merged --limit 100 --json number,title,mergedAt \
     --jq "[.[] | select(.mergedAt > \"${LAST_RELEASE_DATE}\")] | sort_by(.mergedAt) | .[] | \"#\\(.number): \\(.title)\""
+
+# Create promotion PR (dev → release, triggers staging deploy)
+git checkout -b promote/YYYY.MM.DD[-N] origin/release
+git merge origin/dev --no-edit
+git push -u origin promote/YYYY.MM.DD[-N]
+gh pr create --base release --title "Promotion: DDth Month YYYY"
+
+# Create release PR (release → master, triggers production deploy)
+git checkout -b releases/YYYY.MM.DD[-N] origin/master
+git merge origin/release --no-edit
+# (bump version, uv lock, commit, then:)
+gh pr create --base master --title "Release: DDth Month YYYY"
 
 # Check current version
 grep '^version' pyproject.toml

--- a/plugins/backend-release/skills/release-manager/references/detailed-procedures.md
+++ b/plugins/backend-release/skills/release-manager/references/detailed-procedures.md
@@ -1,0 +1,241 @@
+# Release Manager — Detailed Reference
+
+This file contains the detailed procedural steps that complement the
+orchestrating SKILL.md.  Read the SKILL.md first for when to use this
+skill and the core workflow, then refer here for step-by-step detail.
+
+## Version Numbering Convention
+
+| Scenario | Version Format | Example |
+|----------|---------------|---------|
+| First release of day | `YYYY.MM.DD` | `2026.01.21` |
+| Second release | `YYYY.MM.DD-2` | `2026.01.21-2` |
+| Third release | `YYYY.MM.DD-3` | `2026.01.21-3` |
+| Hotfix release | `YYYY.MM.DD` or `YYYY.MM.DD-N` | `2026.01.21` |
+
+## PR Title and Body Format
+
+**Title patterns:**
+- Promotion: `Promotion: 21st January 2026`
+- Regular release: `Release: 21st January 2026`
+- Multiple same-day: `Release 2: 21st January 2026`
+- Hotfix: `Hotfix Release: 21st January 2026`
+
+**Promotion PR body:**
+```markdown
+- https://github.com/DiversioTeam/Django4Lyfe/pull/XXXX
+- https://github.com/DiversioTeam/Django4Lyfe/pull/YYYY
+```
+
+**Release/Hotfix PR body:**
+```markdown
+- https://github.com/DiversioTeam/Django4Lyfe/pull/XXXX
+- https://github.com/DiversioTeam/Django4Lyfe/pull/YYYY
+```
+
+## Resolving Merge Conflicts
+
+If the merge has conflicts:
+
+```bash
+# 1. Edit conflicted files to keep correct changes
+# 2. For uv.lock conflicts, regenerate:
+git checkout --theirs uv.lock
+uv lock
+
+# 3. Stage resolved files
+git add <resolved-files>
+
+# 4. Complete merge
+git commit -m "Merge origin/release into releases/YYYY.MM.DD"
+```
+
+## Publishing a GitHub Release
+
+After the release PR is merged to master, create a GitHub release.
+
+**IMPORTANT: Merge Strategy** — Release PRs to master MUST be merged using
+**"Create a merge commit"** (not squash). Squash merging breaks commit ancestry
+and causes `master..release` to grow unboundedly. If GitHub is configured to
+allow multiple merge strategies, always select "Create a merge commit" for
+release PRs.
+
+### Step 1: Verify PR is merged
+
+```bash
+gh pr view <PR_NUMBER> --json state,mergeCommit,mergedAt
+# Should show: "state": "MERGED"
+```
+
+### Step 2: Check recent releases for format consistency
+
+```bash
+gh release list --limit 5
+```
+
+### Step 3: Get PR details for release notes
+
+```bash
+# Get the PR body which contains the list of included PRs
+gh pr view <PR_NUMBER> --json body,title
+```
+
+### Step 4: Create the GitHub release
+
+```bash
+gh release create YYYY.MM.DD[-N] \
+  --title "Release Title" \
+  --notes "$(cat <<'EOF'
+- https://github.com/DiversioTeam/Django4Lyfe/pull/XXXX
+- https://github.com/DiversioTeam/Django4Lyfe/pull/YYYY
+EOF
+)" \
+  --target master
+```
+
+### GitHub Release Title Patterns
+
+| Release Type | Tag | Title |
+|--------------|-----|-------|
+| First of day | `2026.01.21` | `January 21st 2026` |
+| Second release | `2026.01.21-2` | `Release 2: January 21st 2026` |
+| Third release | `2026.01.21-3` | `Release 3: January 21st 2026` |
+| Hotfix | `2026.01.21` | `Hotfix Release: January 21st 2026` |
+
+### Step 5: Verify release was created
+
+```bash
+gh release list --limit 3
+# Or view specific release:
+gh release view YYYY.MM.DD[-N]
+```
+
+### Complete Example
+
+```bash
+# 1. Check PR is merged
+gh pr view 2608 --json state,mergeCommit,mergedAt
+
+# 2. Create release (using heredoc for multi-line notes)
+gh release create 2026.01.21 \
+  --title "January 21st 2026" \
+  --notes "$(cat <<'EOF'
+- https://github.com/DiversioTeam/Django4Lyfe/pull/2607
+EOF
+)" \
+  --target master
+
+# 3. Verify
+gh release list --limit 3
+```
+
+## Full End-to-End Example
+
+Here's a complete example of promoting and releasing PR #2607:
+
+```bash
+# ============================================
+# PHASE 1: Promote dev → release (staging)
+# ============================================
+
+# 1. Check what's on dev but not release
+git fetch origin dev release
+git diff --stat origin/release origin/dev
+
+# 2. Create promotion branch and merge dev
+git checkout -b promote/2026.01.21 origin/release
+git merge origin/dev --no-edit
+git push -u origin promote/2026.01.21
+gh pr create --base release \
+  --title "Promotion: 21st January 2026" \
+  --body "- https://github.com/DiversioTeam/Django4Lyfe/pull/2607"
+
+# 3. After promotion PR is merged, staging deploy triggers automatically.
+#    Validate staging before proceeding.
+
+# ============================================
+# PHASE 2: Release release → master (production)
+# ============================================
+
+# 4. Check what needs releasing
+git fetch origin master release
+git diff --stat origin/master origin/release
+# Output shows files changed — confirms there IS something to release
+
+# 5. Identify which PRs are included
+LAST_RELEASE_DATE=$(gh pr list --base master --state merged --limit 100 \
+  --json number,title,mergedAt \
+  --jq '[.[] | select(.title | test("^(Release|Hotfix)"))] | sort_by(.mergedAt) | last | .mergedAt // empty' \
+  2>/dev/null || echo "")
+gh pr list --base release --state merged --limit 100 --json number,title,mergedAt \
+  --jq "[.[] | select(.mergedAt > \"${LAST_RELEASE_DATE}\")] | sort_by(.mergedAt) | .[] | \"#\\(.number): \\(.title)\""
+# Output: #2607: #GH-4420: Include alert notifications in Slack App Home
+
+# 6. Create branch from master and merge release
+git checkout -b releases/2026.01.21 origin/master
+git merge origin/release --no-edit
+
+# 7. Bump version (^ anchors to line start — only matches project-level
+#     version, not python-version or target-version under [tool.*] sections)
+sed -i '' 's/^version = ".*"/version = "2026.01.21"/' pyproject.toml
+uv lock
+git add pyproject.toml uv.lock
+git commit -m "Version bump to 2026.01.21"
+
+# 8. Push and create release PR
+git push -u origin releases/2026.01.21
+gh pr create --base master \
+  --title "Release: 21st January 2026" \
+  --body "- https://github.com/DiversioTeam/Django4Lyfe/pull/2607"
+
+# 9. After PR is merged, publish GitHub release
+gh pr view 2608 --json state  # Verify merged
+gh release create 2026.01.21 \
+  --title "January 21st 2026" \
+  --notes "- https://github.com/DiversioTeam/Django4Lyfe/pull/2607" \
+  --target master
+
+# 10. Merge master back into release AND dev (MANDATORY)
+git fetch origin
+git checkout release
+git merge origin/master --no-edit
+git push origin release
+git checkout dev
+git merge origin/release --no-edit
+git push origin dev
+
+# 11. Verify
+gh release list --limit 3
+git diff --stat origin/master origin/release  # Should be empty
+git diff --stat origin/release origin/dev      # Should be empty
+```
+
+## Error Recovery
+
+### Merge conflict during release branch creation
+```bash
+# For uv.lock conflicts:
+git checkout --theirs uv.lock
+uv lock
+git add uv.lock
+
+# For code conflicts: resolve manually, then:
+git add <resolved-files>
+git commit  # Completes the merge
+```
+
+### Wrong version bumped
+```bash
+# Edit pyproject.toml to correct version
+uv lock
+git add pyproject.toml uv.lock
+git commit --amend -m "Version bump to correct-version"
+git push --force-with-lease  # Only if not yet reviewed
+```
+
+### PR created against wrong base
+```bash
+gh pr close <NUMBER>
+# Create new PR with correct base
+gh pr create --base master ...
+```


### PR DESCRIPTION
## Summary

Updates the `backend-pr-workflow` skill to reflect the new `dev` integration branch model for Django4Lyfe.

## Key Changes

- **Base branch selection**: Default feature PR base is now `dev` (not `release`)
- **Staging promotion**: Added `dev → release` promotion PR flow with staging deploy consequences
- **Release flow**: Updated to `dev → release → master` three-branch model

## Why

Backend PRs now target `dev` by default (companion PR `DiversioTeam/Django4Lyfe#3052`). This skill tells agents which base branch to use when creating or reviewing backend PRs — stale instructions would cause agents to open PRs against the wrong branch.