### PR TITLE
Add Xquik plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -215,6 +215,17 @@
       "source": "./plugins/frontend",
       "category": "process",
       "keywords": ["frontend", "digest", "react", "monorepo", "design-system", "review", "testing", "api", "cicd", "workflow", "diversio"]
+    },
+    {
+      "name": "xquik",
+      "description": "Use Xquik REST, MCP, SDKs, and webhooks for X data workflows.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Xquik"
+      },
+      "source": "./plugins/xquik",
+      "category": "data",
+      "keywords": ["x", "twitter", "mcp", "rest-api", "sdk", "webhooks", "xquik"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ agent-skills-marketplace/
 │   │       ├── review.md
 │   │       ├── commit.md
 │   │       └── new-branch.md
+│   └── xquik/                         # X data workflow skill
+│       ├── .claude-plugin/plugin.json
+│       ├── skills/xquik/SKILL.md
+│       └── commands/work.md
 ├── AGENTS.md                          # Source of truth for Claude Code behavior
 ├── CLAUDE.md                          # Sources AGENTS.md
 ├── README.md
@@ -288,6 +292,7 @@ agent-skills-marketplace/
 | `terraform` | Terraform/Terragrunt workflows: atomic-commit quality gates and PR workflow checks |
 | `login-cta-attribution-skill` | CTA login attribution implementation Skill for Django4Lyfe - guides adding new CTA sources, button/tab attribution, and enum registration |
 | `frontend` | Digest-first frontend skill with repo classification, dynamic detection, and internal lane routing for review, API, testing, analytics, observability, CI/CD, planning, and commit workflows |
+| `xquik` | X data workflows through Xquik REST, MCP, SDKs, webhooks, and the `x-developer` package |
 
 ## Available Pi Packages
 
@@ -303,7 +308,7 @@ sub-package so pi can discover them from a single clone - see
 | `image-router` | Pi-native image routing extension that describes screenshots and other image inputs with a vision-capable model when the active model is text-only |
 | `oh-my-pi` | Pi-native cmux integration with native cmux notifications (Waiting / Task Complete / Error), readable split pane commands (`/omp-split-*`) and workspace tab commands (`/omp-workspace*`), plus short aliases for faster typing. Low-level cmux primitives are shared via `@diversio/pi-cmux`. Works only inside cmux |
 | `pi-timestamps` | Pi-native subtle transcript timing rows for exact timestamps and reply-start timing, plus a playful live status line for the newest turn |
-| `skills-bridge` | Auto-discovers all 21 Claude Code plugin skills from plugins/*/skills/ and registers them as pi skills. One install bridges the gap between the plugin ecosystem and pi |
+| `skills-bridge` | Auto-discovers all 22 Claude Code plugin skills from plugins/*/skills/ and registers them as pi skills. One install bridges the gap between the plugin ecosystem and pi |
 
 Helpful mental model:
 
@@ -474,6 +479,7 @@ claude plugin install dependabot-remediation@diversiotech
 claude plugin install terraform@diversiotech
 claude plugin install login-cta-attribution-skill@diversiotech
 claude plugin install frontend@diversiotech
+claude plugin install xquik@diversiotech
 ```
 
 For project-scoped installation (shared with collaborators via `.claude/settings.json`):
@@ -509,6 +515,7 @@ claude plugin install monty-code-review@diversiotech --scope project
 | Terraform workflows | `claude plugin install terraform@diversiotech` |
 | Login CTA attribution | `claude plugin install login-cta-attribution-skill@diversiotech` |
 | Frontend (all lanes) | `claude plugin install frontend@diversiotech` |
+| Xquik X data workflows | `claude plugin install xquik@diversiotech` |
 
 </details>
 
@@ -571,6 +578,7 @@ Once plugins are installed:
    /frontend:review                        # Review a frontend PR using the repo-local digest and Bumang-style priorities
    /frontend:commit                        # Create a digest-aware atomic frontend commit with quality gates
    /frontend:new-branch                    # Create a frontend branch using the repo's detected branch model
+   /xquik:work                             # Use Xquik for X data workflows
    /omp-split-right                          # Recommended default: open new right-side cmux split → fresh Pi session
    /omp-split-right-command <cmd>            # Recommended default: open new right-side cmux split → shell command
    /omp-split-down                           # Recommended default: open new down-side cmux split → fresh Pi session
@@ -687,6 +695,7 @@ claude plugin uninstall dependabot-remediation@diversiotech
 claude plugin uninstall terraform@diversiotech
 claude plugin uninstall login-cta-attribution-skill@diversiotech
 claude plugin uninstall frontend@diversiotech
+claude plugin uninstall xquik@diversiotech
 ```
 
 **Step 3: Uninstall project-scoped plugins (if any)**
@@ -713,6 +722,7 @@ claude plugin uninstall dependabot-remediation@diversiotech --scope project
 claude plugin uninstall terraform@diversiotech --scope project
 claude plugin uninstall login-cta-attribution-skill@diversiotech --scope project
 claude plugin uninstall frontend@diversiotech --scope project
+claude plugin uninstall xquik@diversiotech --scope project
 ```
 
 </details>
@@ -766,7 +776,8 @@ python3 "$CODEX_HOME/skills/.system/skill-installer/scripts/install-skill-from-g
     plugins/terraform/skills/terraform-atomic-commit \
     plugins/terraform/skills/terraform-pr-workflow \
     plugins/login-cta-attribution-skill/skills/login-cta-attribution-skill \
-    plugins/frontend/skills/frontend
+    plugins/frontend/skills/frontend \
+    plugins/xquik/skills/xquik
 ```
 
 **Codex console alternative:**
@@ -793,7 +804,8 @@ $skill-installer install from github repo=DiversioTeam/agent-skills-marketplace 
   path=plugins/terraform/skills/terraform-atomic-commit \
   path=plugins/terraform/skills/terraform-pr-workflow \
   path=plugins/login-cta-attribution-skill/skills/login-cta-attribution-skill \
-  path=plugins/frontend/skills/frontend
+  path=plugins/frontend/skills/frontend \
+  path=plugins/xquik/skills/xquik
 ```
 
 </details>
@@ -842,7 +854,8 @@ rm -rf "$CODEX_HOME/skills/monty-code-review" \
        "$CODEX_HOME/skills/terraform-atomic-commit" \
        "$CODEX_HOME/skills/terraform-pr-workflow" \
        "$CODEX_HOME/skills/login-cta-attribution-skill" \
-       "$CODEX_HOME/skills/frontend"
+       "$CODEX_HOME/skills/frontend" \
+       "$CODEX_HOME/skills/xquik"
 echo "Done. Restart Codex and reinstall skills."
 ```
 

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -130,7 +130,7 @@ when command files change.
   - Purpose: auto-discovers Claude Code plugin skills from
     `plugins/*/skills/` directories and registers them as pi
     skills via the `resources_discover` extension hook. One install makes all
-    21 plugin skills available in pi without restructuring the
+    22 plugin skills available in pi without restructuring the
     repo.
   - Pi install from repo checkout:
     `pi install "$PWD/pi-packages/skills-bridge"`
@@ -148,7 +148,7 @@ when command files change.
     `clickup-ticket`, `github-ticket`, `repo-docs-generator`,
     `visual-explainer`, `dependabot-remediation`, `terraform-atomic-commit`,
     `terraform-pr-workflow`, `login-cta-attribution-skill`,
-    `monolith-review-orchestrator`, `frontend` (21 total).
+    `monolith-review-orchestrator`, `frontend`, `xquik` (22 total).
   - Context safe: only skill names + descriptions enter context at startup
     (~5-10KB); full SKILL.md loads on demand via progressive disclosure.
 - `monolith-review-orchestrator`
@@ -314,6 +314,12 @@ when command files change.
   - Skill path:
     `plugins/login-cta-attribution-skill/skills/login-cta-attribution-skill`
   - Slash commands: `/login-cta-attribution-skill:implement`
+- `xquik`
+  - Purpose: X data workflows through Xquik REST, MCP, SDKs, webhooks, and the
+    `x-developer` package.
+  - Claude install: `claude plugin install xquik@diversiotech`
+  - Skill path: `plugins/xquik/skills/xquik`
+  - Slash commands: `/xquik:work`
 
 ## Frontend
 

--- a/docs/runbooks/distribution.md
+++ b/docs/runbooks/distribution.md
@@ -61,6 +61,7 @@ PLUGINS=(
   terraform
   login-cta-attribution-skill
   frontend
+  xquik
 )
 
 for plugin in "${PLUGINS[@]}"; do
@@ -101,6 +102,7 @@ PLUGINS=(
   terraform
   login-cta-attribution-skill
   frontend
+  xquik
 )
 
 for plugin in "${PLUGINS[@]}"; do
@@ -350,6 +352,7 @@ SKILLS=(
   terraform-pr-workflow
   login-cta-attribution-skill
   frontend
+  xquik
 )
 
 for skill in "${SKILLS[@]}"; do

--- a/plugins/xquik/.claude-plugin/plugin.json
+++ b/plugins/xquik/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "xquik",
+  "version": "0.1.0",
+  "description": "Use Xquik REST, MCP, SDKs, and webhooks for X data workflows.",
+  "author": {
+    "name": "Xquik"
+  }
+}

