### PR TITLE
Teach workflow and release skills about backend local-ci

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -42,8 +42,8 @@
     },
     {
       "name": "backend-pr-workflow",
-      "description": "Diversio backend PR workflow plugin that follows repo-local PR docs, GitHub issue linkage, safe migrations, and downtime-safe schema changes.",
-      "version": "0.1.6",
+      "description": "Diversio backend PR workflow plugin that follows repo-local PR docs, GitHub issue linkage, local-ci-aware release semantics, safe migrations, and downtime-safe schema changes.",
+      "version": "0.1.7",
       "author": {
         "name": "Diversio Devs"
       },
@@ -53,8 +53,8 @@
     },
     {
       "name": "backend-atomic-commit",
-      "description": "Pedantic backend pre-commit and atomic-commit Skill with an iterative convergence protocol (budgets + stuck detection), enforcing AGENTS.md, repo-local docs, pre-commit hooks, .security/* helpers, and repo-local commit hygiene without AI signatures.",
-      "version": "0.2.6",
+      "description": "Pedantic backend pre-commit and atomic-commit Skill with an iterative convergence protocol (budgets + stuck detection), enforcing AGENTS.md, repo-local docs, pre-commit hooks, .security/* helpers, repo-local commit hygiene, and local-ci validation when the repo exposes it.",
+      "version": "0.2.7",
       "author": {
         "name": "Diversio Devs"
       },
@@ -174,8 +174,8 @@
     },
     {
       "name": "backend-release",
-      "description": "Manages Django4Lyfe release workflow: dev→release promotion PRs (staging deploy), release→master production PRs, version bumping, conflict resolution, GitHub releases, and post-release branch sync.",
-      "version": "0.3.1",
+      "description": "Manages Django4Lyfe release workflow: promotion/release PRs, exact-head local-ci validation, validated deploy-helper triggers, version bumping, conflict resolution, GitHub releases, and post-release branch sync.",
+      "version": "0.3.2",
       "author": {
         "name": "Diversio Devs"
       },

--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ agent-skills-marketplace/
 |--------|-------------|
 | `monolith-review-orchestrator` | Monolith-local PR review harness for deep PR understanding, thread-aware GitHub review acquisition, deterministic worker-owned review worktrees, persistent review context, and author-guiding review output |
 | `monty-code-review` | Hyper-pedantic Django4Lyfe backend code review Skill with a built-in pytest test-hardening lane and persistent JSON-first review memory |
-| `backend-atomic-commit` | Backend pre-commit / atomic-commit Skill with iterative convergence protocol (budgets + stuck detection), enforcing AGENTS.md, pre-commit hooks (including djlint), .security helpers, and repo-local commit hygiene without AI signatures |
-| `backend-pr-workflow` | Backend PR workflow Skill that follows repo-local workflow docs, GitHub issue linkage, and migration safety checks |
+| `backend-atomic-commit` | Backend pre-commit / atomic-commit Skill with iterative convergence protocol (budgets + stuck detection), enforcing AGENTS.md, pre-commit hooks (including djlint), .security helpers, repo-local commit hygiene, and `local-ci run --no-github` when the repo exposes local-ci |
+| `backend-pr-workflow` | Backend PR workflow Skill that follows repo-local workflow docs, GitHub issue linkage, migration safety checks, and the local-ci + validated-deploy-helper backend release model |
 | `bruno-api` | API endpoint documentation generator from Bruno (`.bru`) files that traces Django4Lyfe implementations (DRF/Django Ninja) |
 | `code-review-digest-writer` | Weekly code-review digest writer Skill (repo-agnostic) |
 | `plan-directory` | Structured plan directories with PLAN.md index, numbered task files, and RALPH loop integration for iterative execution |
@@ -283,7 +283,7 @@ agent-skills-marketplace/
 | `github-ticket` | GitHub-native issue management with smart defaults for `monolith`, backlog capture, repo-local execution routing, and project-board hydration |
 | `repo-docs` | Generate and canonicalize repository harness docs: short AGENTS.md maps, README.md, CLAUDE.md stubs, and focused repo-local docs for architecture, gates, and runbooks |
 | `visual-explainer` | Generate presentation-ready HTML explainers for plans, diffs, diagrams, audits, and stakeholder updates with interactive intake, explicit fact-vs-inference separation, and optional Netlify preview publishing |
-| `backend-release` | Django4Lyfe backend release workflow - create release PRs, date-based version bumping (YYYY.MM.DD), and GitHub release publishing |
+| `backend-release` | Django4Lyfe backend release workflow - promotion/release PRs, exact-head local-ci validation, validated deploy-helper triggers, date-based version bumping (YYYY.MM.DD), and GitHub release publishing |
 | `dependabot-remediation` | Unified backend/frontend Dependabot remediation workflow: `.github/dependabot.yml` review/scaffold, backend waves, frontend triage/execute/release, and post-merge closure verification |
 | `terraform` | Terraform/Terragrunt workflows: atomic-commit quality gates and PR workflow checks |
 | `login-cta-attribution-skill` | CTA login attribution implementation Skill for Django4Lyfe - guides adding new CTA sources, button/tab attribution, and enum registration |
@@ -299,7 +299,7 @@ sub-package so pi can discover them from a single clone - see
 | Package | Description |
 |---------|-------------|
 | `ci-status` | Pi-native CI status extension with `/ci`, `/ci-detail`, `/ci-logs`, auto-watch after pushes, widget/status rendering, GitHub Actions + CircleCI support, and LLM CI tools |
-| `dev-workflow` | Pi-native daily developer workflow with 15 core workflow prompts, `/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`, XDG/project prompt config, CI analysis, PR review feedback, release PR prep, local skills, optional pi-subagents chain, and default cmux split launching for subagent-style workflow prompts when Pi runs inside cmux |
+| `dev-workflow` | Pi-native daily developer workflow with 15 core workflow prompts, `/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`, XDG/project prompt config, remote CI analysis, local-ci-aware ship/release prompts, PR review feedback, local skills, optional pi-subagents chain, and default cmux split launching for subagent-style workflow prompts when Pi runs inside cmux |
 | `image-router` | Pi-native image routing extension that describes screenshots and other image inputs with a vision-capable model when the active model is text-only |
 | `oh-my-pi` | Pi-native cmux integration with native cmux notifications (Waiting / Task Complete / Error), readable split pane commands (`/omp-split-*`) and workspace tab commands (`/omp-workspace*`), plus short aliases for faster typing. Low-level cmux primitives are shared via `@diversio/pi-cmux`. Works only inside cmux |
 | `pi-timestamps` | Pi-native subtle transcript timing rows for exact timestamps and reply-start timing, plus a playful live status line for the newest turn |

--- a/docs/plugins/catalog.md
+++ b/docs/plugins/catalog.md
@@ -24,10 +24,10 @@ when command files change.
 - `dev-workflow` (pi package)
   - Purpose: pi-native daily developer workflow with TypeScript extension
     commands, stable workflow prompt codes, XDG/project prompt config,
-    interactive TUI help panel, CI analysis, PR review feedback handling,
-    release PR prep prompts, local skills, optional pi-subagents chain, and
-    default seeded cmux split launching for subagent-style workflow prompts when
-    Pi runs inside cmux.
+    interactive TUI help panel, CI analysis, local-ci-aware ship/release
+    prompts, PR review feedback handling, local skills, optional pi-subagents
+    chain, and default seeded cmux split launching for subagent-style workflow
+    prompts when Pi runs inside cmux.
   - Pi install from repo checkout:
     `pi install "$PWD/pi-packages/dev-workflow"`
   - Package path: `pi-packages/dev-workflow`
@@ -192,16 +192,16 @@ when command files change.
   - Slash commands: `/monty-code-review:code-review`,
     `/monty-code-review:test-hardening`
 - `backend-atomic-commit`
-  - Purpose: backend pre-commit fixes and strict atomic commits aligned to repo-local commit hygiene.
+  - Purpose: backend pre-commit fixes and strict atomic commits aligned to repo-local commit hygiene, including `local-ci run --no-github` when the repo exposes local-ci.
   - Claude install: `claude plugin install backend-atomic-commit@diversiotech`
   - Skill path: `plugins/backend-atomic-commit/skills/backend-atomic-commit`
   - Slash commands: `/backend-atomic-commit:pre-commit`,
     `/backend-atomic-commit:atomic-commit`, `/backend-atomic-commit:commit`
 - `backend-pr-workflow`
   - Purpose: backend PR workflow for the dev→release→master branch model
-    (feature PRs target dev, promotion PRs trigger staging, release PRs deploy
-    production), GitHub issue linkage, Django migration safety, and
-    downtime-safe schema changes.
+    (feature PRs target dev, release/master deploys use local-ci plus the
+    validated deploy helper instead of auto-deploying on PR merge), GitHub
+    issue linkage, Django migration safety, and downtime-safe schema changes.
   - Claude install: `claude plugin install backend-pr-workflow@diversiotech`
   - Skill path: `plugins/backend-pr-workflow/skills/backend-pr-workflow`
   - Slash commands: `/backend-pr-workflow:check-pr`
@@ -211,9 +211,9 @@ when command files change.
   - Skill path: `plugins/process-code-review/skills/process-code-review`
   - Slash commands: `/process-code-review:process-review`
 - `backend-release`
-  - Purpose: Django4Lyfe two-phase release workflow — promote staging
-    (dev→release), release to production (release→master), version bumping,
-    GitHub releases, and three-branch post-release sync.
+  - Purpose: Django4Lyfe two-phase release workflow — promotion/release PRs,
+    exact-head local-ci validation, validated deploy-helper triggers,
+    version bumping, GitHub releases, and three-branch post-release sync.
   - Claude install: `claude plugin install backend-release@diversiotech`
   - Skill path: `plugins/backend-release/skills/release-manager`
   - Slash commands: `/backend-release:check`, `/backend-release:create`,

--- a/docs/runbooks/distribution.md
+++ b/docs/runbooks/distribution.md
@@ -238,9 +238,10 @@ Quick mental model:
 ```text
 ci-status    -> CI visibility and job logs
 
-dev-workflow -> workflow prompts, review passes, shipping, and
-                automatic seeded cmux splits for subagent-style prompts
-                when Pi is inside cmux and the parent session is idle
+dev-workflow -> workflow prompts, remote CI checks, local-ci-aware
+                shipping/release steps, and automatic seeded cmux splits
+                for subagent-style prompts when Pi is inside cmux and the
+                parent session is idle
 
 oh-my-pi     -> explicit cmux notifications, split-pane commands,
                 and workspace-tab commands
@@ -258,9 +259,12 @@ UI widgets, notifications, and LLM tools (`get_ci_status`,
 The `dev-workflow` package provides `/workflow:*` commands,
 `/workflow:help`, `/workflow:run`, `/workflow:prompts`, `/workflow:flow`, the
 `dev-workflow` and `ci` skills, XDG/project prompt config, and a bundled
-`agents/workflow-pipeline.chain.md` file for pi-subagents. If your
-pi-subagents setup only scans `.pi/agents/`, copy that chain file there
-manually.
+`agents/workflow-pipeline.chain.md` file for pi-subagents. When `local-ci` is
+on PATH and repo root contains `.local-ci.toml`, its ship/release prompts treat
+local-ci as the repo-owned validation path and use
+`scripts/deploy/trigger_validated_backend_deploy.sh` for backend release/master
+deploys when present. If your pi-subagents setup only scans `.pi/agents/`,
+copy that chain file there manually.
 
 The `oh-my-pi` package provides explicit `/omp-split-*` and
 `/omp-workspace*` cmux commands plus native cmux notifications.

--- a/pi-packages/dev-workflow/README.md
+++ b/pi-packages/dev-workflow/README.md
@@ -1,6 +1,6 @@
 # dev-workflow
 
-Daily developer workflow for pi: plan review, self-review, standards, CI, documentation, PR review feedback, release PR prep, handoff, and shipping. Ships `15` core workflow prompts plus `/workflow:help`, `/workflow:flow`, `/workflow:run`, and `/workflow:prompts`, with XDG/project prompt customization.
+Daily developer workflow for pi: plan review, self-review, standards, remote CI, local-ci-aware shipping/release prompts, documentation, PR review feedback, release PR prep, handoff, and shipping. Ships `15` core workflow prompts plus `/workflow:help`, `/workflow:flow`, `/workflow:run`, and `/workflow:prompts`, with XDG/project prompt customization.
 
 ## Install
 
@@ -359,4 +359,4 @@ Optional environment variables:
   `ci-status` both globally and from a different project-local path; duplicated
   CI tools can conflict.
 
-Subagent commands can use [pi-subagents](https://github.com/nicobailon/pi-subagents) for true agent isolation. When Pi is inside cmux, the default workflow behavior is to open a seeded split for subagent-style prompts; inside that split, the prompt still asks the AI to use the `subagent` tool when available and to fall back gracefully when it is not. CI prompts prefer the `ci-status` package when installed and only fall back to `get_ci_status` / `ci_fetch_job_logs` when the current harness exposes those tools.
+Subagent commands can use [pi-subagents](https://github.com/nicobailon/pi-subagents) for true agent isolation. When Pi is inside cmux, the default workflow behavior is to open a seeded split for subagent-style prompts; inside that split, the prompt still asks the AI to use the `subagent` tool when available and to fall back gracefully when it is not. CI prompts prefer the `ci-status` package when installed and only fall back to `get_ci_status` / `ci_fetch_job_logs` when the current harness exposes those tools. In repos where `local-ci` is on PATH and repo root contains `.local-ci.toml`, ship/release prompts treat local-ci as the repo-owned local validation path; backend release/master deploys use `scripts/deploy/trigger_validated_backend_deploy.sh` when present.

--- a/pi-packages/dev-workflow/agents/workflow-pipeline.chain.md
+++ b/pi-packages/dev-workflow/agents/workflow-pipeline.chain.md
@@ -68,4 +68,8 @@ Ship the work. First discover context:
 3. If no PR exists, create one, linking any related issues
 4. Ask me if you're unsure about anything
 
+If the repo supports local-ci (repo root `.local-ci.toml` + `local-ci` on PATH), run it as the repo-owned local validation path before finalizing.
+
+For backend release/master deploy flows, if `scripts/deploy/trigger_validated_backend_deploy.sh` exists, use it from the exact clean release/master head instead of assuming merge deploys automatically.
+
 Then: atomic commit (ensure everything passes), generate a PR description, and open the PR on GitHub.

--- a/pi-packages/dev-workflow/extensions/dev-workflow/index.ts
+++ b/pi-packages/dev-workflow/extensions/dev-workflow/index.ts
@@ -151,6 +151,8 @@ Please check all of the following:
 
 For a specific failing job, use /ci-logs <job-name> to pull its logs directly. If the ci-status package is not installed or the slash commands are unavailable, use get_ci_status and ci_fetch_job_logs if those tools are available. If neither path is available, ask the user to install ci-status before proceeding.
 
+If this repo supports local-ci (repo root has .local-ci.toml and local-ci is on PATH), note that local-ci is the repo-owned local validation path. Keep this prompt focused on remote CI status unless I explicitly ask to run local-ci.
+
 For every failing job:
 - **Ours or flake?** Is this failure caused by our changes, or is it a pre-existing flake?
 - **Root cause.** If ours, what's the actual problem?
@@ -197,6 +199,8 @@ Use commands, docs, strings, and anything else helpful so that future readers of
     prompt: `Let's finalize and ship this work.
 
 First, check CI. Prefer the ci-status extension commands if they are available: /ci, /ci-detail, and /ci-logs <job>. If those commands are not available, use get_ci_status and ci_fetch_job_logs if those tools are available. If neither path is available, ask the user to install ci-status before proceeding.
+
+If this repo supports local-ci (repo root has .local-ci.toml and local-ci is on PATH), run it as the repo-owned local validation path before the final commit/PR. If this is a backend release/master deploy flow and scripts/deploy/trigger_validated_backend_deploy.sh exists, use that helper from the exact clean branch head instead of assuming merge deploys automatically.
 
 If anything is failing:
 - Determine if failures are from our changes or pre-existing flakes
@@ -281,6 +285,8 @@ Safety rules:
 
 Important context:
 - Use the backend-release / release-manager skill for the backend release workflow.
+- If backend exposes .local-ci.toml and local-ci is on PATH, validate exact origin/release / origin/master heads locally before calling the backend release ready.
+- If backend exposes scripts/deploy/trigger_validated_backend_deploy.sh, that helper is the backend deploy trigger; PR merges alone do not deploy.
 - For frontend, optimo-frontend, and design-system, first read and follow each repo's own guidelines if available (AGENTS.md, CLAUDE.md, README, CONTRIBUTING, release docs, package scripts, or repo-local docs).
 - These repos may have different base branches, release branches, versioning rules, build steps, and PR body expectations.
 

--- a/pi-packages/dev-workflow/package.json
+++ b/pi-packages/dev-workflow/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dev-workflow",
-  "version": "0.0.4",
-  "description": "Daily developer workflow for pi — workflow prompt registry, plan review, self-review, standards, CI, PR review comments, release PR prep, docs, and shipping. 15 core prompts plus help, run, prompts, and flow.",
+  "version": "0.0.5",
+  "description": "Daily developer workflow for pi — workflow prompt registry, plan review, self-review, standards, remote CI, local-ci-aware ship/release prompts, PR review comments, docs, and shipping. 15 core prompts plus help, run, prompts, and flow.",
   "keywords": ["pi-package"],
   "files": ["extensions/", "skills/", "agents/", "README.md"],
   "dependencies": {

--- a/pi-packages/dev-workflow/skills/ci/SKILL.md
+++ b/pi-packages/dev-workflow/skills/ci/SKILL.md
@@ -18,6 +18,16 @@ Fallback tools, when exposed by the current harness:
 - `get_ci_status` — Fetch the latest CI status for the current git branch/PR. Returns a per-job breakdown with IDs, URLs, and durations. Uses gh CLI for GitHub Actions. Set `CIRCLECI_TOKEN` for CircleCI enrichment.
 - `ci_fetch_job_logs` — Fetch failure logs for a specific CI job. Pass the job id from `get_ci_status` output, a GitHub run databaseId (for GH Actions), or a CircleCI job number. Returns the log output truncated to 500 lines.
 
+## Scope boundary
+
+- This skill is for **remote CI status**: `/ci`, `/ci-detail`, `/ci-logs`,
+  `get_ci_status`, and `ci_fetch_job_logs`.
+- If `local-ci` is on PATH and the repo root contains `.local-ci.toml`, treat
+  local-ci as the repo-owned **local validation** path instead of a CI-status
+  replacement.
+- Deploy helpers such as `scripts/deploy/trigger_validated_backend_deploy.sh`
+  belong to release/deploy workflows, not this status-check skill.
+
 ## Process
 
 1. **Fetch status.**

--- a/pi-packages/dev-workflow/skills/dev-workflow/SKILL.md
+++ b/pi-packages/dev-workflow/skills/dev-workflow/SKILL.md
@@ -71,6 +71,10 @@ Before manual verification, check CI for the current branch using the separate *
 **Orchestration command:**
 - `/workflow:ci` — guides the AI through the full CI check: run `/ci` or `/ci-detail`, analyze each failure (ours vs flake), propose fixes, summarize.
 
+Boundary: `/workflow:ci` is for remote CI status. If `local-ci` is on PATH and
+repo root contains `.local-ci.toml`, use local-ci later as the repo-owned local
+validation path; do not replace `/ci` with local-ci here.
+
 The ci-status extension auto-watches CI on startup and after git pushes. Failure notifications appear automatically. Covers GitHub Actions and CircleCI (set `CIRCLECI_TOKEN` for CircleCI enrichment).
 
 **Command:** `/workflow:ci` (orchestrated) or `/ci-detail` (direct interactive UI)
@@ -88,14 +92,17 @@ Make the outcome legible. Document all updated code, especially new additions, i
 ### Step 8: Ship It
 Finalize and ship the work:
 
-1. **Verify CI green** — prefer `/ci` and `/ci-detail`; fall back to available CI tools if the harness exposes them
-2. **Discover context** — check the current branch, look for existing GitHub PRs and issues
-3. **Update existing PR** if one already exists for this branch
-4. **Create new PR** if none exists, linking any related GitHub issues
-5. **Ask questions** if uncertain about anything (existing PRs, issue linking, branch targets)
-6. **Atomic commit** — use the atomic commit skill, ensure everything passes (lint, types, tests, pre-commit)
-7. **PR description** — use the PR description writer skill for a reviewer-friendly summary
-8. **Open the PR** on GitHub
+1. **Verify remote CI green** — prefer `/ci` and `/ci-detail`; fall back to available CI tools if the harness exposes them
+2. **Run repo-owned local validation** — if `local-ci` is on PATH and repo root contains `.local-ci.toml`, run `local-ci run --no-github` (or the repo-local equivalent) before finalizing
+3. **Discover context** — check the current branch, look for existing GitHub PRs and issues
+4. **Update existing PR** if one already exists for this branch
+5. **Create new PR** if none exists, linking any related GitHub issues
+6. **Ask questions** if uncertain about anything (existing PRs, issue linking, branch targets)
+7. **Atomic commit** — use the atomic commit skill, ensure everything passes (lint, types, tests, pre-commit)
+8. **PR description** — use the PR description writer skill for a reviewer-friendly summary
+9. **Open the PR** on GitHub
+
+For backend release/master deploy flows, if `scripts/deploy/trigger_validated_backend_deploy.sh` exists, use it from the exact clean `origin/release` or `origin/master` head instead of assuming merge deploys automatically.
 
 Never compromise by excluding files that are part of the change. Everything touched must be improved.
 

--- a/plugins/backend-atomic-commit/.claude-plugin/plugin.json
+++ b/plugins/backend-atomic-commit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "backend-atomic-commit",
-  "version": "0.2.6",
-  "description": "Pedantic backend pre-commit and atomic-commit Skill for Django/Optimo-style repos, enforcing local AGENTS.md, repo-local docs, pre-commit hooks, and repo-local commit hygiene with an explicit fix-retry convergence protocol.",
+  "version": "0.2.7",
+  "description": "Pedantic backend pre-commit and atomic-commit Skill for Django/Optimo-style repos, enforcing local AGENTS.md, repo-local docs, pre-commit hooks, repo-local commit hygiene, and local-ci validation when the repo exposes it.",
   "author": {
     "name": "Diversio Devs"
   }

--- a/plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md
+++ b/plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md
@@ -109,6 +109,8 @@ When this Skill runs, you should first gather context using `Bash`, `Read`,
   - `uv` and `.bin/` wrappers:
     - `.bin/ruff`, `.bin/ty`, `.bin/pyright`, `.bin/mypy`, `.bin/django`,
       `.bin/pytest`.
+  - Detect repo-owned local-ci support only when `local-ci` is on PATH **and**
+    repo root contains `.local-ci.toml`.
   - Fallback to `uv run` or plain `python` / `pytest` / `ruff` where necessary.
   - Read local typing policy docs when present (for example:
     `docs/python-typing-3.14-best-practices.md`, `TY_MIGRATION_GUIDE.md`) and
@@ -304,6 +306,14 @@ In **both** `pre-commit` and `atomic-commit` modes, follow this pipeline:
    results directly in the final output using the existing severity-tagged
    sections (`Checks run`, `Needs changes`, etc.).
 
+8. **Repo-owned local-ci validation (when available)**
+   - Only after the normal gates above are green and the tree is stable, run:
+     ```bash
+     local-ci run --no-github
+     ```
+   - Do this only when `local-ci` is on PATH and repo root has `.local-ci.toml`.
+   - This skill must **not** publish GitHub statuses or trigger deploy helpers.
+
 ## Backend Fix Rules
 
 When you need concrete auto-fix heuristics, load:
@@ -343,6 +353,7 @@ you must be **very strict**:
      - `.bin/django check` / `manage.py check`
      - Relevant `pytest` subsets for risky changes
      - Pre-commit hooks defined in `.pre-commit-config.yaml`
+     - `local-ci run --no-github` when the repo supports local-ci
    - A passing pre-commit hook execution counts as satisfying the matching gate.
      Do not require duplicate direct-command reruns unless diagnosing failures.
    - Where available, heavy gates should run via `./.security/gate_cache.sh`

--- a/plugins/backend-pr-workflow/.claude-plugin/plugin.json
+++ b/plugins/backend-pr-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "backend-pr-workflow",
-  "version": "0.1.6",
-  "description": "Follows Diversio backend repo-local PR workflow docs, GitHub issue linkage, safe Django migrations, and downtime-safe schema changes.",
+  "version": "0.1.7",
+  "description": "Follows Diversio backend repo-local PR workflow docs, GitHub issue linkage, local-ci-aware release semantics, safe Django migrations, and downtime-safe schema changes.",
   "author": {
     "name": "Diversio Devs"
   }

--- a/plugins/backend-pr-workflow/commands/check-pr.md
+++ b/plugins/backend-pr-workflow/commands/check-pr.md
@@ -8,6 +8,7 @@ workflow aspects:
 - Repo-local branch naming and PR title/body conventions.
 - Commit message clarity and any documented repo-local commit rules.
 - Correct base branch for normal vs hotfix releases.
+- Local-ci-backed validation and validated deploy-helper steps when the repo exposes them.
 - PR description quality and self-review checklist completion.
 - Django migrations cleanup and downtime-safe schema changes.
 - Repo-local workflow docs / harness clarity when rules are non-obvious.

--- a/plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md
+++ b/plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md
@@ -74,6 +74,10 @@ Before applying the checklist, inspect the repo harness:
 - Read `AGENTS.md` first.
 - Load linked workflow/release/runbook docs or relevant directory-scoped
   `AGENTS.md` files when they exist.
+- Detect local-ci support only when `local-ci` is on PATH **and** repo root
+  contains `.local-ci.toml`.
+- Detect the validated deploy helper when
+  `scripts/deploy/trigger_validated_backend_deploy.sh` exists.
 - If workflow rules are tribal knowledge or only implied by stale docs, emit a
   `[SHOULD_FIX]` harness finding recommending a `repo-docs` update.
 
@@ -178,11 +182,14 @@ Confirm the base branch matches the project’s release workflow:
   - Merging into `dev` runs validation only — no staging deploy.
 - **Staging promotion**:
   - Base branch should be `release`.
-  - A PR from `dev` → `release` is a **promotion PR** — merging deploys staging.
+  - A PR from `dev` → `release` is a **promotion PR** — merging moves the
+    candidate to `release`; staging deploy then happens from the exact
+    `origin/release` head via repo-local local-ci / deploy helper steps.
 - **Hotfix** that must bypass the current `release` contents:
   - Base branch should be `master`.
 - **Production release**:
-  - `release` → `master` after staging validation.
+  - `release` → `master` after staging validation; production deploy then runs
+    from the exact `origin/master` head, not from PR merge itself.
 
 If a PR targets the wrong base branch:
 
@@ -229,7 +236,9 @@ Prompt the author to confirm they have checked:
 - All debugging code is removed:
   - No `print()` / `ipdb` / `pdb` left behind.
 - Tests have been added or updated for new functionality.
-- Tests are passing in CI.
+- Remote CI is green when applicable.
+- If the repo supports local-ci (`command -v local-ci` + `.local-ci.toml`),
+  repo-owned local validation has been run on the intended commit/worktree.
 - Active Python type gate is passing for touched files:
   - Detect in this order unless repo docs/CI differ: `ty`, then `pyright`,
     then `mypy`.
@@ -252,25 +261,29 @@ This Skill enforces a clean release flow.
 For normal deployments, check that:
 
 - Feature/bugfix PRs merge into `dev` (integration branch).
-- To deploy staging:
+- To stage changes:
   - A **promotion PR** is opened from `dev` → `release`.
-  - Merging this PR triggers staging deploy (run_staging_deploy=true).
+  - Merging that PR does **not** deploy automatically.
+  - If the validated deploy helper exists, use it from the clean
+    `origin/release` checkout; it validates with local-ci and then triggers
+    staging deploy.
+  - Otherwise, if the repo supports local-ci, validate the exact
+    `origin/release` head locally and follow the repo-local deploy path.
 - Before releasing to production:
   - The version (e.g. in `pyproject.toml`) is bumped to the intended release
-    version, using CalVer (e.g. `2025-08-19`).
-  - If direct pushes to `release` are not allowed, a small PR is created to
-    bump the version on `release`.
-- When ready to deploy:
-  - A PR is created from `release` → `master` with a title like:
-    - `Release: 2025-08-19`
-    - `Release 2: 2025-08-19` (for multiple releases in one day).
+    version using `YYYY.MM.DD` or `YYYY.MM.DD-N`.
+- When ready to release:
+  - A PR is created from `release` → `master` with a title like
+    `Release: 21st January 2026` or `Release 2: 21st January 2026`.
   - The release PR **lists all tickets / PRs included** in the description.
-
-Post-deployment:
-
-- A GitHub Release is created targeting `master`.
-- Tag name uses date-based versioning (CalVer):
-  - `YYYY-MM-DD` or `YYYY-MM-DD-2`.
+  - If the validated deploy helper exists, use it from the clean
+    `origin/master` checkout; it validates with local-ci and then triggers
+    production deploy.
+  - Otherwise, if the repo supports local-ci, validate the exact
+    `origin/master` head locally and follow the repo-local deploy path.
+- Post-release:
+  - Create a GitHub Release targeting `master`.
+  - Sync `master` back into `release` and `dev` per repo docs.
 
 If any of these are obviously missing from the plan, emit `[SHOULD_FIX]`.
 
@@ -279,16 +292,16 @@ If any of these are obviously missing from the plan, emit `[SHOULD_FIX]`.
 For hotfixes, enforce:
 
 - The hotfix PR targets `master` (not `release` or `dev`).
-- The title clearly indicates a hotfix, e.g.:
-  - `Hotfix release: 2025-08-19`
-- After deployment:
-  - Changes are merged back into `release` so it stays ahead of or equal to
-    `master`.
-  - Changes are also merged or cherry-picked back into **`dev`** so the
-    integration branch does not drift from production.  Without this,
-    subsequent feature branches and the next `dev → release` promotion are
-    developed against an integration branch missing code already in production.
-  - A GitHub Release is created and tagged using the same CalVer scheme.
+- The title clearly indicates a hotfix, e.g. `Hotfix Release: 21st January 2026`.
+- After merge:
+  - if the validated deploy helper exists, use it from the clean
+    `origin/master` checkout; it validates with local-ci and then triggers
+    deploy
+  - otherwise, validate the exact `origin/master` head with local-ci when
+    supported and follow the repo-local deploy path
+  - merge changes back into `release` and **`dev`** so the integration branch
+    does not drift from production
+  - create a GitHub Release with the same `YYYY.MM.DD[-N]` version
 
 If a supposed hotfix PR is targeting `dev` or `release`, or a hotfix is not
 planned to be merged back into `release` **and `dev`**, emit `[BLOCKING]`.

--- a/plugins/backend-release/.claude-plugin/plugin.json
+++ b/plugins/backend-release/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "backend-release",
-  "version": "0.3.1",
-  "description": "Manages Django4Lyfe release workflow: dev→release promotion PRs (staging deploy), release→master production PRs, version bumping, conflict resolution, GitHub releases, and post-release branch sync across all three branches.",
+  "version": "0.3.2",
+  "description": "Manages Django4Lyfe release workflow: promotion/release PRs, exact-head local-ci validation, validated deploy-helper triggers, version bumping, conflict resolution, GitHub releases, and post-release branch sync.",
   "author": {
     "name": "Diversio Devs"
   }

--- a/plugins/backend-release/commands/check.md
+++ b/plugins/backend-release/commands/check.md
@@ -62,3 +62,8 @@ Also checks:
 - Recommended next version (YYYY.MM.DD format)
 
 Use this before creating a release to understand what will be included.
+
+If the repo exposes `scripts/deploy/trigger_validated_backend_deploy.sh`,
+prefer that helper from the exact clean `origin/release` or `origin/master`
+head because it validates with local-ci and then triggers deploy. Release PR
+merges do not deploy automatically.

--- a/plugins/backend-release/commands/create.md
+++ b/plugins/backend-release/commands/create.md
@@ -12,6 +12,12 @@ Creates a release PR by merging release into a branch from master:
 4. Runs `uv lock` to update lock file
 5. Pushes and creates PR against `master`
 
+Creating the PR does **not** deploy production. After merge, if the repo
+exposes `scripts/deploy/trigger_validated_backend_deploy.sh`, prefer that
+helper from the exact clean `origin/master` checkout because it runs local-ci
+and then triggers deploy. Otherwise, if the repo supports local-ci, validate
+that head locally and follow the repo-local deploy steps.
+
 **Why merge (not cherry-pick)?** Cherry-picking creates duplicate commits with
 different SHAs on master vs release. This causes `git log master..release` to
 permanently show already-shipped commits as "pending". Merging preserves the

--- a/plugins/backend-release/commands/publish.md
+++ b/plugins/backend-release/commands/publish.md
@@ -7,9 +7,14 @@ Use your `release-manager` Skill in **publish** mode.
 After a release PR is merged to master, this command:
 
 1. Verifies the PR is actually merged
-2. Gets the PR body (list of included PRs)
-3. Creates a GitHub release with matching tag
-4. Merges master back into release to keep branches in sync
+2. If the repo exposes `scripts/deploy/trigger_validated_backend_deploy.sh`,
+   runs that helper from the exact clean `origin/master` head because it
+   validates with local-ci and then triggers deploy; otherwise, if the repo
+   supports local-ci, validates that head locally and follows the repo-local
+   deploy path
+3. Gets the PR body (list of included PRs)
+4. Creates a GitHub release with matching tag
+5. Merges master back into release to keep branches in sync
 
 **Arguments:**
 - `[PR_NUMBER]` - The merged release PR number
@@ -29,6 +34,7 @@ After a release PR is merged to master, this command:
 
 **Important:**
 - Tag must match version in `pyproject.toml`
+- Production deploy does **not** start on PR merge; if the validated deploy helper exists, prefer it from the exact clean `origin/master` checkout because it runs local-ci and then triggers deploy; otherwise validate that head and follow the repo-local deploy path
 - Release notes contain the list of PR URLs from the release PR body
 - Always verify with `gh release list --limit 3` after publishing
 - **Always merge master back into release** after publishing — without this, `git diff --stat origin/master origin/release` shows the version bump as a pending difference and the next release merge will conflict on `pyproject.toml` / `uv.lock`. The publish step does this automatically:

--- a/plugins/backend-release/skills/release-manager/SKILL.md
+++ b/plugins/backend-release/skills/release-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-manager
-description: "Create and manage promotion and release PRs for Django4Lyfe. Use this when preparing staging promotion PRs (dev→release), production release PRs (release→master), bumping versions, resolving merge conflicts, and publishing GitHub releases. Handles the full three-branch workflow."
+description: "Create and manage promotion and release PRs for Django4Lyfe. Use this when preparing dev→release promotion PRs, release→master release PRs, validating exact branch heads with local-ci, triggering validated backend deploys, bumping versions, resolving merge conflicts, and publishing GitHub releases."
 allowed-tools: Bash Read Edit Grep Glob
 argument-hint: "[action] (e.g., promote-staging, release-prod, publish, check)"
 ---
@@ -11,23 +11,23 @@ Manages the full release workflow for Django4Lyfe backend releases.
 
 ## Branch Model
 
+```text
+feature PRs -> dev        (validation only)
+promotion PRs -> release  (move staging candidate)
+origin/release head -> local-ci -> validated deploy helper -> staging deploy
+release PRs -> master     (move production candidate)
+origin/master head -> local-ci -> validated deploy helper -> production deploy
 ```
-feature PRs
-    │  merge to dev (validation only, no deploy)
-    ▼
-   dev    ── integration branch
-    │  promotion PR (dev → release) → staging deploy
-    ▼
-release   ── staging promotion branch
-    │  release PR (release → master) → production deploy
-    ▼
-master    ── production branch
-```
+
+## Repo Feature Detection
+
+- local-ci support: `command -v local-ci` succeeds and repo root contains `.local-ci.toml`
+- validated deploy helper: `scripts/deploy/trigger_validated_backend_deploy.sh` exists
 
 ## When to Use This Skill
 
-- Creating **promotion PRs** from `dev` → `release` to deploy staging
-- Creating **release PRs** from `release` → `master` to deploy production
+- Creating **promotion PRs** from `dev` → `release` to move a staging candidate onto `release`
+- Creating **release PRs** from `release` → `master` to move a production candidate onto `master`
 - Preparing hotfix releases
 - Bumping versions in pyproject.toml
 - Resolving merge conflicts between branches
@@ -36,10 +36,10 @@ master    ── production branch
 
 ## Core Workflow
 
-### 0. Promotion PR: dev → release (Staging Deploy)
+### 0. Promotion PR: dev → release (prepare staging candidate)
 
-Before a production release, promote changes from the integration branch to
-the staging branch. This is the ONLY path that triggers staging deploy.
+Before a production release, promote reviewed changes from `dev` to `release`.
+Merging the promotion PR does **not** deploy staging automatically.
 
 ```bash
 # 1. Check what's on dev but not yet on release
@@ -57,34 +57,24 @@ git push -u origin promote/YYYY.MM.DD[-N]
 gh pr create --base release --title "Promotion: DDth Month YYYY" --body "..."
 ```
 
-**First principles — why two phases?**
+Routine feature PRs still merge into `dev` where CI validates but never
+deploys. The promotion PR is the intentional step that moves the candidate onto
+`release`.
 
-The old model deployed staging on every merge to `release`:
+**After merge**: use the exact `origin/release` head from a clean checkout.
+If the validated deploy helper exists, prefer it — it runs local-ci and then
+triggers staging deploy. Otherwise, if the repo supports local-ci, run
+`local-ci` manually and follow the repo-local deploy steps.
 
+```bash
+git fetch origin
+git worktree add ../backend-release origin/release
+cd ../backend-release
+CIRCLECI_TOKEN=... scripts/deploy/trigger_validated_backend_deploy.sh
 ```
-old:  feature PR → release → staging deploy (every merge!)
-```
 
-This was noisy and expensive.  The new model separates concerns:
-
-```
-new:  feature PR → dev           (validation only, cheap)
-      promotion PR → release     (staging deploy, intentional)
-```
-
-Routine feature PRs merge into `dev` where CI validates but never deploys.
-Only a human opening a `dev → release` promotion PR triggers staging deploy.
-This means:
-
-- **Fewer staging deploys** — only when someone intentionally promotes
-- **Clearer intent** — the promotion PR says "I've reviewed these changes
-  and believe they're ready for staging"
-- **Lower CI cost** — dev merges run `run_tests` (classifier-derived flags),
-  not full `run_staging_deploy`
-
-**After merge**: Validate staging.  If issues are found, fix them on `dev` and
-create a new promotion PR.  Do not fix directly on `release` — `release`
-should only receive changes through promotion PRs.
+Validate staging before proceeding. If issues are found, fix them on `dev` and
+create a new promotion PR instead of patching `release` directly.
 
 ### 1. Check What Needs Releasing (release → master)
 
@@ -161,6 +151,19 @@ git commit -m "Version bump to YYYY.MM.DD[-N]"
 # 6. Push and create PR
 git push -u origin releases/YYYY.MM.DD[-N]
 gh pr create --base master --title "Release: DDth Month YYYY" --body "..."
+```
+
+Merging the release PR does **not** deploy production automatically. After it
+lands, use the exact `origin/master` head from a clean checkout. If the
+validated deploy helper exists, prefer it — it runs local-ci and then triggers
+production deploy. Otherwise, if the repo supports local-ci, run `local-ci`
+manually and follow the repo-local deploy steps.
+
+```bash
+git fetch origin
+git worktree add ../backend-master origin/master
+cd ../backend-master
+CIRCLECI_TOKEN=... scripts/deploy/trigger_validated_backend_deploy.sh
 ```
 
 **Why merge instead of cherry-pick?** Cherry-picking creates new commits with
@@ -264,10 +267,11 @@ When reporting promotion PR status:
 Created: https://github.com/DiversioTeam/Django4Lyfe/pull/XXXX
 
 **Summary:**
-- Type: Promotion (dev → release, triggers staging deploy)
+- Type: Promotion (dev → release, staging candidate only)
 - Title: "Promotion: DDth Month YYYY"
 - Target: `release`
 - Conflicts: None / Resolved
+- Deploy: run the validated deploy helper from the clean `origin/release` head
 ```
 
 When reporting release status:
@@ -280,6 +284,7 @@ Created: https://github.com/DiversioTeam/Django4Lyfe/pull/XXXX
 - Title: "Release: DDth Month YYYY"
 - Target: `master`
 - Conflicts: None / Resolved
+- Deploy: run the validated deploy helper from the clean `origin/master` head
 
 **Included PRs:**
 - #XXXX - Description
@@ -306,7 +311,7 @@ When listing releases:
 8. **Tag must match version in pyproject.toml** — e.g., version `2026.01.21-2` = tag `2026.01.21-2`
 9. **Always merge master back into release AND dev after publish** — Run `git merge origin/master --no-edit` on release, then merge release into dev. Without this, the version bump stays only on master, causing stale diffs and future merge conflicts.
 10. **Never squash-merge release PRs** — Release PRs to master MUST use "Create a merge commit". Squash merging breaks commit ancestry tracking.
-11. **Staging deploy only on promotion PRs** — Only a `dev → release` promotion PR triggers staging deploy. Routine feature merges to `dev` run validation only.
+11. **Promotion/release PR merges do not deploy automatically** — After `dev → release` or `release → master` merges, use `scripts/deploy/trigger_validated_backend_deploy.sh` from the exact clean branch head when the repo exposes it; otherwise validate that head with `local-ci` and follow the repo-local deploy path.
 
 ## Full End-to-End Example
 
@@ -335,17 +340,25 @@ LAST_RELEASE_DATE=$(gh pr list --base master --state merged --limit 100 \
   gh pr list --base release --state merged --limit 100 --json number,title,mergedAt \
     --jq "[.[] | select(.mergedAt > \"${LAST_RELEASE_DATE}\")] | sort_by(.mergedAt) | .[] | \"#\\(.number): \\(.title)\""
 
-# Create promotion PR (dev → release, triggers staging deploy)
+# Create promotion PR (dev → release, prepare staging candidate)
 git checkout -b promote/YYYY.MM.DD[-N] origin/release
 git merge origin/dev --no-edit
 git push -u origin promote/YYYY.MM.DD[-N]
 gh pr create --base release --title "Promotion: DDth Month YYYY"
 
-# Create release PR (release → master, triggers production deploy)
+# Create release PR (release → master, prepare production candidate)
 git checkout -b releases/YYYY.MM.DD[-N] origin/master
 git merge origin/release --no-edit
 # (bump version, uv lock, commit, then:)
 gh pr create --base master --title "Release: DDth Month YYYY"
+
+# Validate + deploy exact release head after promotion PR merge
+git fetch origin && git worktree add ../backend-release origin/release && cd ../backend-release
+CIRCLECI_TOKEN=... scripts/deploy/trigger_validated_backend_deploy.sh
+
+# Validate + deploy exact master head after release PR merge
+git fetch origin && git worktree add ../backend-master origin/master && cd ../backend-master
+CIRCLECI_TOKEN=... scripts/deploy/trigger_validated_backend_deploy.sh
 
 # Check current version
 grep '^version' pyproject.toml

--- a/plugins/backend-release/skills/release-manager/references/detailed-procedures.md
+++ b/plugins/backend-release/skills/release-manager/references/detailed-procedures.md
@@ -52,7 +52,11 @@ git commit -m "Merge origin/release into releases/YYYY.MM.DD"
 
 ## Publishing a GitHub Release
 
-After the release PR is merged to master, create a GitHub release.
+After the release PR is merged to master, use the exact clean
+`origin/master` head. If `scripts/deploy/trigger_validated_backend_deploy.sh`
+exists, prefer it — it runs local-ci and then triggers deploy. Otherwise,
+validate that head with local-ci manually and follow the repo-local deploy
+path. GitHub release publication is separate from that deploy trigger.
 
 **IMPORTANT: Merge Strategy** — Release PRs to master MUST be merged using
 **"Create a merge commit"** (not squash). Squash merging breaks commit ancestry
@@ -150,7 +154,12 @@ gh pr create --base release \
   --title "Promotion: 21st January 2026" \
   --body "- https://github.com/DiversioTeam/Django4Lyfe/pull/2607"
 
-# 3. After promotion PR is merged, staging deploy triggers automatically.
+# 3. After promotion PR is merged, use the exact release head and trigger staging deploy
+git fetch origin
+git worktree add ../backend-release origin/release
+cd ../backend-release
+CIRCLECI_TOKEN=... scripts/deploy/trigger_validated_backend_deploy.sh
+cd -
 #    Validate staging before proceeding.
 
 # ============================================
@@ -188,14 +197,21 @@ gh pr create --base master \
   --title "Release: 21st January 2026" \
   --body "- https://github.com/DiversioTeam/Django4Lyfe/pull/2607"
 
-# 9. After PR is merged, publish GitHub release
+# 9. After PR is merged, use the exact master head and trigger production deploy
 gh pr view 2608 --json state  # Verify merged
+git fetch origin
+git worktree add ../backend-master origin/master
+cd ../backend-master
+CIRCLECI_TOKEN=... scripts/deploy/trigger_validated_backend_deploy.sh
+cd -
+
+# 10. Publish GitHub release
 gh release create 2026.01.21 \
   --title "January 21st 2026" \
   --notes "- https://github.com/DiversioTeam/Django4Lyfe/pull/2607" \
   --target master
 
-# 10. Merge master back into release AND dev (MANDATORY)
+# 11. Merge master back into release AND dev (MANDATORY)
 git fetch origin
 git checkout release
 git merge origin/master --no-edit
@@ -204,7 +220,7 @@ git checkout dev
 git merge origin/release --no-edit
 git push origin dev
 
-# 11. Verify
+# 12. Verify
 gh release list --limit 3
 git diff --stat origin/master origin/release  # Should be empty
 git diff --stat origin/release origin/dev      # Should be empty


### PR DESCRIPTION
## Summary

Teach the marketplace workflow/release skills about the backend local-ci model.

### Key Features

| Feature | Description |
|---|---|
| Release semantics | Removes stale guidance that implied staging/production deploys happen automatically on PR merge |
| local-ci detection | Teaches the relevant workflow skills to detect local-ci via `local-ci` on PATH + `.local-ci.toml` |
| validated deploy helper | Points backend release flows at `scripts/deploy/trigger_validated_backend_deploy.sh` when present |
| docs/manifests | Updates package/plugin descriptions and inventory docs to match the shipped backend model |

## Backend release flow

```text
feature PRs -> dev                 (validation only)
promotion PR -> release            (move staging candidate)
exact origin/release head
  -> local-ci / validated helper   (staging deploy)
release PR -> master               (move production candidate)
exact origin/master head
  -> local-ci / validated helper   (production deploy)
```

---

## What changed

### 1. Backend release + PR workflow skills

Updated the release-facing skills to stop implying that merge alone deploys staging or production.

Key changes:
- `backend-release` now documents exact-head validation and validated-helper deploy triggering
- `backend-pr-workflow` now reviews promotion/release plans against the local-ci model
- backend release command wrappers now match the new semantics

### 2. dev-workflow local-ci awareness

Updated the pi package so the workflow prompts distinguish:
- remote CI status (`/ci`, `/ci-detail`, `get_ci_status`)
- repo-owned local validation (`local-ci`)
- backend release/master deploy triggering (validated helper)

This keeps the CI prompt narrow while teaching ship/release prompts the right backend behavior.

### 3. backend atomic commit integration

Updated `backend-atomic-commit` so backend repos with local-ci support run:
- `local-ci run --no-github`

This is explicitly post-gates validation only. It does not publish statuses or trigger deploys.

---

## Files Changed

<details>
<summary>Backend workflow/release skills</summary>

- `plugins/backend-release/skills/release-manager/SKILL.md`
- `plugins/backend-release/skills/release-manager/references/detailed-procedures.md`
- `plugins/backend-release/commands/check.md`
- `plugins/backend-release/commands/create.md`
- `plugins/backend-release/commands/publish.md`
- `plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md`
- `plugins/backend-pr-workflow/commands/check-pr.md`
- `plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md`

</details>

<details>
<summary>dev-workflow package</summary>

- `pi-packages/dev-workflow/skills/ci/SKILL.md`
- `pi-packages/dev-workflow/skills/dev-workflow/SKILL.md`
- `pi-packages/dev-workflow/extensions/dev-workflow/index.ts`
- `pi-packages/dev-workflow/agents/workflow-pipeline.chain.md`
- `pi-packages/dev-workflow/README.md`
- `pi-packages/dev-workflow/package.json`

</details>

<details>
<summary>Catalog / README / manifests</summary>

- `README.md`
- `docs/plugins/catalog.md`
- `docs/runbooks/distribution.md`
- `.claude-plugin/marketplace.json`
- plugin manifests for `backend-atomic-commit`, `backend-pr-workflow`, `backend-release`

</details>

## Testing

```bash
git diff --check
bash scripts/validate-skills.sh
jq -e . .claude-plugin/marketplace.json >/dev/null
jq -e . plugins/backend-atomic-commit/.claude-plugin/plugin.json >/dev/null
jq -e . plugins/backend-pr-workflow/.claude-plugin/plugin.json >/dev/null
jq -e . plugins/backend-release/.claude-plugin/plugin.json >/dev/null
jq -e . pi-packages/dev-workflow/package.json >/dev/null
(cd pi-packages/dev-workflow && npm pack --dry-run --json >/tmp/dev-workflow-pack.json)
printf '{"id":"cmds","type":"get_commands"}\n' | PI_OFFLINE=1 pi --mode rpc --no-session --no-context-files --no-extensions -e ./pi-packages/dev-workflow --no-prompt-templates --no-skills
```

## Notes

- No related GitHub issue was found in `DiversioTeam/agent-skills-marketplace`.
- Two SKILL files are still under the hard cap but above the warn threshold:
  - `plugins/backend-atomic-commit/skills/backend-atomic-commit/SKILL.md` (`461` lines)
  - `plugins/backend-pr-workflow/skills/backend-pr-workflow/SKILL.md` (`461` lines)