--- a/plugins/xquik/commands/work.md
+++ b/plugins/xquik/commands/work.md
@@ -1,0 +1,10 @@
+---
+description: Use Xquik for X data workflows through REST, MCP, SDKs, or webhooks.
+argument-hint: "<task>"
+---
+
+Invoke the `xquik` skill for `$ARGUMENTS`.
+
+If no task is provided, ask which X data workflow the user wants to run,
+validate the required Xquik API key or MCP setup, and keep write operations
+behind explicit user confirmation.

--- a/plugins/xquik/skills/xquik/SKILL.md
+++ b/plugins/xquik/skills/xquik/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: xquik
+description: "Use Xquik for X data workflows through REST, MCP, SDKs, webhooks, and the x-developer package."
+---
+
+# Xquik Skill
+
+## When To Use
+
+Use this skill when a task needs X data through Xquik, including REST API
+workflows, MCP tool use, SDK integration, webhook setup, or the `x-developer`
+package.
+
+## Source Of Truth
+
+- Product docs: `https://docs.xquik.com`
+- MCP overview: `https://docs.xquik.com/mcp/overview`
+- REST API reference: `https://docs.xquik.com/api-reference`
+- Package: `x-developer@2.4.16`
+
+## Setup Checks
+
+1. Confirm the user has an Xquik API key when REST, SDK, MCP, or private data
+   access is needed.
+2. For Node projects, use `x-developer@2.4.16` unless the user asks to check a
+   newer package version.
+3. For MCP use, connect the documented Xquik MCP server and keep API keys in
+   the user's approved secret store.
+4. Do not request, store, or print X login material.
+
+## Workflow
+
+1. Classify the task as read-only data access, write action, webhook handling,
+   SDK setup, or MCP setup.
+2. Read the relevant Xquik docs before generating endpoint names, parameters,
+   or install instructions.
+3. Prefer the smallest integration surface that satisfies the task.
+4. Ask for explicit confirmation before write actions or account-affecting
+   operations.
+5. Return concise implementation steps, code changes, or commands that match
+   the user's project.
+
+## Output
+
+- Include the selected Xquik surface: REST, MCP, SDK, webhook, or package.
+- Include required environment variables by name only.
+- Mention verification steps such as type checks, request shape checks, or
+  package dry runs when relevant.
+- Avoid unsupported capability, pricing, uptime, or performance claims.


### PR DESCRIPTION
## Summary
- Add a public Xquik plugin with one `xquik` skill and `/xquik:work` command.
- Register marketplace metadata and update README, plugin catalog, and distribution runbook mirrors.
- Pin package guidance to `x-developer@2.4.16` and route users to Xquik docs for source truth.

## Validation
- `jq -e . .claude-plugin/marketplace.json`
- `jq -e . plugins/xquik/.claude-plugin/plugin.json`
- `bash scripts/validate-skills.sh`
- Marketplace consistency check matching CI JSON, source, version, and skill presence rules
- `git diff --cached --check`
- Public-surface scan for private or blocked terms returned no matches
